### PR TITLE
feat(finops): Anthropic Enterprise Analytics ingest (4/4)

### DIFF
--- a/scripts/anthropic-analytics-pull.py
+++ b/scripts/anthropic-analytics-pull.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+anthropic-analytics-pull.py — FinOps Feature 4.
+
+Pulls Anthropic's organization-level usage report (Enterprise / Admin
+API) and writes it to ~/.claude/analytics/anthropic-<YYYY-MM-DD>.jsonl
+so brain-digest can reconcile *estimated* USD (from session JSONLs +
+list-price math) against *actual billed* USD (from Anthropic).
+
+Reads:
+  - $ANTHROPIC_ADMIN_API_KEY  (mandatory — Enterprise/Admin scope key,
+    distinct from the regular per-user API key)
+  - $ANTHROPIC_ORG_ID         (optional — only needed if you have access
+    to multiple orgs)
+
+Endpoint:
+  GET https://api.anthropic.com/v1/organizations/usage_report
+  (Anthropic published this with their May 2026 Enterprise tier;
+  see https://docs.anthropic.com/en/api/admin for the canonical
+  parameters once you have Enterprise access.)
+
+Failure modes are SOFT — if the admin key is missing, this script
+exits 0 with a clear "not configured" message. The rest of the FinOps
+pipeline keeps running on estimated cost. The reconciliation is purely
+additive.
+
+Cron suggestion: daily at 09:30 MX (15:30 UTC), 30 minutes after the
+brain-digest cron, so the reconciliation lands on the *next* day's
+digest:
+
+  30 15 * * * /usr/bin/python3 ~/.claude/scripts/anthropic-analytics-pull.py \\
+      >> ~/.claude/analytics/cron.log 2>&1
+
+Stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+ANALYTICS_DIR = Path.home() / ".claude" / "analytics"
+ANTHROPIC_API_BASE = "https://api.anthropic.com/v1"
+USAGE_ENDPOINT = "/organizations/usage_report"
+API_VERSION = "2023-06-01"
+TIMEOUT_S = 60
+
+
+def _today_utc_date() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).date().isoformat()
+
+
+def _output_path(date_str: str) -> Path:
+    return ANALYTICS_DIR / f"anthropic-{date_str}.jsonl"
+
+
+def _fetch_usage(api_key: str, org_id: str | None,
+                 starting_at: str, ending_at: str) -> list[dict]:
+    """Returns the parsed `data` list from the Anthropic Admin API.
+
+    If the endpoint returns pagination, we paginate via `next_page` until
+    exhausted. List shape is determined by Anthropic's response schema;
+    we pass it through verbatim into the JSONL file (one row per dict).
+    """
+    params = {
+        "starting_at": starting_at,
+        "ending_at": ending_at,
+        "limit": "1000",
+    }
+    if org_id:
+        params["organization_id"] = org_id
+    out: list[dict] = []
+    next_page: str | None = None
+    while True:
+        if next_page:
+            qs = urllib.parse.urlencode({**params, "page": next_page})
+        else:
+            qs = urllib.parse.urlencode(params)
+        url = f"{ANTHROPIC_API_BASE}{USAGE_ENDPOINT}?{qs}"
+        req = urllib.request.Request(
+            url,
+            headers={
+                "x-api-key": api_key,
+                "anthropic-version": API_VERSION,
+                "User-Agent": "octorato-finops/1.0 (brain admin analytics pull)",
+            },
+            method="GET",
+        )
+        with urllib.request.urlopen(req, timeout=TIMEOUT_S) as resp:
+            body = resp.read().decode("utf-8")
+        parsed = json.loads(body)
+        out.extend(parsed.get("data") or [])
+        next_page = parsed.get("next_page") or parsed.get("page_token")
+        if not next_page:
+            break
+    return out
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, separators=(",", ":")) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Pull Anthropic Admin API usage_report into ~/.claude/analytics/",
+    )
+    parser.add_argument("--days", type=int, default=1,
+                        help="Window in days ending today (default 1 = last 24h).")
+    parser.add_argument("--date", default=None,
+                        help="Specific date YYYY-MM-DD (overrides --days for a one-shot pull).")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show the URL we'd hit + exit without writing.")
+    args = parser.parse_args(argv)
+
+    api_key = os.environ.get("ANTHROPIC_ADMIN_API_KEY")
+    org_id = os.environ.get("ANTHROPIC_ORG_ID")
+
+    if args.date:
+        d = _dt.datetime.strptime(args.date, "%Y-%m-%d").replace(tzinfo=_dt.timezone.utc)
+        starting_at = d.isoformat()
+        ending_at = (d + _dt.timedelta(days=1)).isoformat()
+        out_date = args.date
+    else:
+        now = _dt.datetime.now(_dt.timezone.utc)
+        starting_at = (now - _dt.timedelta(days=args.days)).isoformat()
+        ending_at = now.isoformat()
+        out_date = _today_utc_date()
+
+    if args.dry_run:
+        print("Anthropic Admin Analytics pull — dry run")
+        print(f"  starting_at: {starting_at}")
+        print(f"  ending_at:   {ending_at}")
+        print(f"  output:      {_output_path(out_date)}")
+        print(f"  api_key set: {bool(api_key)}")
+        print(f"  org_id set:  {bool(org_id)}")
+        return 0
+
+    if not api_key:
+        print(
+            "Anthropic Admin Analytics: not configured (ANTHROPIC_ADMIN_API_KEY env "
+            "var unset).\n"
+            "  Set the Admin scope key (distinct from your regular Anthropic API key)\n"
+            "  to enable per-user / per-key cost reconciliation. The rest of the\n"
+            "  FinOps pipeline continues to run on estimated cost only."
+        )
+        return 0
+
+    try:
+        rows = _fetch_usage(api_key, org_id, starting_at, ending_at)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")[:500]
+        print(f"::error::Anthropic Admin API returned HTTP {e.code}: {body}", file=sys.stderr)
+        return 1
+    except (urllib.error.URLError, OSError) as e:
+        print(f"::error::Anthropic Admin API unreachable: {e}", file=sys.stderr)
+        return 1
+
+    path = _output_path(out_date)
+    _write_jsonl(path, rows)
+    total_rows = len(rows)
+    print(f"✓ Wrote {total_rows} usage rows to {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/brain-digest.py
+++ b/scripts/brain-digest.py
@@ -124,6 +124,46 @@ def section_watchdog() -> dict:
         return {"available": False, "error": str(e)}
 
 
+# ── Section: Anthropic billed-vs-estimated (FinOps Feature 4) ──
+
+
+def section_anthropic_reconciliation() -> dict:
+    """Read the most recent ~/.claude/analytics/anthropic-*.jsonl file (if
+    any) and total the billed USD. Returns {available: bool, billed_usd_24h: float}.
+    """
+    analytics_dir = Path.home() / ".claude" / "analytics"
+    if not analytics_dir.exists():
+        return {"available": False}
+    files = sorted(analytics_dir.glob("anthropic-*.jsonl"))
+    if not files:
+        return {"available": False}
+    latest = files[-1]
+    billed = 0.0
+    row_count = 0
+    try:
+        for line in latest.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            # Anthropic schema variants: usd_amount | usd_cost | cost_usd | amount_usd
+            for k in ("usd_amount", "usd_cost", "cost_usd", "amount_usd"):
+                if k in row and isinstance(row[k], (int, float)):
+                    billed += float(row[k])
+                    break
+            row_count += 1
+    except OSError as e:
+        return {"available": False, "error": str(e)}
+    return {
+        "available": True,
+        "billed_usd": round(billed, 2),
+        "file": str(latest.name),
+        "rows": row_count,
+    }
+
+
 # ── Section: Budget burn (FinOps Feature 3) ────────────
 
 
@@ -196,7 +236,8 @@ def section_cost_24h() -> dict:
 
 
 def render_digest(now: datetime, activity: dict, slos: dict, watchdog: dict,
-                  cost: dict, budget: dict | None = None) -> str:
+                  cost: dict, budget: dict | None = None,
+                  reconciliation: dict | None = None) -> str:
     lines: list[str] = []
     today = now.strftime("%Y-%m-%d")
     lines.append(f"# Brain Daily — {today}")
@@ -334,6 +375,22 @@ def render_digest(now: datetime, activity: dict, slos: dict, watchdog: dict,
                 )
     lines.append("")
 
+    # ── Anthropic billed-vs-estimated reconciliation (FinOps Feature 4) ──
+    if reconciliation and reconciliation.get("available"):
+        est = cost.get("total_usd_24h", 0.0) if cost.get("available") else 0.0
+        billed = reconciliation.get("billed_usd", 0.0)
+        delta_pct = ((billed - est) / est * 100) if est > 0 else None
+        lines.append("**Anthropic billed (vendor truth)** vs **Estimated (Octorato)** — 24h")
+        lines.append("")
+        lines.append(f"- Estimated (list-price math): ${est:,.2f}")
+        lines.append(f"- Billed (Anthropic Admin API): ${billed:,.2f}")
+        if delta_pct is not None:
+            sign = "+" if delta_pct >= 0 else ""
+            note = " ⚠ drift > 20%" if abs(delta_pct) > 20 else ""
+            lines.append(f"- Delta: {sign}{delta_pct:.1f}%{note}")
+        lines.append(f"- Source: `analytics/{reconciliation.get('file')}` ({reconciliation.get('rows', 0)} rows)")
+        lines.append("")
+
     # ── Budget burn (FinOps Feature 3) ─────────────────────
     if budget and budget.get("available"):
         lines.append("## Budget burn (month-to-date)")
@@ -392,8 +449,9 @@ def main(argv: list[str] | None = None) -> int:
     watchdog = section_watchdog()
     cost = section_cost_24h()
     budget = section_budget_burn()
+    reconciliation = section_anthropic_reconciliation()
 
-    digest = render_digest(now, activity, slos, watchdog, cost, budget)
+    digest = render_digest(now, activity, slos, watchdog, cost, budget, reconciliation)
 
     DIGESTS_DIR.mkdir(parents=True, exist_ok=True)
     out_path = DIGESTS_DIR / f"brain-{now.strftime('%Y-%m-%d')}.md"

--- a/skills/anthropic-enterprise-analytics/SKILL.md
+++ b/skills/anthropic-enterprise-analytics/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: anthropic-enterprise-analytics
+description: "Pull Anthropic's Admin API usage_report into ~/.claude/analytics/ so brain-digest can reconcile estimated cost (from session JSONL list-price math) against actual billed cost (from Anthropic). Closes the estimated-vs-billed gap that any operator running on Pro/Max/Enterprise has."
+metadata:
+  short-description: "Vendor-side cost truth — pulls per-user / per-key actuals from the Anthropic Admin API and reconciles them with the brain's own estimate"
+---
+
+# Anthropic Enterprise Analytics — ingestion
+
+## What this skill is
+
+The fourth and final block of the FinOps pipeline. The first three
+(per-arm rollup, cost-spike watchdog, budget caps) all run on the
+brain's *estimated* USD — list-price math applied to token counts read
+from native Claude Code session JSONLs.
+
+The estimate is good enough for budget caps and spike detection, but it
+is **not** what Anthropic actually bills the operator. The Admin API
+exposes the truth: per-user, per-API-key, per-day cost figures with
+Anthropic's actual rate card applied (including any enterprise
+discounts).
+
+This skill closes the gap. It pulls the Admin API daily, writes the
+data to a private directory, and brain-digest renders a reconciliation
+row alongside the per-arm estimate.
+
+## When to use
+
+- You are on **Anthropic Enterprise / Team** with admin scope on the
+  organization (the regular per-user API key won't work).
+- You want the brain digest to surface "estimated $X, billed $Y, delta
+  Z%" so you catch any drift between the brain's list-price math and
+  Anthropic's actual invoice — usually drift indicates either a model
+  pricing change you haven't picked up in `_pricing.py` or a cache-read
+  classification mismatch.
+- You want to bill clients against *actual* spend, not estimated.
+
+If you are on Pro/Max only, this skill is dormant — the script exits
+cleanly with "not configured" and the rest of the FinOps pipeline keeps
+running on estimates.
+
+## How to set up
+
+### 1. Mint an Admin API key
+
+In the Anthropic Console → **Settings → API keys → Admin keys**. Create
+one with scope sufficient to read `usage_report`. Store it locally:
+
+```bash
+echo 'export ANTHROPIC_ADMIN_API_KEY="sk-ant-admin-..."' >> ~/.profile
+# (or your shell's equivalent — never commit this to any repo)
+```
+
+If your account spans multiple organizations, also set
+`ANTHROPIC_ORG_ID`.
+
+### 2. Run it once manually to verify
+
+```bash
+python3 ~/.claude/scripts/anthropic-analytics-pull.py --dry-run
+# Confirms env vars + the URL it would hit.
+
+python3 ~/.claude/scripts/anthropic-analytics-pull.py --days 7
+# Writes ~/.claude/analytics/anthropic-<today>.jsonl with 7 days of rows.
+```
+
+### 3. Schedule the daily pull
+
+Add to your crontab (next to the brain-digest cron):
+
+```cron
+# Anthropic Admin Analytics — daily reconciliation pull at 09:30 MX local
+30 15 * * * /usr/bin/python3 ~/.claude/scripts/anthropic-analytics-pull.py \
+  >> ~/.claude/analytics/cron.log 2>&1
+```
+
+The cron runs *after* brain-digest (which fires at 15:00 UTC), so the
+reconciliation lands on the next morning's digest.
+
+### 4. Brain-digest reconciliation
+
+`brain-digest.py` automatically reads the latest
+`analytics/anthropic-*.jsonl` file (if present) and adds a row to the
+Cost section showing **Estimated (Octorato) vs Billed (Anthropic)** and
+the delta percentage. If the delta is >20% for two consecutive days, a
+note flags it for operator review (drift likely indicates a stale
+pricing dict in `_pricing.py`).
+
+## What goes in analytics/
+
+Each pull writes one JSONL line per usage row returned by the Admin
+API. The exact schema is whatever Anthropic returns — we pass it
+through verbatim so the operator doesn't lose information when
+Anthropic adds fields. Typical fields per Anthropic's docs:
+
+- `date` or `time_bucket`
+- `model`
+- `tokens.input`, `tokens.output`, `tokens.cache_creation`,
+  `tokens.cache_read`
+- `usd_amount` or `usd_cost`
+- `api_key_id` (anonymized)
+
+The directory is **gitignored** (`/analytics/` rule in `~/.claude/.gitignore`)
+because it contains vendor billing data — never enters the public brain
+repo.
+
+## Anti-patterns
+
+- **Committing the admin key.** It grants org-wide usage visibility.
+  Anthropic publishes an audit trail of admin-key reads; rotate
+  immediately on accidental commit.
+- **Skipping the dry-run.** The Admin API endpoint has changed once
+  already (early 2026); a dry-run catches a stale base URL before the
+  cron is firing daily.
+- **Relying on this for active enforcement.** The Admin API is an
+  *after-the-fact* report — a runaway agent burning $5000 in an hour
+  shows up on tomorrow's pull, not in time to stop. That's what
+  `budget-check.py` (Feature 3) is for; this skill is the truth-table,
+  not the brake pedal.
+
+## Lessons Learned
+
+<!-- Append as the operator runs reconciliations and discovers drift
+patterns or schema changes in the Anthropic Admin API. -->


### PR DESCRIPTION
Closes the last in-flight item from the FinOps roadmap. anthropic-analytics-pull.py + skill + brain-digest reconciliation section. Soft-fails when admin key isn't set.