### PR TITLE
Add documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,24 @@
+---
+name: Documentation issue
+about: Report a docs gap, typo, broken link, or unclear section
+title: "[docs] "
+labels: documentation
+---
+
+## What needs attention
+
+Tell us which file, page, heading, or section needs documentation work.
+
+## Problem
+
+Describe the typo, docs gap, broken link, outdated content, or confusing section.
+
+## Suggested fix
+
+Share what you think should be changed or added.
+
+## Additional context
+
+Add links, screenshots, or examples if helpful.
+
+> Do not paste secrets, client names, or internal data — this repo is public.


### PR DESCRIPTION
## What & why

Adds a documentation issue template for docs gaps, typos, broken links, and unclear sections.

## Type

- [x] Docs / wiki / README

## Generic-safety checklist (MANDATORY — the brain is public)

- [x] No client names, coworker names, internal codenames, ticket IDs, or internal URLs — in file contents, filenames, branch name, or commit message
- [x] No secrets / tokens / keys
- [x] No SDD artifacts at repo root
- [ ] scripts/check-generic.py passes locally
- [x] If this is a lesson learned from an arm, it has been distilled to a generic skill before landing here

## 4D discipline

- [x] Diligent — documentation-only change, reviewed template contents
- [x] Disclose — Impact Radius: `.github/ISSUE_TEMPLATE/documentation.md`

## Evidence

Documentation-only change. Adds a new issue template requested by #18.

Closes #18