### PR TITLE
docs(i18n): add README.es.md (completes #22 language switcher)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,39 @@
+[English](README.md) | [Español](README.es.md)
+
+# Octopus Brain Framework
+
+[![License: MIT](https://img.shields.io/github/license/CarlosCaPe/octorato)](LICENSE)
+[![Stars](https://img.shields.io/github/stars/CarlosCaPe/octorato?style=social)](https://github.com/CarlosCaPe/octorato/stargazers)
+[![Issues](https://img.shields.io/github/issues/CarlosCaPe/octorato)](https://github.com/CarlosCaPe/octorato/issues)
+[![Good first issues](https://img.shields.io/github/issues/CarlosCaPe/octorato/good%20first%20issue?label=good%20first%20issues&color=7057ff)](https://github.com/CarlosCaPe/octorato/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+
+📣 **Artículo de lanzamiento:** [Introducing Octorato — the open-source FinOps brain for AI agents](https://www.linkedin.com/pulse/introducing-octorato-open-source-finops-brain-ai-agents-dataqbs-trbjc) · 🛠️ [Hecho con Octorato](SHOWCASE.md) · 📘 [dataqbs en Facebook](https://www.facebook.com/dataQBS/)
+
+> **Sistema operativo open-source para agentes de IA, con FinOps integrado.**
+> Atribución de tokens por cliente. Brazos aislados *(aislamiento a nivel de software entre los espacios de trabajo de cada cliente)*. Topes de presupuesto con un mecanismo real de paro.
+> El cerebro que consultores y agencias pequeñas necesitan para facturar a sus clientes de forma justa —
+> el cerebro FinOps open-source para quedar del lado correcto de la
+> [predicción de Gartner: más del 40 % de los proyectos de IA agéntica se cancelarán para 2027](https://www.gartner.com/en/newsroom/press-releases/2025-06-25-gartner-predicts-over-40-percent-of-agentic-ai-projects-will-be-canceled-by-end-of-2027)
+> por costos no gestionados.
+
+> *"Un cerebro. Más de 150 especialistas. Cero renta de oficina. Un libro contable por cliente."*
+
+---
+
+## ¿Qué es?
+
+Octorato es un **sistema operativo de agentes open-source con FinOps integrado**: reglas versionadas, más de 150 personas de agentes especialistas, y un grafo (*connectome*) con compuertas de flujo obligatorias y aislamiento estricto del trabajo por cliente. Se apoya en más de 20 años de ingeniería de datos — la base que hace creíble a la IA.
+
+## ¿Por qué un pulpo? 🐙
+
+Un cerebro central (`~/.claude/`) coordina brazos independientes (un repo sellado por cliente). Cada brazo ejecuta de forma autónoma y devuelve aprendizajes al cerebro como **skills genéricos y anonimizados** — nunca datos de cliente. Ocho brazos de lado forman el **∞** (lemniscata): alcance sin límite. El **teseracto → 4D** es el ancla del paradigma de cuatro fases (Describe → Delegate → Diligent → Disclose).
+
+## 📖 Documentación completa
+
+Esta es una **introducción traducida**. La guía completa — arquitectura, paradigma 4D, quick start, *connectome*, sincronización multi-máquina y más — está en el **[README en inglés](README.md)**.
+
+¿Quieres ayudar a traducir el resto al español (o a otro idioma)? **Las contribuciones son bienvenidas** — abre un [issue](https://github.com/CarlosCaPe/octorato/issues) o un Pull Request. Buscamos a más gente que quiera construir y aprender aquí. 🐙
+
+---
+
+_Switcher de idioma iniciado por la comunidad ([#22](https://github.com/CarlosCaPe/octorato/pull/22))._


### PR DESCRIPTION
Adds the Spanish README that #22's [Español] switcher links to (that PR added the link but not the file). Translates the intro + octopus rationale + invites more i18n contributions. Credits @YuuGR1337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)