### PR TITLE
feat(governance): harden master — PR-only + Claude Code review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Octorato brain — code ownership
+#
+# Single-owner repo: every change to the brain pings @CarlosCaPe for
+# review on the PR. External contributor PRs auto-request his review.
+#
+# This file complements branch protection on master (PR-only, no direct
+# pushes, no admin bypass) — see .github/workflows/brain-pr-checks.yml
+# and brain-pr-review.yml for the enforcement gates.
+
+* @CarlosCaPe

--- a/.github/workflows/brain-pr-review.yml
+++ b/.github/workflows/brain-pr-review.yml
@@ -1,0 +1,58 @@
+name: Brain PR Review (Claude Code)
+
+# Automated code review on every PR targeting master.
+#
+# Why this exists: the brain is solo-owner. Branch protection requires a
+# PR for every change (no direct commits, no admin bypass), but a human
+# reviewer ≠ author is impossible. This workflow has Claude Code act as
+# the second pair of eyes — it inspects the diff, posts inline review
+# comments, and surfaces correctness / security / scope-creep concerns.
+#
+# Required secret: CLAUDE_CODE_OAUTH_TOKEN
+#   Generate with: `claude /setup-token` (Claude Code subscription) and
+#   register via: `gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo CarlosCaPe/octorato`
+#
+# This check is intended to be added to required_status_checks on master
+# once the secret exists.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [master, main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  claude-code-review:
+    name: Claude Code Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO_DIR="$(pwd)"
+            Review this PR against the diff and post inline review comments using
+            the `mcp__github_inline_comment__create_inline_comment` tool when you
+            find issues. Focus on:
+              1. Correctness bugs (logic errors, off-by-one, null handling)
+              2. Brain leak risk — client/arm tokens, internal codenames, secrets
+                 (the brain is public on GitHub; see .githooks/push-policy.txt)
+              3. Scope creep — Change Manifest discipline; reject 1-line tasks
+                 that grew to 50-line diffs
+              4. Skill/agent metadata drift (broken triggers, missing frontmatter)
+              5. SDD artifacts at brain root (feature*.md / plan*.md / spec*.md)
+                 — these must live in docs/specs-archive/ only
+            Use ${REPO_DIR} as the working directory for Read/Bash. Be concise.
+          claude_args: '--max-turns 12'


### PR DESCRIPTION
## What

Hardens `master` so every change to the brain ships via PR:

- **`.github/CODEOWNERS`** — auto-request @CarlosCaPe on every PR.
- **`.github/workflows/brain-pr-review.yml`** — runs `anthropics/claude-code-action@v1` on every PR; posts inline review comments.
- **Branch protection** (applied via API alongside this PR):
  - `enforce_admins=true` → no owner bypass
  - `required_pull_request_reviews` → no direct commits
  - keeps existing `check-generic` + `connectome-rebuild` required checks
  - `claude-code-review` added to required checks after `CLAUDE_CODE_OAUTH_TOKEN` secret is set

## Why

Solo-owner repo; until today owner could (and did) push directly to master. Brain is public on GitHub — every change is permanent. The PR diff is the last chance to catch a client-name leak or scope creep.

## Operator action required

Add the secret:
```bash
claude /setup-token   # generates a Claude Code OAuth token
gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo CarlosCaPe/octorato
```

Then add `Claude Code Review` to required_status_checks via `gh api PATCH .../branches/master/protection`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)