### PR TITLE
chore(gitignore): exclude skills/learned/ — draft skills from /learn sta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,14 @@ tasks/
 # not in BRAIN_PATHS allowlist). Keeping the dir itself out of git status reduces noise.
 knowledge/
 
+# Session-extracted draft skills — produced by /learn (session-learn-extractor).
+# MUST stay local until the operator manually promotes a draft via
+#   mv skills/learned/<slug> skills/<slug>
+# Drafts are unreviewed scaffolds; pushing them would pollute the public connectome
+# with provisional content. This rule is the canonical companion of skills/learned/
+# (see skills/session-learn-extractor/SKILL.md).
+skills/learned/
+
 # Nested project memories (per-arm .claude/ dirs)
 .claude/
 


### PR DESCRIPTION
Auto-opened by `ai-push` (master is PR-protected).

```
chore(gitignore): exclude skills/learned/ — draft skills from /learn stay local until promoted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)