### PR TITLE
feat(scripts): add -h/--help to query_connectome.py (closes #13)

### DIFF
--- a/scripts/query_connectome.py
+++ b/scripts/query_connectome.py
@@ -1030,8 +1030,12 @@ def _fuzzy_match(G, query):
 # ─── Main ─────────────────────────────────────────────────────────────────────
 
 def main():
-    if len(sys.argv) < 2:
+    # No args or an explicit help flag: print usage + the full command list and
+    # exit 0, without touching the connectome (help must work even if
+    # neural_map.json is missing). delegate-check already supports -h/--help.
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help", "help"):
         print(__doc__)
+        print("Commands: stats, gods, path, query, impact, communities, viz, 4d")
         return 0
 
     cmd = sys.argv[1].lower()


### PR DESCRIPTION
Adds a `-h`/`--help`/`help` branch to `query_connectome.py` main().

- Prints the usage docstring + the full command list (`stats, gods, path, query, impact, communities, viz, 4d`) and exits 0.
- Returns before `load_connectome()`, so help works even if `neural_map.json` is missing.
- Existing subcommand behavior unchanged; unknown command still exits 1.

Verified: `--help`→0, `-h`→0, all 8 subcommands listed, `stats`→0, `bogus`→1.

Closes #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)