### PR TITLE
docs(template): add YAML frontmatter to skill authoring template (closes #12)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ What this agent produces.
 
 1. **Create the directory**: `skills/<skill-name>/`
 2. **Create SKILL.md** using `templates/skill/SKILL.md.template` as a starting point
-3. **Include**: Purpose, Triggers, Workflow, Best Practices, Lessons Learned
+3. **Include**: a `---` YAML frontmatter block (`name` kebab-case slug, `description`, `metadata.type`) followed by Purpose, Triggers, Workflow, Best Practices, Lessons Learned
 4. **Regenerate the connectome**: `python3 scripts/generate_neural_map.py`
 
 ### Skill Naming Convention

--- a/templates/skill/SKILL.md.template
+++ b/templates/skill/SKILL.md.template
@@ -1,3 +1,10 @@
+---
+name: "{{SKILL_SLUG}}"
+description: "{{ONE_LINE_DESCRIPTION}}"
+metadata:
+  type: "{{SKILL_TYPE}}"
+---
+
 # {{SKILL_NAME}}
 
 ## Purpose


### PR DESCRIPTION
Adds the frontmatter block required by #12.

- `templates/skill/SKILL.md.template` now begins with `---` frontmatter (`name` slug, `description`, `metadata.type`) before the `# {{SKILL_NAME}}` heading — so a first-time author produces a file the connectome/loader indexes well.
- New placeholders (`{{SKILL_SLUG}}`, `{{SKILL_TYPE}}`) match the existing `{{UPPER_SNAKE}}` style; values are quoted so the raw template (and the rendered result) are both valid YAML.
- `CONTRIBUTING.md` 'Adding a New Skill' step 3 now mentions the frontmatter.

Closes #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)