### PR TITLE
docs(readme): add Octorato banner image at top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://www.dataqbs.com/banner-octorato.webp?v=3" alt="Octorato — the open-source AI Agent OS" width="100%">
+</p>
+
 > 🌍 This README is in English (the open-source lingua franca). Running an AI agent? Ask it to read this in your language — eating our own dog food. 🐙
 
 # Octopus Brain Framework


### PR DESCRIPTION
Adds a centered banner image to the top of the README (hosted on dataqbs.com, versioned `?v=3` so it stays operator-updatable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)