### PR TITLE
docs(changelog): v2.1.0 — Contributor-Ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,22 @@ machine-generated growth ledger lives at
 
 ## [Unreleased]
 
+## [2026-05-29] — v2.1.0 "Contributor-Ready"
+
+### Added
+- `scripts/capability_inventory.py` + `docs/capability-inventory.md` — read-only census of which tools each agent declares and each skill references; flags unscoped agents. Input to the M1 Kernel-ABI RFC. (closes #28)
+- `schemas/skill-manifest.schema.json` + `scripts/validate-skill-manifest.py` — `skill.json` manifest schema (name/semver/license + capabilities/dependencies) and validator with `--selftest`. On-ramp for M5. (closes #31)
+- `schemas/tests/test_trace_event_schema.py` — validation test for `trace-event.schema.json` against real samples. (closes #29)
+- `scripts/tests/test_check_generic.py` — message-scan unit test for `check-generic.py` using a temp blocklist via `CLAUDE_DIR` (never the private one). (closes #15)
+- `tests/isolation/` — cross-arm red-team corpus (16 cases: 12 must-refuse + 4 allow controls) for the M2 isolation enforcer. (closes #30)
+- `-h`/`--help` flag for `scripts/query_connectome.py`. (closes #13)
+- YAML frontmatter (`name`/`description`/`metadata`) in `templates/skill/SKILL.md.template`. (closes #12)
+- `CLAUDE.md` §"Octorato's Stance" + `skills/octorato-symbolism` "The Operator" section — generic identity: an organic, octopus-like connector tool (never a human, no fabrication/judgment; `act as X` → cited-data reframe; recursion + cellular arm-isolation as the superpower).
+- README banner.
+
+### Changed
+- All seven `good first issue`s closed (#12, #13, #15, #28, #29, #30, #31) — first full contributor on-ramp clear.
+
 ## [2026-05-28]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://www.dataqbs.com/octorato-sigil.webp?v=3" alt="Octorato — the open-source AI Agent OS" width="100%">
+  <img src="https://www.dataqbs.com/banner-octorato.webp?v=3" alt="Octorato — the open-source AI Agent OS" width="100%">
 </p>
 
 > 🌍 This README is in English (the open-source lingua franca). Running an AI agent? Ask it to read this in your language — eating our own dog food. 🐙


### PR DESCRIPTION
CHANGELOG entry for the v2.1.0 release (53 commits since v2.0.0). Cut the tag after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)