### PR TITLE
feat(content): canon-render — canonical facts propagate to every surface

### DIFF
--- a/content/EXAMPLE.md
+++ b/content/EXAMPLE.md
@@ -1,0 +1,15 @@
+<!-- This fixture demonstrates canon-render. The marker spans below are
+     deliberately STALE — run `python3 scripts/canon-render.py` and watch each
+     one snap to the canonical value from content/canon.facts.yaml. Re-running
+     is a no-op (idempotent). This is the content counterpart of the Unison
+     Test in skills/octorato-harmony/SKILL.md. -->
+
+# Octorato — canonical content propagation demo
+
+Octorato is <!--canon:octorato.tagline-->an organic, file-native AI agent operating system — one brain, many sealed arms<!--/canon-->.
+
+The source lives at <!--canon:repo.url-->https://github.com/CarlosCaPe/octorato<!--/canon-->.
+
+It ships <!--canon:skills.count-->190+<!--/canon--> skills and
+<!--canon:agents.count-->150+<!--/canon--> specialist agents — these two RECOMPUTE
+from `brain-stats.py`, so they can never be hand-edited into a lie.

--- a/content/canon.facts.yaml
+++ b/content/canon.facts.yaml
@@ -1,0 +1,67 @@
+# Octorato canonical fact registry — the genome every surface reads.
+#
+# One canonical value per fact, propagated to every surface, copied NOWHERE.
+# This is the CONTENT counterpart of tokens/canon.json (which governs design
+# VALUES). A surface subscribes to a fact by embedding a marker:
+#
+#     <!--canon:octorato.tagline-->...anything...<!--/canon-->
+#
+# `canon-render.py` rewrites the span between the markers to the canonical
+# rendered value. The marker IS the subscription — a file opts in by carrying
+# one. See skills/octorato-harmony/SKILL.md for the why (the octopus moves as
+# one; no value is copied, only cited).
+#
+# kind:
+#   asserted — the operator is the ONLY editor; canon-render snaps every
+#              subscribed surface to `value`. (positioning, tagline, urls)
+#   derived  — `value` is RECOMPUTED from `derive` (a command + a JSON key);
+#              never hand-set. Reuses the existing source of truth.
+#   floored  — derived, then rounded DOWN to the nearest ten and suffixed "+"
+#              (the operator's stat convention: a floor is always TRUE and
+#              stable across small changes; also enforced by check-stats-drift.py).
+#
+# Averaging is BANNED for content. Only design-token VALUES average to the
+# middle (10,12 -> 11). Facts converge to canon BY TYPE, never by arithmetic
+# mean — a half-true sentence is worse than either source.
+
+meta:
+  schema: 1
+  # canon-render only ever touches files matching these globs (relative to the
+  # brain root). README.md / FAQ.md are intentionally ABSENT: their counts are
+  # still owned by the counts-triad (sync-readme-counts.py + brain-stats.py +
+  # check-stats-drift.py). Adding them here is the COORDINATED convergence step,
+  # not a unilateral one. See the PR coordination note.
+  targets:
+    - "content/*.md"
+
+facts:
+  - id: repo.url
+    kind: asserted
+    value: "https://github.com/CarlosCaPe/octorato"
+    citation: 'CLAUDE.md "Self-Awareness — You Are Running on Octorato"'
+
+  - id: octorato.tagline
+    kind: asserted
+    value: "an organic, file-native AI agent operating system — one brain, many sealed arms"
+    citation: "README.md hero (line 13)"
+
+  - id: skills.count
+    kind: floored
+    derive:
+      cmd: "python3 scripts/brain-stats.py --json"
+      json: skills
+    citation: "scripts/brain-stats.py — the single source of truth for headline counts"
+
+  - id: agents.count
+    kind: floored
+    derive:
+      cmd: "python3 scripts/brain-stats.py --json"
+      json: agents
+    citation: "scripts/brain-stats.py"
+    note: >
+      DIVERGENCE FLAGGED 2026-05-30 — brain-stats counts 152 personas (floor 150+),
+      but README prose currently reads "180+". Two counting RULES disagree (personas
+      under a division vs the connectome's total). The count DEFINITION must be
+      converged with the counts-triad owner BEFORE wiring this fact to README/FAQ.
+      Until then it renders to the fixture only — which is the canon catching its
+      first real drift, exactly as designed.

--- a/scripts/canon-render.py
+++ b/scripts/canon-render.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""canon-render — propagate canonical FACTS to every subscribed surface.
+
+The content counterpart of harmony-check.py (which governs design VALUES).
+A surface subscribes to a fact by embedding a marker span:
+
+    <!--canon:octorato.tagline-->old or stale text<!--/canon-->
+
+canon-render rewrites the inner text to the canonical rendered value from
+`content/canon.facts.yaml`. The marker IS the subscription: a file opts in by
+carrying one. Idempotent — only writes when a span actually changed.
+
+This GENERALIZES the counts-triad (sync-readme-counts.py + brain-stats.py +
+check-stats-drift.py): instead of a count-and-noun regex over README/FAQ, any
+fact of any kind flows to any marked surface, and `derived`/`floored` facts
+RECOMPUTE from the existing source of truth (brain-stats.py) — converging with
+the triad, not forking it.
+
+Reconciliation is typed by `kind`, never averaged:
+  asserted -> snap surface to value          (operator is the only editor)
+  derived  -> recompute value from `derive`  (cmd + JSON key)
+  floored  -> derived, floored to nearest ten, suffixed "+"
+
+Modes:
+  (default)        heal every marker in every target file; report writes.
+  --file <path>    heal only one file (for a PostToolUse Write|Edit hook).
+  --check          no writes; exit 1 if ANY marker is out of sync (pre-push).
+  --audit          no writes; print a drift table; always exit 0.
+
+Soft-fails (exit 0, no error) when the registry is absent, so it is safe to
+wire into ai-push before any arm adopts it.
+"""
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+import sys
+from glob import glob
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+REGISTRY = ROOT / "content" / "canon.facts.yaml"
+
+# <!--canon:ID-->inner<!--/canon-->  (ID = dotted/kebab word, inner may be empty)
+MARKER = re.compile(
+    r"<!--\s*canon:([\w.\-]+)\s*-->(.*?)<!--\s*/canon\s*-->",
+    re.DOTALL,
+)
+
+
+def floor_ten(n: int) -> int:
+    """Round DOWN to the nearest ten (152 -> 150, 196 -> 190)."""
+    return (n // 10) * 10
+
+
+def load_registry():
+    if not REGISTRY.exists():
+        return None
+    try:
+        import yaml  # PyYAML
+    except ImportError:
+        print("canon-render: PyYAML not available — skipping (soft-fail)", file=sys.stderr)
+        return None
+    data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8")) or {}
+    meta = data.get("meta", {}) or {}
+    facts = {f["id"]: f for f in (data.get("facts", []) or [])}
+    targets = meta.get("targets", []) or []
+    return facts, targets
+
+
+# Cache derive command results so we run brain-stats.py once, not per-marker.
+_DERIVE_CACHE: dict[str, dict] = {}
+
+
+def _run_derive(cmd: str) -> dict:
+    if cmd in _DERIVE_CACHE:
+        return _DERIVE_CACHE[cmd]
+    import json
+    out = subprocess.run(
+        shlex.split(cmd), cwd=ROOT, capture_output=True, text=True, timeout=60
+    )
+    if out.returncode != 0:
+        raise RuntimeError(f"derive failed: {cmd}\n{out.stderr.strip()}")
+    parsed = json.loads(out.stdout)
+    _DERIVE_CACHE[cmd] = parsed
+    return parsed
+
+
+def render(fact: dict) -> str:
+    """Return the canonical rendered string for a fact, by kind."""
+    kind = fact.get("kind", "asserted")
+    if kind == "asserted":
+        return str(fact["value"])
+    if kind in ("derived", "floored"):
+        d = fact.get("derive") or {}
+        data = _run_derive(d["cmd"])
+        val = data
+        for key in str(d["json"]).split("."):
+            val = val[key]
+        if kind == "floored":
+            return f"{floor_ten(int(val))}+"
+        return str(val)
+    raise ValueError(f"unknown kind '{kind}' for fact '{fact.get('id')}'")
+
+
+def target_files(targets: list[str]) -> list[Path]:
+    seen: list[Path] = []
+    for pat in targets:
+        for p in sorted(glob(str(ROOT / pat))):
+            path = Path(p)
+            if path.is_file() and path not in seen:
+                seen.append(path)
+    return seen
+
+
+def process_text(text: str, facts: dict, drifts: list, path: Path):
+    """Return (new_text, changed_count). Records drifts for reporting."""
+    changed = 0
+
+    def _sub(m: re.Match) -> str:
+        nonlocal changed
+        fid, inner = m.group(1), m.group(2)
+        fact = facts.get(fid)
+        if fact is None:
+            drifts.append((path.name, fid, "UNMANAGED", "(no such fact id)"))
+            return m.group(0)
+        try:
+            canonical = render(fact)
+        except Exception as exc:  # derive failure = unverifiable, never write garbage
+            drifts.append((path.name, fid, "UNVERIFIABLE", str(exc).splitlines()[0]))
+            return m.group(0)
+        if inner != canonical:
+            drifts.append((path.name, fid, "DRIFT", f"{inner!r} -> {canonical!r}"))
+            changed += 1
+        return f"<!--canon:{fid}-->{canonical}<!--/canon-->"
+
+    return MARKER.sub(_sub, text), changed
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    check = "--check" in argv
+    audit = "--audit" in argv
+    one_file = None
+    if "--file" in argv:
+        i = argv.index("--file")
+        one_file = Path(argv[i + 1]).resolve() if i + 1 < len(argv) else None
+
+    reg = load_registry()
+    if reg is None:
+        print("canon-render: no registry — nothing to do (soft-fail)")
+        return 0
+    facts, targets = reg
+
+    if one_file is not None:
+        files = [one_file] if one_file.exists() else []
+    else:
+        files = target_files(targets)
+
+    drifts: list = []
+    wrote = 0
+    write = not (check or audit)
+    for path in files:
+        before = path.read_text(encoding="utf-8")
+        after, changed = process_text(before, facts, drifts, path)
+        if changed and after != before:
+            if write:
+                path.write_text(after, encoding="utf-8")
+                wrote += 1
+                print(f"canon-render: healed {changed} marker(s) in {path.name}")
+
+    real_drift = [d for d in drifts if d[2] in ("DRIFT", "UNMANAGED", "UNVERIFIABLE")]
+    if audit or check:
+        if real_drift:
+            print(f"canon-render: {len(real_drift)} issue(s)")
+            for fname, fid, state, detail in real_drift:
+                print(f"  [{state}] {fname} :: canon:{fid}  {detail}")
+        else:
+            print(f"canon-render: all markers in unison across {len(files)} file(s)")
+    elif write and wrote == 0:
+        print(f"canon-render: already in unison across {len(files)} file(s)")
+
+    if check and real_drift:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

The **content** counterpart of `harmony-check.py` (which governs design **values**). The first real application of the `octorato-harmony` canon (#67): one canonical fact, propagated to every subscribed surface as a reflex — so facts *flow* instead of being hand-updated "pixelated" and drifting apart.

A surface subscribes by embedding a marker span:
```
Octorato is <!--canon:octorato.tagline-->...<!--/canon-->.
```
`canon-render.py` rewrites the inner text to the canonical value from `content/canon.facts.yaml`. The marker **is** the subscription.

| Mode | Use |
|---|---|
| *(default)* | heal every marker in every target, write |
| `--file <p>` | heal one file (for a `PostToolUse Write\|Edit` hook) |
| `--check` | no write; **exit 1** on any drift (pre-push / CI) |
| `--audit` | no write; print drift table; exit 0 |

Reconciliation is **typed by `kind`, never averaged** (averaging is banned for content): `asserted`→snap, `derived`→recompute, `floored`→recompute+floor.

## Converges with the counts-triad — does NOT fork it

Per the canon itself (*"converge, don't fork — the octopus moves as one"*), this **generalizes** the existing counts-triad rather than duplicating it:

- `derived`/`floored` facts **recompute from `brain-stats.py`** — the existing single source of truth is reused, not replaced.
- `sync-readme-counts.py` + `check-stats-drift.py` keep working untouched; `canon-render` is the general case (any fact, any marked surface), they are the count-specific case.
- **Targets are limited to `content/*.md`.** README.md / FAQ.md are intentionally *not* wired yet — adding them is the **coordinated convergence step** (handoff below), not a unilateral edit into the triad's lane.
- `content/` must be added to `BRAIN_PATHS` in `scripts/ai_sync.py:56` (cc [[lesson_ai_push_silent_allowlist_drop]]) — left for the coordinated wiring PR so it lands with the ai-push `--check` reflex.

## 🚩 Divergence this surfaced (for the counts-triad owner)

Building this immediately caught a real drift — exactly what the canon is for:

> `brain-stats.py --json` → `agents: 152` (floor **150+**), but `README.md` prose reads **180+**.

Two counting **rules** disagree (personas-under-a-division vs the connectome total). This PR does **not** resolve it (not my lane) — the `agents.count` fact carries a `note:` flagging it and renders to the fixture only. **The count definition should be converged before wiring `agents.count` to README/FAQ.**

## Coordinated next steps (after this merges + the triad owner aligns)

1. Converge the agent-count definition (brain-stats vs connectome) → one rule.
2. Add `README.md`/`FAQ.md` to `meta.targets`; add count markers; retire `sync-readme-counts.py`'s regex into `canon-render` (counts become the first wired fact).
3. Wire the reflexes: `PostToolUse` hook (`--file`), ai-push `--check` (FATAL) next to `check-stats-drift`, heartbeat drift-count line, daily `canon-publish`/`canon-detect`.
4. Add `content/` to `BRAIN_PATHS`.

## Test evidence

`--audit`→4 DRIFT · `--check`→exit 1 · default→healed 4 · re-run→idempotent "in unison" · `--check`→exit 0 · `--file`→ok.

Depends conceptually on #67 (the harmony canon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)