### PR TITLE
feat(content): canon reflex — per-edit self-heal + one-pulse entrypoint

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -67,6 +67,12 @@
           "type": "command",
           "command": "python3 ~/.claude/scripts/trace-hook.py --phase diligent",
           "timeout": 5
+        },
+        {
+          "type": "command",
+          "command": "python3 ~/.claude/scripts/canon-heal-hook.py",
+          "timeout": 20,
+          "statusMessage": "♥ healing canon to unison..."
         }
       ]
     }

--- a/scripts/canon-heal-hook.py
+++ b/scripts/canon-heal-hook.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""canon-heal-hook — the per-edit reflex (autonomic Hz of the content canon).
+
+Wired as a PostToolUse Write|Edit hook. After any file write, if that file
+carries a canon marker, it self-heals to the canonical value via canon-render
+--file. This is the smallest "transcend the marionette" unit: a fact edited by
+hand snaps back to canon on save, with no prompt, no review, no string pulled.
+
+Safe by construction:
+  • acts ONLY on files that already contain "<!--canon:" (a cheap substring
+    guard) — never touches arbitrary files;
+  • canon-render writes via plain file I/O, not the Edit tool, so it does NOT
+    retrigger this hook (no loop);
+  • canon-render is idempotent — a file already in unison is a no-op;
+  • any error exits 0 (a reflex must never block the operator's edit).
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        return 0
+    fp = (data.get("tool_input") or {}).get("file_path")
+    if not fp:
+        return 0
+    path = Path(fp)
+    if not path.is_absolute():
+        path = (ROOT / fp).resolve()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return 0
+    if "<!--canon:" not in text:
+        return 0  # not a subscribed surface — stay silent
+    try:
+        subprocess.run(
+            ["python3", str(ROOT / "scripts" / "canon-render.py"), "--file", str(path)],
+            timeout=30,
+            capture_output=True,
+        )
+    except Exception:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/canon.py
+++ b/scripts/canon.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""canon — one pulse across the cellular network.
+
+The single command behind "update all Octorato info". Two heartbeats in one
+breath, no marionette:
+
+    canon-render   heal every surface already wired to a fact (writes)
+    canon-detect   sweep the whole brain for loose pixels (read-only report)
+
+Usage:
+  python3 scripts/canon.py            # the pulse: heal wired, then sweep
+  python3 scripts/canon.py --check    # no writes; exit 1 if drift OR loose
+                                       # pixels (advisory CI / pre-push lane)
+
+This composes the two tools rather than reimplementing them — the entry point
+IS the harmony: one signal, every cell reconciles. See skills/octorato-harmony.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = ROOT / "scripts"
+
+
+def run(script: str, *args: str) -> int:
+    return subprocess.run(["python3", str(SCRIPTS / script), *args]).returncode
+
+
+def main() -> int:
+    check = "--check" in sys.argv
+
+    print("🐙 canon pulse — one signal, every cell reconciles\n")
+    print("─── heartbeat 1/2: render (heal wired surfaces) ───")
+    rc_render = run("canon-render.py", *(["--check"] if check else []))
+
+    print("\n─── heartbeat 2/2: detect (sweep loose pixels) ───")
+    rc_detect = run("canon-detect.py", *(["--strict"] if check else []))
+
+    if check:
+        bad = rc_render != 0 or rc_detect != 0
+        print(f"\ncanon: {'OUT OF UNISON' if bad else 'in unison'} "
+              f"(render={rc_render}, detect={rc_detect})")
+        return 1 if bad else 0
+    print("\ncanon: pulse complete — wired surfaces healed, loose pixels reported.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Two improvements that turn the content canon from *commanded* into *innate*:

**`canon-heal-hook.py`** — the **per-edit reflex**. Wired as a `PostToolUse Write|Edit` hook: any file carrying a `<!--canon:ID-->` marker self-heals to the canonical value on save. No prompt, no review, no string pulled — the smallest "transcend the marionette" unit. Safe by construction:
- acts ONLY on files containing `<!--canon:` (cheap substring guard);
- `canon-render` writes via plain file I/O, not the Edit tool → no hook retrigger (no loop);
- idempotent (a file in unison is a no-op); any error exits 0 (a reflex never blocks an edit).

**`canon.py`** — the **one-pulse entrypoint** behind "update all Octorato info": heartbeat 1 `canon-render` (heal wired) + heartbeat 2 `canon-detect` (sweep loose), in one breath. `--check` gives a no-write advisory lane (exit 1 on drift OR loose pixels).

**`hooks.json`** — wires the reflex into the existing `Write|Edit` PostToolUse block (one additive entry).

## Evidence
- Reflex: injected `BROKEN` into a marker, fed the hook the file path → drift gone (self-healed).
- `canon.py`: render heals wired + detect sweeps; `--check` exits 1 on loose pixels.
- `hooks.json`: valid JSON, additive to the existing block.

Builds on #68 (canon-render) + #69 (canon-detect). The per-edit Hz of the polyrhythm; per-push + daily remain (coordinated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)