### PR TITLE
fix(stats): converge agent count to one rule (167) + seed README canon markers

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -4,7 +4,7 @@ Plain answers to the questions people (and the AI agents that read this repo) ac
 
 ## What is Octorato?
 
-Octorato is an **open-source AI agent operating system**: one file-native "brain" — rules, 190+ skills (HOW), 180+ specialist agents (WHO), and memory, all plain markdown under git — that a single operator runs across many sealed client "arms." It adds per-client token attribution and hard budget halts (FinOps), so a consultant or small agency can bill many clients fairly from one brain. Licensed MIT.
+Octorato is an **open-source AI agent operating system**: one file-native "brain" — rules, 190+ skills (HOW), 160+ specialist agents (WHO), and memory, all plain markdown under git — that a single operator runs across many sealed client "arms." It adds per-client token attribution and hard budget halts (FinOps), so a consultant or small agency can bill many clients fairly from one brain. Licensed MIT.
 
 ## What is an "AI agent operating system"?
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 >
 > <sub>the Octopus Brain Framework</sub>
 
-> **Octorato is an open-source AI agent operating system: one file-native "brain" — 190+ skills and 180+ specialist agents in plain markdown under git — that one operator runs across many isolated client "arms."**
+> **Octorato is an open-source AI agent operating system: one file-native "brain" — <!--canon:skills.count-->190+<!--/canon--> skills and <!--canon:agents.count-->160+<!--/canon--> specialist agents in plain markdown under git — that one operator runs across many isolated client "arms."**
 
 [![License: MIT](https://img.shields.io/github/license/CarlosCaPe/octorato)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/CarlosCaPe/octorato?style=social)](https://github.com/CarlosCaPe/octorato/stargazers)
@@ -70,7 +70,7 @@ Octorato isn't a demo — it ships real software. A few of the products this bra
 - [The Corporation](#the-corporation)
 - [The Connectome — Neural Architecture](#the-connectome--neural-architecture)
 - [Client Arms — Total Isolation](#client-arms--total-isolation)
-- [Org Chart — 13 Divisions, 180+ Agents](#org-chart--13-divisions-180-agents)
+- [Org Chart — 13 Divisions, 160+ Agents](#org-chart--13-divisions-160-agents)
 - [Synapses — The Skill Layer (190+ reusable techniques)](#synapses--the-skill-layer-190-reusable-techniques)
 - [Memory — Hippocampus and the Working Set](#memory--hippocampus-and-the-working-set)
 - [Reflexes — The Spinal Cord Layer](#reflexes--the-spinal-cord-layer)
@@ -133,7 +133,7 @@ An open-source AI agent operating system where a single human operator directs a
 
 With nothing but natural language, you can direct a team of AI specialists to build and ship software, and bill the client honestly when it ships.
 
-**Live framework**: 190+ skills, 180+ agent personas across 13 divisions, enforcement scripts, multi-machine sync, a neural connectome that learns over time, and a FinOps pipeline that tags every trace event with the client who incurred it — with per-arm USD rollup and a `PreToolUse` budget halt **shipped, opt-in** (configure `budgets.yaml` to arm caps; run the `anthropic-enterprise-analytics` pull to reconcile estimate against billed cost). See [roadmap below](#finops-roadmap).
+**Live framework**: 190+ skills, 160+ agent personas across 13 divisions, enforcement scripts, multi-machine sync, a neural connectome that learns over time, and a FinOps pipeline that tags every trace event with the client who incurred it — with per-arm USD rollup and a `PreToolUse` budget halt **shipped, opt-in** (configure `budgets.yaml` to arm caps; run the `anthropic-enterprise-analytics` pull to reconcile estimate against billed cost). See [roadmap below](#finops-roadmap).
 
 **Shipped with it**: live products built and maintained agent-first on this brain — see [Built with Octorato](SHOWCASE.md).
 
@@ -203,9 +203,9 @@ The central brain sets high-level intent. The arms execute with local intelligen
 
 | Octopus Biology | Framework Architecture | What It Does |
 |----------------|----------------------|-------------|
-| Central brain | `~/.claude/` (this repo) | Shared rules, paradigms, 180+ specialist agents, 190+ skills |
+| Central brain | `~/.claude/` (this repo) | Shared rules, paradigms, 160+ specialist agents, 190+ skills |
 | Arms | Client project repos | Isolated workspaces — each client is a sealed arm |
-| Neurons | Agent personas | 180+ specialist agents across 13 divisions |
+| Neurons | Agent personas | 160+ specialist agents across 13 divisions |
 | Synapses | Skills | 190+ reusable techniques that connect agents to capabilities |
 | Chemoreceptors (suckers) | `query_connectome.py` | TF-IDF cosine similarity against the indexed agent/skill corpus — a sparse lexical retriever, not multimodal chemoreception |
 | Afferent/efferent signal cycle | 4D Paradigm | Sense → plan → act → evaluate, with feedback — every signal follows 4 phases |
@@ -292,7 +292,7 @@ The framework uses an object-oriented inheritance model:
 │     - The 4D Paradigm (Describe-Delegate-Diligent-Disclose)  │
 │     - The Octopus Architecture (brain/arm isolation)         │
 │     - The connectome engine (TF-IDF, cosine similarity)      │
-│     - 180+ generic agent personas                              │
+│     - 160+ generic agent personas                              │
 │     - 190+ generic skills (techniques, not client workflows)  │
 │     - Enforcement scripts (delegate-check, gate-check, etc.) │
 │     - Templates for creating your own company brain + arms   │
@@ -479,7 +479,7 @@ The archived specs become institutional memory — future tasks reference past d
                         │   BRAIN         │
                         │  ~/.claude/     │
                         │  190+ Skills     │
-                        │  180+ Agents     │
+                        │  160+ Agents     │
                         │  N Client Arms  │
                         └────────┬────────┘
                                  │
@@ -594,7 +594,7 @@ Human → Agent   Explicit cross-arm requests         (human decides what to bri
 
 ---
 
-## Org Chart — 13 Divisions, 180+ Agents
+## Org Chart — 13 Divisions, 160+ Agents
 
 ```mermaid
 graph TB
@@ -603,7 +603,7 @@ graph TB
     classDef div fill:#21262D,stroke:#30363D,stroke-width:1px,color:#C9D1D9,font-size:12px
 
     CEO["Human Operator"]:::ceo
-    BRAIN["BRAIN — 190+ Skills · 180+ specialist agents · N Arms"]:::brain
+    BRAIN["BRAIN — 190+ Skills · 160+ specialist agents · N Arms"]:::brain
     CEO --> BRAIN
 
     BRAIN --> ENG["Engineering — 28"]:::div
@@ -1267,7 +1267,7 @@ ai-pull --status
 ├── HEBBIAN_LEARNING.md      ← How the connectome learns over time
 ├── hooks.json               ← Shared hooks (source of truth, synced to all machines)
 ├── neural_map.json          ← The Deep Connectome (auto-generated, never edit)
-├── agents/                  ← 180+ specialist agents
+├── agents/                  ← 160+ specialist agents
 │   ├── REGISTRY.md          ← Auto-activation triggers & cross-references
 │   ├── engineering/         ← 28 agents
 │   ├── design/              ← 8 agents

--- a/content/EXAMPLE.md
+++ b/content/EXAMPLE.md
@@ -11,5 +11,5 @@ Octorato is <!--canon:octorato.tagline-->an organic, file-native AI agent operat
 The source lives at <!--canon:repo.url-->https://github.com/CarlosCaPe/octorato<!--/canon-->.
 
 It ships <!--canon:skills.count-->190+<!--/canon--> skills and
-<!--canon:agents.count-->150+<!--/canon--> specialist agents — these two RECOMPUTE
+<!--canon:agents.count-->160+<!--/canon--> specialist agents — these two RECOMPUTE
 from `brain-stats.py`, so they can never be hand-edited into a lie.

--- a/content/canon.facts.yaml
+++ b/content/canon.facts.yaml
@@ -33,6 +33,12 @@ meta:
   # not a unilateral one. See the PR coordination note.
   targets:
     - "content/*.md"
+    # README.md joined 2026-05-30: the hero-line counts are now wrapped in canon
+    # markers, which removes them from sync-readme-counts.py's regex reach (the
+    # comment tag breaks the number+noun adjacency) and hands those occurrences to
+    # canon-render. sync-readme still owns the ASCII-box / TOC-anchor / heading
+    # counts it handles specially — coexistence, the converge-not-fork migration.
+    - "README.md"
 
 facts:
   - id: repo.url
@@ -59,9 +65,12 @@ facts:
       json: agents
     citation: "scripts/brain-stats.py"
     note: >
-      DIVERGENCE FLAGGED 2026-05-30 — brain-stats counts 152 personas (floor 150+),
-      but README prose currently reads "180+". Two counting RULES disagree (personas
-      under a division vs the connectome's total). The count DEFINITION must be
-      converged with the counts-triad owner BEFORE wiring this fact to README/FAQ.
-      Until then it renders to the fixture only — which is the canon catching its
-      first real drift, exactly as designed.
+      CONVERGED 2026-05-30 — the earlier divergence (brain-stats 152 vs README 180+)
+      was a real bug: brain-stats counted personas non-recursively (missed 15 nested
+      in sub-categories like game-development/godot/), while sync-readme counted
+      recursively but wrongly INCLUDED the 16 strategy/ reference docs (playbooks,
+      runbooks — not personas). Both fixed to ONE rule: recursive personas under a
+      division, excluding examples/ + strategy/. True count = 167 → floor 160+.
+      brain-stats.py + sync-readme-counts.py + canon all agree now. (The connectome's
+      ~183 is indexed agent-RELATED nodes for retrieval, a different metric from
+      persona headcount — keep them distinct; the public count is brain-stats.)

--- a/scripts/brain-stats.py
+++ b/scripts/brain-stats.py
@@ -12,8 +12,8 @@ CANONICAL DEFINITIONS (explicit so they're unambiguous forever):
   • Skill     = a directory under  ~/.claude/skills/<name>/  containing SKILL.md
   • Division  = an immediate subdirectory of ~/.claude/agents/ that is NOT in
                 EXCLUDED_AGENT_DIRS and that contains >= 1 persona file
-  • Persona   = a *.md file DIRECTLY under a division dir (non-recursive),
-                excluding README.md and index files
+  • Persona   = a *.md file under a division dir (recursive — personas may be
+                nested in sub-categories), excluding README.md and index files
 
 EXCLUDED_AGENT_DIRS are reference material, not specialist personas:
   • examples/  — workflow examples + README
@@ -50,8 +50,8 @@ def agent_divisions() -> dict[str, int]:
         if not d.is_dir() or d.name in EXCLUDED_AGENT_DIRS:
             continue
         personas = [
-            f for f in d.glob("*.md")          # non-recursive: direct children only
-            if f.name not in NON_PERSONA_FILES
+            f for f in d.rglob("*.md")         # recursive: personas may be nested in
+            if f.name not in NON_PERSONA_FILES  # sub-categories (e.g. game-development/godot/)
         ]
         if personas:
             out[d.name] = len(personas)
@@ -69,7 +69,7 @@ def compute() -> dict:
         "definitions": {
             "skill": "dir under skills/ with SKILL.md",
             "division": "immediate subdir of agents/ (excl examples,strategy) with >=1 persona",
-            "persona": "*.md directly under a division dir, excl README/REGISTRY/index",
+            "persona": "*.md under a division dir (recursive), excl README/REGISTRY/index",
         },
     }
 

--- a/scripts/sync-readme-counts.py
+++ b/scripts/sync-readme-counts.py
@@ -37,10 +37,13 @@ def count_skills() -> int:
 
 
 def count_agents() -> int:
+    # Match brain-stats.py exactly: recursive personas, excluding the reference
+    # divisions (examples/, strategy/ — playbooks/runbooks/briefs, not personas).
     return sum(
         1 for p in (ROOT / "agents").rglob("*.md")
-        if not p.name.upper().startswith(("README", "REGISTRY", "_"))
+        if not p.name.upper().startswith(("README", "REGISTRY", "_", "INDEX"))
         and "examples" not in p.parts
+        and "strategy" not in p.parts
     )
 
 


### PR DESCRIPTION
## The divergence (real bug, caught by the content canon)

The agent count read differently on three surfaces. Root cause: two counting rules disagreed AND both were wrong.

| Source | Was | Bug |
|---|---|---|
| `brain-stats.py` | 152 | counted personas **non-recursively** (`d.glob`) → missed **15** nested personas (`game-development/godot/`, `roblox-studio/`, `blender/`…) |
| `sync-readme-counts.py` | 183 | counted recursively but **included** the **16** `strategy/` reference docs (playbooks/runbooks/briefs — not personas) |
| README/FAQ | 180+ | floor of the buggy 183 — silently advertised playbooks as agents |

**183 − 16 strategy = 167 = true count.** Verified empirically.

## The convergence (one rule)

Both scripts fixed to the SAME definition: *recursive personas under a division, excluding `examples/` + `strategy/`*. Now:

- `brain-stats.py` = **167** · `sync-readme-counts.py` = **167** · canon `agents.count` = **160+**
- README/FAQ regenerated **180+ → 160+** (more honest)
- skills unchanged (197 → 190+, already correct)

The connectome's ~183 is **indexed agent-related nodes** (a retrieval metric) — kept deliberately distinct from persona headcount; the public count is `brain-stats.py`.

## First canon markers on a real surface

The README hero counts are now wrapped in `<!--canon:skills.count-->190+<!--/canon-->` / `<!--canon:agents.count-->160+<!--/canon-->`. This **removes them from sync-readme's regex reach** (the comment tag breaks the number+noun adjacency) and hands them to `canon-render`, derived live from `brain-stats.py`. `sync-readme` still owns the ASCII-box / TOC-anchor / heading counts it handles specially — **coexistence, the converge-not-fork migration path**.

## Evidence
- `brain-stats` 167 = `sync-readme` 167 ✓
- `canon-render --check` exit 0 · `sync-readme --check --floor` "already in sync" exit 0 (the two mechanisms do **not** fight) ✓
- README hero renders clean (markers invisible): *"190+ skills and 160+ specialist agents"* ✓
- `check-stats-drift.py` exit 0 ✓

## ⚠️ Remaining propagation surface (flagged, not in this PR)
The counts also live in the **dataqbs site** (`cv.ts`, i18n, the Octorato page) — a separate repo/arm. That pixel still reads the old floor and needs its own update + deploy.

Builds on #68/#69/#70 (the canon engine + reflex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)