### PR TITLE
fix(hooks): canon-heal-hook timeout 20→5 (schema max is 5)

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -71,7 +71,7 @@
         {
           "type": "command",
           "command": "python3 ~/.claude/scripts/canon-heal-hook.py",
-          "timeout": 20,
+          "timeout": 5,
           "statusMessage": "♥ healing canon to unison..."
         }
       ]


### PR DESCRIPTION
The canon-heal-hook added in #70 set `timeout: 20`, but hooks.schema.json caps hook timeout at 5 — check-hooks-drift.py flags it as a schema violation. 5s is ample for a single-file canon-render. 🤖 Generated with [Claude Code](https://claude.com/claude-code)