### PR TITLE
fix(ci): keep Swift out of Linguist/CodeQL (stops failing autobuild)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# GitHub Linguist / CodeQL language-surface control.
+#
+# The brain's canonical languages are Python + JavaScript. A handful of
+# standalone platform-helper scripts (.swift macOS helpers, vendored repos
+# under knowledge/) are NOT part of the project's build and have no Xcode
+# project or Swift package. When Linguist counts them, GitHub default-setup
+# auto-suggests a Swift CodeQL analysis whose autobuild then fails with
+# "No Xcode project or workspace found". Mark them vendored so they stay out
+# of language detection and CodeQL never re-enables Swift.
+*.swift linguist-vendored
+
+# Vendored external repos cloned for deep-learning are not our source.
+knowledge/repo-deep-learn/** linguist-vendored


### PR DESCRIPTION
## What
Adds `.gitattributes` marking `*.swift` and vendored `knowledge/repo-deep-learn/**` as `linguist-vendored`.

## Why
GitHub default-setup auto-suggested a **Swift CodeQL** analysis because 4 loose `.swift` helper scripts exist (3 macOS screenshot helpers + 1 vendored ECC learning file). They have **no Xcode project / Swift package**, so autobuild failed with `No Xcode project or workspace found` → 3 code-scanning errors.

## Fix (two parts)
1. **Already done out-of-band:** deleted the orphaned Swift analysis (`1307612674`) — tool-status page clears.
2. **This PR (durable):** vendored-mark the scripts so Swift drops from language detection and CodeQL never re-enables it.

No code/runtime effect — Linguist stats only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)