### PR TITLE
feat(brain): session-isolation principle + human-cadence delivery rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ AI AGENT — nervous system, executes via 4D paradigm
 4. **Human Gateway** — Only the operator bridges knowledge between arms. AI never does it autonomously.
 5. **Identity Lives in Company Brain** — Professional identity lives in `company/skills/professional-identity/SKILL.md`.
 6. **4D Governs All Flow** — Every action follows Describe → Delegate → Diligent → Disclose.
+7. **Session/Instance Isolation (MANDATORY)** — The same arm can run in two dimensions at once (two live sessions), but **each concurrent session MUST have its own git worktree + session id**. Never two live sessions on one shared working tree. This is Arm Isolation applied to *time*: two instances of one arm are still two arms, so they never share an index. The collision mode is real — a broad `git add` in one session swallows the other session's *uncommitted* files into the wrong commit. The fix is the octopus's superpower, not a limit: one brain runs many isolated instances in parallel (something a serial human can't), because each instance is sealed in its own checkout. Mechanism + protocol in `skills/session-isolation/SKILL.md`. Anthropic's own answer to this scenario: `claude --worktree <name>` per parallel session ("a separate checkout on its own branch ... so concurrent edits don't collide").
 
 ### Information Flow Rules
 
@@ -130,8 +131,13 @@ Any blocklist hit → commit/push blocked. No exceptions, no `--force`. **If a l
 ## Communication
 - **Concise** — 1-3 sentences when possible. No preamble.
 - **No filler** — no "Great question!", "Let me help you with that!", etc.
-- **Structured output** — tables, bullets, code blocks. Wall-of-text = failure.
+- **Structured output** — tables, bullets, code blocks for STRUCTURED/technical answers (specs, comparisons, steps, data). Wall-of-text = failure. For *conversational* prose, see Human Cadence rule 8 below — bullets there read as AI.
 - **Language match** — respond in the language the user writes in.
+
+### Human Cadence — Anti-AI-Tells (ALWAYS-ON, every output)
+Every output (chat, email, doc, commit body, PR description) ships through these 10 DON'Ts so it reads like a person, not a model — and costs fewer tokens. Full detail + per-language blocklists + the verbatim humanizer prompt in `skills/human-cadence/SKILL.md`.
+1. **No em-dash (—)** anywhere — use periods, commas, line breaks. 2. **No AI filler words** (EN: delve/leverage/utilize/robust/seamless/foster/comprehensive… · ES: ahondar/aprovechar/utilizar/robusto/fluido/fomentar/exhaustivo…). 3. **No "not only X, but Y" / "no solo X, sino Y".** 4. **No forced triads** — 1 or 2 items is fine; don't pad to 3. 5. **No rigid transitions** (moreover/furthermore/in conclusion · además/asimismo/en conclusión). 6. **No filler openers** ("I hope this finds you well", "in today's fast-paced world" · "espero que te encuentre bien", "en el vertiginoso mundo actual"). 7. **No uniform sentence length** — mix short/medium/long, use fragments. 8. **No bullets in conversational prose** (chat/casual email/description) — flowing sentences; structured/technical output keeps its tables+code. 9. **No repeated conclusions** ("overall/in summary/to wrap up" · "en general/en resumen/para finalizar") — end on the last real point. 10. **No voiceless perfect grammar** — use contractions + natural voice; keep meaning, add no new ideas.
+Read-aloud test: if a sentence sounds like a LinkedIn thought-leader wrote it, rewrite it. The Provenance footer is exempt (machine receipt, not prose).
 
 ## Git & Version Control
 - **Atomic commits** — one logical change per commit. `type(scope): description`.

--- a/skills/4d-paradigm-protocol/SKILL.md
+++ b/skills/4d-paradigm-protocol/SKILL.md
@@ -15,7 +15,7 @@ This skill carries the formats, templates, and tables for the 4D Paradigm. The s
 1. **Describe** — Before acting, state what you'll do and why. No silent changes. Example: "I'll add an index on HospitalId to fix the seq scan. This is a read-only schema change."
 2. **Delegate** — Use subagents for complex research. Don't guess when you can verify. Search the codebase, read docs, check history before generating output.
 3. **Diligent** — Evaluate output quality. Run tests, check errors, validate results. After every change: build/lint/test. After every query: check row count, null ratios, schema match.
-4. **Disclose** — Always state implications. If a change has side effects, say so before proceeding. Before applying any change, run an Impact Radius scan (see below) to find all upstream/downstream references.
+4. **Disclose** — Always state implications. If a change has side effects, say so before proceeding. Before applying any change, run an Impact Radius scan (see below) to find all upstream/downstream references. **Delivery cadence:** every output ships through the Human Cadence 10 no-rules (`skills/human-cadence/SKILL.md`, summary in CLAUDE.md §Communication) so the text reads like a person, not a model — no em-dash, no AI filler, no triads, varied rhythm, contractions. Disclose is *how* you say it as much as *what* the impact is.
 
 ## Signal Flow (ENTRADA → SALIDA)
 

--- a/skills/human-cadence/SKILL.md
+++ b/skills/human-cadence/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: human-cadence
+description: "The 10 no-rules that strip AI-tells from any written output so text reads like a person, not a model — and costs fewer tokens. Inverted from the soyfelixgo TikTok 'humanizer' prompt into hard DON'Ts. ALWAYS-ON delivery discipline: every output (chat, email, doc, commit body, PR description) passes these before it ships. CLAUDE.md §Communication carries the summary; the verbatim source + per-language blocklists + reconciliation live here. Load when drafting prose, humanizing AI text, or auditing why a draft 'sounds like AI'."
+metadata:
+  short-description: "10 anti-AI-tell no-rules for human-sounding, token-lean output"
+  type: reference
+  source: "https://www.tiktok.com/@soyfelixgo/video/7642065153533496598 (caption = the humanizer prompt)"
+---
+
+# Human Cadence — The 10 No-Rules
+
+## Why
+
+AI text has a fingerprint: em-dashes everywhere, triads, "not only X but Y", rigid transitions, filler openers, uniform sentence length, voiceless perfect grammar. Readers feel it before they can name it, and it erodes trust — the same way an unsourced gut-call does. These 10 no-rules remove the fingerprint. Side effect: **less filler = fewer tokens**. Human cadence and token-economy are the same edit.
+
+This is a **delivery discipline**, not a content rule. It changes *how* the answer is written, never *what* is true or sourced. The Provenance footer still ships; facts still cite. We sound like a person who knows, not a model performing.
+
+## The 10 No-Rules (DON'T)
+
+| # | DON'T | DO instead |
+|---|-------|-----------|
+| 1 | **No em-dash (—) anywhere.** | Use periods, commas, or line breaks. |
+| 2 | **No AI filler vocabulary** (blocklist below). | Plain words. Say the thing. |
+| 3 | **No "not only X, but Y" / "no solo X, sino Y"** contrast frame. | State it straight. |
+| 4 | **No forced triads** (lists of three for rhythm). | One or two items is fine. Don't pad to three. |
+| 5 | **No rigid transitions** (moreover, furthermore, additionally, in conclusion / además, asimismo, adicionalmente, en conclusión). | Let sentences connect naturally, or just start the next one. |
+| 6 | **No filler openers** ("I hope this message finds you well", "in today's fast-paced world", "in the realm of", "it's worth noting that" / "espero que este mensaje te encuentre bien", "en el vertiginoso mundo actual", "en el ámbito de", "cabe destacar que"). | Open on the point. |
+| 7 | **No uniform sentence length.** | Mix short, medium, long. Use fragments. Vary the rhythm. |
+| 8 | **No bullets in informal/conversational prose** (chat reply, casual email, a description). | Write flowing sentences. (Exception below — structured technical output keeps its tables/code.) |
+| 9 | **No repeated conclusions / summary tails** ("overall", "in summary", "to wrap up" / "en general", "en resumen", "para finalizar"). | End on the last real point. Stop. |
+| 10 | **No voiceless perfect grammar.** | Use contractions, natural voice. Sound like a person. Keep the meaning, add no new ideas. |
+
+### Read-aloud test (rule 10's enforcer)
+Read the draft in your head. If a sentence sounds like a LinkedIn thought-leader wrote it, rewrite it.
+
+## Per-language filler blocklist (rule 2)
+
+| EN | ES | DE (extend as needed) |
+|----|----|----|
+| delve, tapestry, leverage, utilize, robust, seamless, multifaceted, navigate, optimize, foster, comprehensive | ahondar, tapiz, aprovechar, utilizar, robusto, fluido, multifacético, navegar, optimizar, fomentar, exhaustivo | — |
+
+The list is a starting set, not exhaustive. The principle: if a word shows up far more in model output than in how a person actually talks, drop it.
+
+## Reconciliation — this does NOT kill structured output
+
+CLAUDE.md §Communication mandates "tables, bullets, code blocks; wall-of-text = failure." That still holds for **structured/technical deliverables** (specs, comparisons, runbooks, query results, step lists). Rule 8 governs **conversational prose** — chat replies, casual emails, narrative descriptions. The two coexist:
+
+- Technical/structured answer → tables, code, numbered steps stay. Cadence rules 1–7, 9, 10 still apply *inside* the prose parts.
+- Conversational/chat answer → prose, varied rhythm, contractions, no bullet-spam.
+
+When unsure which mode you're in: is the user asking for data/structure, or talking with you? Structure for the first, cadence for the second.
+
+The Provenance footer is a system requirement and is exempt — it's a machine receipt, not prose.
+
+## The source prompt (verbatim, for reuse as a humanizer)
+
+The canonical "rewrite to sound human" prompt these rules were inverted from:
+
+> Reescribe el siguiente texto para que suene como una persona real, no como una IA. Elimina lo siguiente:
+> - Todos los guiones largos (em dash). Usa puntos, comas o saltos de línea.
+> - Estas palabras: ahondar, tapiz, aprovechar, utilizar, robusto, fluido, multifacético, navegar, optimizar, fomentar, exhaustivo.
+> - El formato de contraste "no solo X, es Y".
+> - Listas forzadas de tres elementos. Dos elementos están bien. Uno está bien.
+> - Transiciones rígidas: además, asimismo, adicionalmente, en conclusión.
+> - Abridores de relleno: "Espero que este mensaje te encuentre bien", "en el vertiginoso mundo actual", "en el ámbito de", "cabe destacar que".
+> - Oraciones de la misma longitud. Mezcla frases cortas, medianas y largas. Usa fragmentos.
+> - Viñetas si es un correo electrónico informal o una descripción. Escribe en oraciones fluidas.
+> - Repetición de conclusiones. Nada de "en general", "en resumen", "para finalizar".
+> - Gramática perfecta sin voz. Usa contracciones. Suena como una persona.
+> Mantén el significado original. No añadas ideas nuevas. Léelo en voz alta en tu cabeza. Si una frase suena como si la hubiera escrito un líder de opinión de LinkedIn, reescríbela.
+
+Use this prompt directly when the operator hands you AI text and says "humanize this".
+
+## Related
+
+- `token-efficient-prompting` — the same edit from the cost angle (filler = tokens).
+- `voice-and-cadence-consistency` — keeps voice uniform across a long *technical* doc; different concept (consistency, not de-AI-ing).
+- CLAUDE.md §Communication — the always-on summary that points here.
+- 4D Disclose — these rules fire at the delivery boundary, every output.

--- a/skills/session-isolation/SKILL.md
+++ b/skills/session-isolation/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: session-isolation
+description: "MANDATORY isolation for concurrent Claude Code sessions on one repo (especially ~/.claude itself). The same arm can run in two dimensions at once, but each live session MUST have its own git worktree + session id — never two on one shared working tree. Documents the real collision (a broad git add in one lane swallows the other lane's uncommitted files), the octopus-morphology framing (instance isolation = Arm Isolation across time), the worktree protocol, and Anthropic's official `claude --worktree` guidance. Load before starting a second session on a repo, when two agents share ~/.claude, or when investigating 'my changes got committed by another session / ended up on the wrong branch'."
+metadata:
+  short-description: "Each concurrent session gets its own git worktree — period"
+  type: reference
+  source: "https://code.claude.com/docs/en/common-workflows#run-parallel-sessions-with-worktrees + lived 2026-06-02 collision"
+---
+
+# Session / Instance Isolation
+
+## The rule (one line)
+
+**Each concurrent session must run in its own git worktree. Period.** Two live sessions on one shared working tree is forbidden, even when both are "yours".
+
+## Why — the octopus morphology
+
+The brain is one organism with many semi-autonomous arms. `Arm Isolation (MANDATORY)` already says an arm never knows another arm exists and they never share state. Session isolation is that **same rule applied to time**: the same tentacle can run in two dimensions at once (two parallel sessions), and two instances of one arm are *still two arms*. So they never share an index, a working tree, or a HEAD.
+
+This is not a limit to route around. It's the superpower. A serial human is one thread; they can't truly edit the same file from two minds at once. The octopus can run many isolated instances of itself in parallel, because each instance is sealed in its own checkout. We have the two primitives that make it safe: **session id** (who am I) + **working tree** (where my hands are). The 4D magic is parallelism *with* isolation, never parallelism *instead of* it.
+
+## The collision (what actually happens without it)
+
+Lived on 2026-06-02 in `~/.claude` itself. Two sessions shared ONE worktree (`git worktree list` showed a single checkout). The sequence:
+
+1. Session A creates files (a new skill, edits to `CLAUDE.md`) but hasn't committed yet — they sit **uncommitted in the shared working tree**.
+2. Session B runs its own commit flow (`ai-push` / a broad `git add`). The broad stage captures *everything* dirty in the tree, including Session A's uncommitted files.
+3. B commits. A's work is now inside **B's commit, under B's unrelated message**.
+4. B does `git reset HEAD~1` and re-commits to amend its own work. That churn **splits A's changeset** — some hunks ride into the new commit, some fall back to uncommitted. A's change is now fragmented across the index, on a branch A never chose, none of it pushed.
+
+Nothing is "lost" (it's all on disk), but the changeset is shredded and the shared HEAD is unstable while B iterates. Root cause: **no isolation boundary** + **broad `git add`** + **two live writers on one index**.
+
+## The protocol
+
+### Starting a parallel session (the Anthropic-native way)
+```bash
+claude --worktree <name>      # separate checkout on its own branch; run a 2nd with a different <name>
+```
+Anthropic docs, verbatim: *"Work on a feature in one terminal while Claude fixes a bug in another, without the edits colliding. Each worktree is a separate checkout on its own branch."* (`code.claude.com/docs/en/common-workflows#run-parallel-sessions-with-worktrees`)
+
+### Doing it by hand (e.g. inside an agent that must isolate itself)
+```bash
+git fetch origin
+git worktree add /path/outside/repo/<lane> -b auto/<lane> origin/<default-branch>   # master here, not main
+# ... do all edits, commits, push, PR from inside that worktree ...
+git worktree remove /path/outside/repo/<lane>                                       # cleanup when merged
+```
+The Agent tool exposes this as `isolation: "worktree"` — prefer it for any sub-agent that mutates files in parallel.
+
+### Rules inside the protocol
+- **One worktree per live lane.** If a second session is already live in the shared tree, the newcomer isolates; it does not join.
+- **`git fetch` + branch off the published default** (`origin/master`) so the isolated lane starts clean and its PR diff is minimal. Don't branch off another lane's unpushed WIP.
+- **Never a repo-wide `git add -A` while another lane may be dirty.** Stage explicit paths. `ai-push`'s broad allowlist stage is exactly the foot-gun — in a shared tree it bundles a neighbor's files.
+- **Land via PR, not direct push** (operator default on auto-deploy repos). One isolated branch → one PR.
+- **Cleanup:** `git worktree remove` (or `git worktree prune`) once merged, so stale checkouts don't accumulate.
+
+## Recovery — if the collision already happened
+1. Don't add/commit/reset/push into the shared tree while the other lane is live; you'll just race it again.
+2. Back up your created files outside git first (e.g. `cp` to `/tmp`), so a neighbor's `reset --hard` can't take them.
+3. Forensics: `git reflog`, `git worktree list`, `git branch --contains <sha>`, `git show --stat <sha>` to find where your hunks landed.
+4. Create your own worktree off `origin/<default>`, re-apply your changes there cleanly, commit, push, PR. Leave the other lane's tree untouched.
+
+## Related
+- CLAUDE.md `Core Principles` #1 `Arm Isolation` (#7 `Session/Instance Isolation` points here) — same rule, space vs time.
+- `arm-onboarding` — isolation across *clients* (per-repo arms); this is isolation across *concurrent runs*.
+- The Agent tool `isolation: worktree` mode — the in-harness operationalization.
+- Memory: the 2026-06-02 lived collision lesson.


### PR DESCRIPTION
Two generic brain additions. Landed from an **isolated git worktree** (`auto/session-isolation`), dogfooding the principle this PR records, after two concurrent sessions collided in the shared `~/.claude` tree.

## 1. Session / Instance Isolation (root-cause fix)
- **CLAUDE.md Core Principles #7** — the same arm can run in two dimensions at once, but each live session needs its own git worktree + session id. Never two live sessions on one shared working tree. Arm Isolation applied to time.
- **`skills/session-isolation/SKILL.md`** — the lived collision mode (a broad `git add` in one lane swallows the other lane's uncommitted files, then a `reset`+recommit shreds the changeset), the worktree protocol, recovery steps, and Anthropic's official `claude --worktree` guidance.

## 2. Human Cadence (anti-AI-tells)
- **CLAUDE.md §Communication (always-on)** + **`skills/human-cadence/SKILL.md`** — 10 no-rules so every output reads human and costs fewer tokens. Inverted from a humanizer prompt (soyfelixgo TikTok). Wired into **4D Disclose** as a delivery check.
- Reconciled with the existing structured-output rule: tables/code stay for technical answers; rule 8 (no bullets) governs conversational prose only.

## Verification
- `check-generic`: clean (no client tokens).
- Pre-push leak guard: passed.
- Anchors verified against clean `origin/master` base before editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)