### PR TITLE
fix(brain): qa-merge-gate fires only on publish points, not local merges

### DIFF
--- a/scripts/qa-merge-gate.py
+++ b/scripts/qa-merge-gate.py
@@ -7,8 +7,8 @@ env cannot pass to the harness-run hook) is the actual security boundary — she
 indirection (e.g. ``$(echo gh) pr merge``) can evade string-matching and that is
 accepted residual risk by design.
 
-When a Bash command is detected as a merge action (gh pr merge, git merge into
-main/master, or git push directly to main/master), this hook BLOCKS execution
+When a Bash command is detected as a merge action (gh pr merge or git push
+directly to main/master), this hook BLOCKS execution
 unless an operator approval is present via one of three channels:
 
   1. OCTO_MERGE_APPROVE=<pr_number>  — env var, PR-scoped, AGENT-PROOF (preferred).
@@ -43,7 +43,6 @@ from pathlib import Path
 # Order matters: most-specific first to reduce false-negative risk.
 _MERGE_PATTERNS = (
     re.compile(r"\bgh\s+pr\s+merge\b"),
-    re.compile(r"\bgit\s+merge\b.*\b(main|master)\b"),
     re.compile(r"\bgit\b[^|&;]*?\bpush\b[^|&;]*?(?:^|[\s:/'\"+])(?:HEAD:)?\+?(main|master)(?=$|\s|:|['\"])"),
 )
 


### PR DESCRIPTION
## What

Fixes a false positive in `qa-merge-gate`: a **local** fast-forward update from origin (catching the local branch up) published nothing yet was blocked. A local merge is harmless until pushed — and the push is already gated.

## Change (2 lines)

Removed the generic local-merge detection pattern. The gate now fires **only on the true publish-to-main points**:
1. A GitHub PR merge (`gh pr` + merge + number).
2. A direct push to the remote default branch.

## QA (independent harness, 16/16)

- Publish points still **fail-closed** (exit 2 without approval).
- Local merges / fast-forward / pull now exit 0 (the fix).
- Branch names containing `main`/`master` (e.g. `main-feature`, `feature/main-redesign`, `my-main`) still allowed.
- All three approval channels intact (PR-scoped env / file / legacy).

No publish hole opened — the two publish patterns are untouched; only the local-merge pattern was removed.

## Known follow-up (not in this PR)

The gate matches on the command **string**, so a benign command that merely *mentions* a publish pattern inside a quoted argument (a commit message, an `echo`) still trips it. Anchoring detection to a command boundary (start / after `;`/`&&`/`|`) would remove that class too — separate refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
