### PR TITLE
fix(brain): anchor merge-gate detection to a command boundary (no false-trip on quoted mentions)

### DIFF
--- a/scripts/qa-merge-gate.py
+++ b/scripts/qa-merge-gate.py
@@ -5,7 +5,11 @@ NOTE on security boundary: the regex command-matching below is a speed-bump for
 honest mistakes; the AGENT-PROOF env channel (OCTO_MERGE_APPROVE, which an inline
 env cannot pass to the harness-run hook) is the actual security boundary — shell
 indirection (e.g. ``$(echo gh) pr merge``) can evade string-matching and that is
-accepted residual risk by design.
+accepted residual risk by design.  Detection is now command-boundary-anchored:
+the full command string is split on UNQUOTED shell separators (; && || | newline)
+before pattern matching, so a publish pattern that appears only inside a quoted
+argument (``git commit -m "gh pr merge 96"``) does NOT trigger the gate.
+Shell indirection (``bash -c "..."``, ``$(...)``) remains accepted residual risk.
 
 When a Bash command is detected as a merge action (gh pr merge or git push
 directly to main/master), this hook BLOCKS execution
@@ -39,33 +43,144 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-# Patterns that positively identify a merge / direct-push action.
-# Order matters: most-specific first to reduce false-negative risk.
-_MERGE_PATTERNS = (
-    re.compile(r"\bgh\s+pr\s+merge\b"),
-    re.compile(r"\bgit\b[^|&;]*?\bpush\b[^|&;]*?(?:^|[\s:/'\"+])(?:HEAD:)?\+?(main|master)(?=$|\s|:|['\"])"),
+# ---------------------------------------------------------------------------
+# Anchored publish patterns — applied to the START of each sub-command token.
+# Using ^\s* because after splitting we still want to tolerate leading spaces.
+# ---------------------------------------------------------------------------
+
+# gh pr merge <N> [flags]  — anchored at sub-command start
+_PAT_GH_MERGE = re.compile(r"^\s*gh\s+pr\s+merge\b")
+
+# git [-C <path>] [-c key=val] push [opts] <remote> <ref>
+# Catches: git push origin main  /  git push origin "main"  /
+#          git push origin +main  /  git push -u origin master  /
+#          git -C /x push origin main  /  git push origin HEAD:main
+# Does NOT catch: main-feature / feature/main-redesign / my-main /
+#                 git push-mirror / git push-all (hyphenated, not a subcommand) /
+#                 "push" appearing only inside a quoted arg of a different subcommand.
+# FIX 1+2: push must be the git SUBCOMMAND — only the standard global flags
+# -C <path> and -c <key=val> are allowed between `git` and `push`.
+# `push(?=\s)` requires whitespace after push, so `push-mirror` is rejected.
+_PAT_GIT_PUSH = re.compile(
+    r"^\s*git\s+"
+    r"(?:-C\s+\S+\s+|-c\s+\S+\s+)*"
+    r"push(?=\s)"
+    r"[^|&;]*?"
+    r'(?:[\s:/\'"+])(?:HEAD:)?\+?(main|master)(?=$|\s|:|[\'"])'
 )
 
 # Extracts the PR number from `gh pr merge <N> [flags]`
-# (?=\s|$) anchors the digit capture to a whole token — prevents leading-digit
-# extraction from non-numeric selectors like `96x`, `96.5`, `96-evil`.
-_PR_NUM_RE = re.compile(r"\bgh\s+pr\s+merge\s+(\d+)(?=\s|$)")
+# (?=\s|$) anchors the digit capture to a whole token.
+_PR_NUM_RE = re.compile(r"^\s*gh\s+pr\s+merge\s+(\d+)(?=\s|$)")
 
 # Path to the per-PR approvals file
 _APPROVALS_FILE = Path.home() / ".claude" / "connectome" / "merge-approvals.json"
 
 
-def _is_merge_command(cmd: str) -> bool:
-    return any(p.search(cmd) for p in _MERGE_PATTERNS)
+# FIX 5: join backslash-newline continuations before any splitting so that
+# `gh pr \<newline>merge 96` is treated as a single token.
+def _join_continuations(cmd: str) -> str:
+    """Replace backslash-newline pairs with a single space."""
+    return re.sub(r"\\\n", " ", cmd)
 
 
-def _extract_pr_id(cmd: str) -> str:
-    """Return the PR number string, or branch literal 'main'/'master'."""
-    m = _PR_NUM_RE.search(cmd)
+# FIX 3+4: strip leading env-assignments, redirections, and grouping chars
+# from an already-split sub-command before pattern matching.
+# Applied PER sub-command so it never crosses a real separator boundary.
+# Order: grouping brackets first, then env-assignments, then redirections.
+_STRIP_PREFIX_RE = re.compile(
+    r"^(?:[({]\s*)*"               # FIX 4: unquoted ( or { grouping openers
+    r"(?:[A-Za-z_]\w*=\S*\s+)*"   # FIX 3: env assignments  VAR=val
+    r"(?:\d*[<>]+\S*\s+)*"        # FIX 3: redirections      >/dev/null  2>&1
+)
+
+
+def _strip_leading(s: str) -> str:
+    """Return *s* with leading env-vars, redirections, and grouping chars removed."""
+    return _STRIP_PREFIX_RE.sub("", s, count=1)
+
+
+def _split_subcmds(cmd: str) -> list[str]:
+    """Split *cmd* on unquoted shell separators (;  &&  ||  |  newline).
+
+    Tracks single-quote and double-quote state so that separators inside
+    quoted strings are treated as literal characters and do NOT cause a split.
+    Returns a list of raw sub-command strings (may be empty after stripping).
+    """
+    parts: list[str] = []
+    buf: list[str] = []
+    in_single = False
+    in_double = False
+    i = 0
+    n = len(cmd)
+    while i < n:
+        ch = cmd[i]
+        if ch == "'" and not in_double:
+            in_single = not in_single
+            buf.append(ch)
+            i += 1
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+            buf.append(ch)
+            i += 1
+        elif not in_single and not in_double:
+            # Check for two-char separators first
+            two = cmd[i:i + 2]
+            if two in ("&&", "||"):
+                parts.append("".join(buf))
+                buf = []
+                i += 2
+            elif ch in (";", "|", "\n"):
+                parts.append("".join(buf))
+                buf = []
+                i += 1
+            else:
+                buf.append(ch)
+                i += 1
+        else:
+            buf.append(ch)
+            i += 1
+    parts.append("".join(buf))
+    return parts
+
+
+def _find_publish_subcmd(cmd: str) -> str | None:
+    """Return the first sub-command that matches a publish pattern, or None.
+
+    Processing order (FIX 5 → split → FIX 3+4 → pattern):
+      1. Join backslash-newline continuations (FIX 5) so multi-line commands
+         are not split at the wrong boundary.
+      2. Split on unquoted shell separators (; && || | newline).
+      3. Per sub-command, strip leading env-assignments, redirections, and
+         grouping chars (FIX 3+4) — AFTER splitting so we never cross a real
+         separator.
+      4. Match patterns anchored at the start of the stripped sub-command.
+
+    A publish keyword appearing only inside a quoted argument is NOT matched
+    because the split step keeps quoted content intact.
+    """
+    cmd = _join_continuations(cmd)
+    for raw_sub in _split_subcmds(cmd):
+        sub = _strip_leading(raw_sub)
+        if _PAT_GH_MERGE.match(sub):
+            return raw_sub
+        if _PAT_GIT_PUSH.match(sub):
+            return raw_sub
+    return None
+
+
+def _extract_pr_id(matched_sub: str) -> str:
+    """Return the PR number string, or branch literal 'main'/'master'.
+
+    *matched_sub* is the raw sub-command (pre-strip) returned by
+    _find_publish_subcmd.  Strip leading prefixes before matching so that
+    `FOO=1 git push origin main` still yields 'main'.
+    """
+    sub = _strip_leading(matched_sub)
+    m = _PR_NUM_RE.match(sub)
     if m:
         return m.group(1)
-    # Fall back: detect a direct push target branch (same hardened pattern as _MERGE_PATTERNS)
-    push_m = re.search(r"\bgit\b[^|&;]*?\bpush\b[^|&;]*?(?:^|[\s:/'\"+])(?:HEAD:)?\+?(main|master)(?=$|\s|:|['\"])", cmd)
+    push_m = _PAT_GIT_PUSH.match(sub)
     if push_m:
         return push_m.group(1)
     return "unknown"
@@ -119,12 +234,13 @@ def main() -> int:
     except Exception:
         return 0
 
-    # Fast path: not a merge command → exit 0 silently.
-    if not _is_merge_command(cmd):
+    # Fast path: no sub-command starts with a publish pattern → exit 0 silently.
+    matched_sub = _find_publish_subcmd(cmd)
+    if matched_sub is None:
         return 0
 
-    # Positively identified as a merge action — extract target id.
-    pr_id = _extract_pr_id(cmd)
+    # Positively identified as a merge action — extract target id from the matched sub-command.
+    pr_id = _extract_pr_id(matched_sub)
 
     # ── Channel 1: env, PR-scoped, agent-proof (preferred) ───────────────────
     env_approve = os.environ.get("OCTO_MERGE_APPROVE", "").strip()


### PR DESCRIPTION
## What

Second-class fix for `qa-merge-gate` false-positives: the gate matched its patterns **anywhere** in the command string, so a benign command that merely *mentioned* a publish pattern inside a quoted argument tripped it (a commit message, an `echo`, a test loop — all hit this during the session).

## Change

Detection is now **anchored to a command boundary**:
- A quote-aware splitter breaks the command on **unquoted** `;` `&&` `||` `|` newline (and grouping `(){}`), never inside quotes.
- Patterns match **anchored at each sub-command start** (`^\s*…`), after stripping leading env-assignments / redirections / grouping chars.
- Backslash-newline continuations are joined before splitting.

So `git commit -m "ship: <publish cmd>"` no longer trips, but a real invocation at a command boundary still does.

## QA (independent Opus reviewer + harness, 27/27)

The reviewer found **5 defects** in the first attempt (2 regressed the goal — push regex traversed quoted text + `push-mirror` matched; 3 low-severity evasions — env-prefix, grouping, line-continuation). All fixed. Final matrix:
- Mentions in quoted args / `push-mirror` / branch names with `main` → exit 0.
- Real publishes incl. `FOO=1 …`, `>/dev/null …`, `( … )`, `{ … ; }`, `\`-continuation, chained-after-`&&`/`;` → exit 2.
- PR-scoped approval exact-match (96 allow, 95 block) + file + legacy channels intact; fail-open on malformed JSON.

Residual (documented in the script): `bash -c "…"` / `$(…)` shell indirection is accepted residual risk — the agent-proof `OCTO_MERGE_APPROVE` env channel is the real security boundary.

## Note

Stacked on #98 (`auto/gate-ff-fix`); base is that branch for a clean diff. Merge #98 first, then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
