### PR TITLE
fix(brain): make runners-tracked check Windows-aware (.cmd/.ps1 thunks)

### DIFF
--- a/scripts/brain_doctor.py
+++ b/scripts/brain_doctor.py
@@ -195,7 +195,18 @@ def check_runners_tracked(fix: bool) -> Result:
     key = "runners-tracked"
     bin_dir = HOME / ".local" / "bin"
     names = ["ai-pull", "ai-push", "sync-ai-docs"]
-    missing = [n for n in names if not (bin_dir / n).exists()]
+    # On Windows the runners are .cmd/.ps1 thunks, not extensionless POSIX files.
+    exts = ["", ".cmd", ".ps1", ".bat"] if os.name == "nt" else [""]
+
+    def resolve_runner(n):
+        for ext in exts:
+            cand = bin_dir / (n + ext)
+            if cand.exists():
+                return cand
+        return None
+
+    resolved = {n: resolve_runner(n) for n in names}
+    missing = [n for n, p in resolved.items() if p is None]
     if missing:
         return Result(key, FAIL, f"missing runner(s): {', '.join(missing)}",
                       "reinstall runners into ~/.local/bin/ (see arm-onboarding skill)")
@@ -203,7 +214,7 @@ def check_runners_tracked(fix: bool) -> Result:
     untracked = []
     scripts_dir = (CLAUDE_DIR / "scripts").resolve()
     for n in names:
-        p = bin_dir / n
+        p = resolved[n]
         try:
             real = p.resolve()
         except Exception:


### PR DESCRIPTION
## What
`brain_doctor.py` `check_runners_tracked()` looked for **extensionless** runner names (`ai-pull`, `ai-push`, `sync-ai-docs`) in `~/.local/bin`. On Windows `install-runners.py` writes `.cmd`/`.ps1` thunks, so the check always FAILed even with valid, tracked runners.

## Fix
Resolve each runner to the first existing variant — `['', '.cmd', '.ps1', '.bat']` on `os.name=='nt'`, extensionless on POSIX — then run the existing thunk-body verification (`octorato-thunk` / `scripts/ai_sync.py`) against the resolved file. POSIX path unchanged; Windows-only additive.

## Verify
`brain_doctor.py` on Windows: `runners-tracked` PASS — 15 pass / 2 warn / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)