### PR TITLE
feat(brain): octo-dim start launcher + concurrent-sessions guide

### DIFF
--- a/docs/concurrent-sessions.md
+++ b/docs/concurrent-sessions.md
@@ -1,0 +1,107 @@
+# Concurrent Sessions — Isolation Guide
+
+## The problem
+
+`~/.claude/` is a git working tree. When two Claude Code sessions run in the
+same directory they share one index, one HEAD, and one set of uncommitted files.
+This causes real data-churn collisions:
+
+1. Session A creates files (new skill, edits to `CLAUDE.md`) but hasn't committed
+   yet — the files sit uncommitted in the shared tree.
+2. Session B runs its own commit flow with a broad `git add`. That stage captures
+   **everything** dirty, including A's files.
+3. B commits. A's work is now inside B's commit under B's unrelated message.
+4. B resets and re-commits. A's changeset is now fragmented across the index,
+   on a branch A never chose, none of it pushed.
+
+Nothing is permanently lost, but the changeset is shredded and the shared HEAD is
+unstable while B iterates. The root cause is no isolation boundary plus broad
+staging plus two live writers on one index.
+
+The awareness hook in `scripts/dimension-awareness-hook.py` **warns** when other
+live sessions share the main tree, but it is fail-open — it never blocks a write.
+**Warning alone is not isolation.** True isolation requires each session to run
+in its own git worktree from the moment it launches.
+
+## The fix: launch every session in its own dimension
+
+Before opening a second (or third) terminal with `claude`, provision a worktree:
+
+```bash
+python3 ~/.claude/scripts/octo-dim.py start [--session-id <name>]
+```
+
+The command:
+- resolves a session id (`CLAUDE_SESSION_ID` env → `--session-id` arg → `hostname-pid`)
+- idempotently creates a git worktree at `~/.octorato/dim/<first-8-chars>/` on branch `dim/<first-8-chars>`
+- registers the session in the blackboard (`connectome/sessions.json`)
+- warns if other live sessions still share the main tree
+- prints the exact command to start the session in that directory
+
+Then follow the printed instruction:
+
+```bash
+cd ~/.octorato/dim/<short-id> && claude
+```
+
+**The agent cannot re-root itself.** Hooks are subprocesses; `chdir` inside a
+subprocess does not affect the parent process's working directory. That is why
+the operator must `cd` and launch `claude` from the worktree directory — before
+the session starts, not after.
+
+## Workflow summary
+
+```
+# Terminal 1 (already running — this is the main tree)
+# Nothing changes here.
+
+# Terminal 2 — before opening claude:
+python3 ~/.claude/scripts/octo-dim.py start --session-id feat-x
+#  → prints: cd ~/.octorato/dim/feat-x00 && claude
+cd ~/.octorato/dim/feat-x00 && claude
+
+# Work in T2 independently. Commit by explicit pathspec only (see rules below).
+# When done, push the dim branch and open a PR back to master as usual.
+
+# Cleanup after merge:
+git -C ~/.claude worktree remove ~/.octorato/dim/feat-x00
+git -C ~/.claude branch -d dim/feat-x00
+python3 ~/.claude/scripts/octo-dim.py unregister --session-id feat-x
+```
+
+## Hard rules until everyone is isolated
+
+Even with the worktree in place, follow these rules to avoid index collisions
+with sessions that haven't isolated yet:
+
+| Rule | Reason |
+|------|--------|
+| **Commit only by explicit pathspec** — never `git add -A` or `git add .` | A broad add in one session swallows the other session's uncommitted files |
+| **`git pull --ff-only`** to catch up with master | Merge commits on a shared dim branch create noise |
+| **Treat unexpected files in `git status` as another dimension's work** — don't stage them | They belong to a neighbor session's uncommitted changeset |
+| **Land via PR, not direct push to master** | Keeps the main branch stable while dimensions iterate |
+| **`git worktree remove` after merge** | Stale checkouts accumulate and confuse `git worktree list` |
+
+## Reconciling back to master
+
+Work in a dimension is a normal feature branch. When ready:
+
+```bash
+# Inside the dimension worktree:
+git push -u origin dim/<short-id>
+gh pr create --base master --title "..."
+# Operator approves; auto-merge or squash as usual.
+```
+
+The awareness hook warns about the other session's dimension — that is expected
+and correct. The warnings stop once all sessions have isolated worktrees.
+
+## Related
+
+- `skills/session-isolation/SKILL.md` — the full collision narrative, octopus
+  morphology framing, and recovery steps if a collision already happened.
+- `scripts/octo-dim.py` — the dimension registry CLI (`start`, `list`, `prune`,
+  `unregister`, `worktree-init`, `approve-merge`, …).
+- `scripts/dimension-awareness-hook.py` — the warn-only hook that fires on every
+  write when other live sessions share the main tree.
+- Anthropic native: `claude --worktree <name>` (same pattern, built into the CLI).

--- a/scripts/octo-dim.py
+++ b/scripts/octo-dim.py
@@ -465,37 +465,130 @@ def cmd_revoke_merge(args) -> int:
     return 0
 
 
-def cmd_worktree_init(args) -> int:
-    """Idempotently create a git worktree for this dimension."""
-    sid = _resolve_session(args)
+def _worktree_init_core(sid: str) -> tuple[Path, str, bool]:
+    """Shared helper: idempotently create/attach a worktree for *sid*.
+
+    Returns (target_path, branch_name, already_existed).
+    Never raises — caller handles the result.
+    """
     short = sid[:8]
     target = DIM_ROOT / short
     branch = f"dim/{short}"
 
-    # Only short-circuit if target is actually a git worktree (has a .git entry)
+    # Already a valid git worktree checkout — reuse it
     if target.exists() and (target / ".git").exists():
-        print(str(target))
-        return 0
+        return target, branch, True
 
     DIM_ROOT.mkdir(parents=True, exist_ok=True)
 
-    # Try with -b (new branch)
+    # Try with -b (new branch); fall back to attaching an existing branch
     result = subprocess.run(
         ["git", "-C", str(BRAIN), "worktree", "add", str(target), "-b", branch],
         capture_output=True, text=True,
     )
     if result.returncode != 0:
-        # Branch may already exist; try attaching without -b
         result2 = subprocess.run(
             ["git", "-C", str(BRAIN), "worktree", "add", str(target), branch],
             capture_output=True, text=True,
         )
         if result2.returncode != 0:
             msg = result2.stderr.strip() or result.stderr.strip()
-            print(f"worktree-init: could not create worktree: {msg}")
-            return 0  # never hard-fail
+            raise RuntimeError(f"could not create worktree: {msg}")
 
-    print(str(target))
+    return target, branch, False
+
+
+def cmd_worktree_init(args) -> int:
+    """Idempotently create a git worktree for this dimension."""
+    sid = _resolve_session(args)
+    try:
+        target, _branch, _existed = _worktree_init_core(sid)
+        print(str(target))
+    except RuntimeError as exc:
+        print(f"worktree-init: {exc}")
+    return 0  # never hard-fail
+
+
+def cmd_start(args) -> int:
+    """Launch-time helper: provision a dimension and tell the operator how to enter it.
+
+    Workflow:
+      1. Resolve session id.
+      2. Idempotently create/attach the worktree via _worktree_init_core.
+      3. Register the session in the blackboard registry.
+      4. Warn if OTHER live sessions still share the main tree (no true isolation yet).
+      5. Print a copy-pasteable `cd ... && claude` instruction.
+
+    NOTE: a hook running inside an active agent CANNOT re-root that agent's process.
+    Hooks are subprocesses; chdir inside a subprocess does not affect the parent.
+    True isolation requires the OPERATOR to launch `claude` from inside the new
+    worktree directory BEFORE the session starts — that is why this subcommand exists.
+    """
+    try:
+        sid = _resolve_session(args)
+        short = sid[:8]
+
+        # Step 1: provision worktree
+        try:
+            target, branch, existed = _worktree_init_core(sid)
+        except RuntimeError as exc:
+            print(f"start: worktree error (non-fatal): {exc}", file=sys.stderr)
+            # Still register so the heartbeat can track the session
+            target = DIM_ROOT / short
+            branch = f"dim/{short}"
+            existed = False
+
+        # Step 2: register / upsert in blackboard
+        now = _now_iso()
+        data = _load()
+        existing = data["sessions"].get(sid, {})
+        entry = {
+            "session_id": sid,
+            "branch": branch,
+            "worktree": str(target),
+            "pid": os.getpid(),
+            "host": socket.gethostname(),
+            "started": existing.get("started", now),
+            "heartbeat": now,
+            "lanes": existing.get("lanes", []),
+        }
+        data["sessions"][sid] = entry
+        _save(data)
+
+        # Step 3: check for other live sessions on the MAIN tree (no worktree / empty worktree)
+        ttl = 900
+        warn_sessions = []
+        for other_sid, other_entry in data["sessions"].items():
+            if other_sid == sid:
+                continue
+            if not _is_live(other_entry, ttl):
+                continue
+            other_wt = (other_entry.get("worktree") or "").strip()
+            # "sharing main tree" = worktree is empty OR equals the BRAIN path
+            if not other_wt or Path(other_wt) == BRAIN:
+                warn_sessions.append(other_sid)
+
+        # Step 4: emit output
+        status = "already exists" if existed else "created"
+        print(f"dimension ready ({status}): {target}  (branch {branch})")
+        print()
+        print("Start your session there (the agent cannot re-root itself")
+        print("— the operator must launch claude from this directory):")
+        print()
+        print(f"    cd {target} && claude")
+        print()
+
+        if warn_sessions:
+            names = ", ".join(w[:12] for w in warn_sessions)
+            print(
+                f"WARNING: {len(warn_sessions)} other live session(s) still share the main "
+                f"working tree [{names}]. They are NOT isolated. Ask them to run `octo-dim start` too."
+            )
+
+    except Exception as exc:
+        # Top-level guard — start must never crash the operator's shell
+        print(f"start warning (non-fatal): {exc}", file=sys.stderr)
+
     return 0
 
 
@@ -531,6 +624,16 @@ def build_parser() -> argparse.ArgumentParser:
     wi.add_argument("--session-id", dest="session_id", default="",
                     help="Use this session id instead of auto-resolved")
 
+    st = sub.add_parser(
+        "start",
+        help="Provision a dimension worktree and print the cd+claude launch command",
+    )
+    st.add_argument(
+        "--session-id", dest="session_id", default="",
+        help="Pin a session id (default: CLAUDE_SESSION_ID env → hostname-pid)",
+    )
+    del st  # suppress unused-variable lint
+
     am = sub.add_parser("approve-merge", help="Grant operator approval for a PR/branch merge")
     am.add_argument("pr_or_branch", help="PR number or branch name (e.g. 96 or main)")
     am.add_argument("--by", default="", help="Approver name (default: $USER or 'operator')")
@@ -553,6 +656,7 @@ HANDLERS = {
     "claim": cmd_claim,
     "unregister": cmd_unregister,
     "worktree-init": cmd_worktree_init,
+    "start": cmd_start,
     "approve-merge": cmd_approve_merge,
     "approvals": cmd_approvals,
     "revoke-merge": cmd_revoke_merge,


### PR DESCRIPTION
Closes the **data-churn** the operator flagged (parallel sessions sharing one ~/.claude tree).

**Honest constraint:** a hook cannot re-root the parent agent process — so isolation is **launch-time**, not a magic hook.

- **octo-dim start** — idempotently forks `~/.octorato/dim/<id>` (branch `dim/<id>`), registers in the blackboard, and prints the `cd … && claude` next step the operator runs to launch the session isolated.
- **docs/concurrent-sessions.md** — operator guide: the collision mechanism, the start→cd→claude workflow, hard rules until isolated (pathspec-only commits, never `git add -A`, `pull --ff-only`).

Self-tested: worktree round-trip clean, ast OK. No hooks/settings activation (sessions live).

Separately (not in this PR): 3 learned-skill drafts in `skills/learned/` (gitignored) await operator promotion — agent-proof-approval-gate · command-boundary-hook-matching · stacked-pr-squash-delete-gotcha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)