### PR TITLE
feat(brain): lane enforcement — first-writer claims, agent-proof deny on cross-dimension writes

### DIFF
--- a/scripts/dimension-awareness-hook.py
+++ b/scripts/dimension-awareness-hook.py
@@ -1,46 +1,99 @@
 #!/usr/bin/env python3
-"""dimension-awareness-hook.py — PreToolUse hook for 4D session dimension awareness.
+"""dimension-awareness-hook.py — PreToolUse hook for 4D session dimension awareness
+AND lane enforcement.
 
-Warns when multiple Claude Code sessions (dimensions) share the same working
-tree so each session avoids stomping on the other's in-progress changes.
+Two jobs, in order of force:
+  1. ENFORCE lanes (Write/Edit only): if the target file is claimed by ANOTHER
+     live session, DENY the tool call. Two dimensions must never write one file.
+  2. AUTO-CLAIM (Write/Edit only): if the target file is free, claim it for this
+     session — the first writer owns the lane, involuntarily. This is what turns
+     the lane system from etiquette into a reflex (the cerebellum principle:
+     enforcement must fire without anyone choosing to run it).
+  3. WARN (all matched tools): when other live dimensions share the tree, inject
+     the shared-tree warning as before.
+
+Lanes die with their session: a session that stops heartbeating past the TTL is
+no longer live, so its lanes stop blocking (and `octo-dim prune` removes them).
+Cooperative handoff: `octo-dim release <path>` / `release <path> --from-any`.
+
+Operator override: OCTO_LANE_OVERRIDE=1 in the HARNESS environment bypasses the
+deny. An agent cannot set the harness env for Write/Edit tool calls (an inline
+`FOO=1` only scopes a Bash command), so the override is operator-only — the same
+agent-proof property as OCTO_MERGE_APPROVE in the merge gate.
 
 Design principles (mirroring grafo-gate.py):
-  - FAIL-OPEN always. Any exception → exit 0. A broken hook must never brick a session.
+  - FAIL-OPEN on infrastructure errors (bad JSON, unreadable registry, lock
+    failure) — a broken hook must never brick a session.
+  - FAIL-CLOSED only on a genuine, attributable lane conflict.
   - Fast: no subprocess calls, only JSON reads + datetime math.
-  - No denied commands. This hook ONLY warns; it never blocks.
-  - Output format: {"hookSpecificOutput": {"hookEventName": "PreToolUse",
-                    "additionalContext": "..."}} — same as grafo-gate.py.
+  - Registry writes use lock + re-read-merge (same contract as octo-dim.py's
+    _save) so concurrent heartbeats/claims from parallel sessions never lose
+    each other's updates. The lock/merge block is intentionally duplicated from
+    octo-dim.py — hooks stay import-free and self-contained.
 
-Stdin: {"tool_name": str, "tool_input": {...}}
-Stdout: JSON additionalContext if other live sessions exist, else nothing.
-Exit: always 0.
+Stdin:  {"session_id": str, "tool_name": str, "tool_input": {...}}
+Stdout: hookSpecificOutput JSON — additionalContext (warn) or
+        permissionDecision: "deny" (lane conflict).
+Exit:   always 0 (the deny travels in the JSON, not the exit code).
 
-Concurrency: reads registry with best-effort; stale/corrupted registry → no-op warn.
+Known limitation (shared-tree attribution): a file already git-modified by a
+session that never wrote through this hook has no lane — the first post-
+enforcement writer claims it. Attribution of pre-existing uncommitted edits is
+impossible in a shared tree; full isolation still means one worktree per
+session (`octo-dim worktree-init`).
+
+Security note — session identity resolution: env CLAUDE_SESSION_ID wins over
+the stdin payload field. The harness sets the env; an agent cannot set harness
+env for Write/Edit calls (inline `FOO=1` scopes only Bash), so session_id in
+the payload is treated as an untrusted hint. This closes the impersonation
+bypass: an agent writing session_id=<other> in stdin cannot masquerade as that
+session to skip a lane conflict.
 """
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import socket
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
-REGISTRY = Path.home() / ".claude" / "connectome" / "sessions.json"
+try:
+    import fcntl as _fcntl
+    _HAS_FCNTL = True
+except ImportError:
+    _HAS_FCNTL = False
+
+REGISTRY_DIR = Path.home() / ".claude" / "connectome"
+REGISTRY = REGISTRY_DIR / "sessions.json"
 DEFAULT_TTL = 900  # seconds
+_FUTURE_SKEW = 120  # seconds; heartbeat this far ahead of now is considered NOT live
+
+# Tools whose target path participates in lane enforcement.
+_LANE_TOOLS = ("Write", "Edit", "NotebookEdit")
 
 
 # ── session id (same resolution order as octo-dim.py) ───────────────────────
 
 def _resolve_session(payload: dict | None = None) -> str:
-    """Priority: stdin payload session_id → env CLAUDE_SESSION_ID → hostname-pid."""
+    """Priority: env CLAUDE_SESSION_ID → stdin payload session_id → hostname-pid.
+
+    env wins over payload because CLAUDE_SESSION_ID is set by the harness (the
+    operator-controlled process that spawns Claude Code). An agent cannot set the
+    harness env for Write/Edit tool calls — an inline `CLAUDE_SESSION_ID=X`
+    only scopes a Bash command, not the hook execution environment. This makes
+    session identity agent-proof: a rogue payload field cannot impersonate another
+    session and bypass the lane conflict check.
+    """
+    from_env = os.environ.get("CLAUDE_SESSION_ID", "")
+    if from_env:
+        return from_env
     if payload:
         from_payload = payload.get("session_id", "")
         if from_payload:
             return str(from_payload)
-    from_env = os.environ.get("CLAUDE_SESSION_ID", "")
-    if from_env:
-        return from_env
     return f"{socket.gethostname()}-{os.getpid()}"
 
 
@@ -61,24 +114,60 @@ def _load_registry() -> dict:
     return {"sessions": {}}
 
 
-def _save_registry(data: dict) -> None:
-    """Atomic write. Race window: last-writer-wins (same note as octo-dim.py)."""
-    import tempfile
-    registry_dir = REGISTRY.parent
-    registry_dir.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(dir=registry_dir, prefix=".sessions.tmp.")
+@contextlib.contextmanager
+def _registry_lock():
+    """Exclusive advisory lock on sessions.json.lock (POSIX only); no-op fallback."""
+    lock_path = REGISTRY_DIR / "sessions.json.lock"
+    if not _HAS_FCNTL:
+        yield
+        return
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            json.dump(data, fh, indent=2)
-        os.replace(tmp, REGISTRY)
-    except Exception:
+        REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+        lf = open(lock_path, "w")
         try:
-            os.unlink(tmp)
-        except OSError:
-            pass
+            _fcntl.flock(lf.fileno(), _fcntl.LOCK_EX)
+            yield
+        finally:
+            _fcntl.flock(lf.fileno(), _fcntl.LOCK_UN)
+            lf.close()
+    except Exception:
+        yield  # fail-open
 
 
-_FUTURE_SKEW = 120  # seconds; heartbeat this far ahead of now is considered NOT live
+def _upsert_session(sid: str, mutate) -> None:
+    """Lock → re-read → mutate(entry) → atomic write. Merge-safe upsert of ONE
+    session entry; concurrent writers' entries survive (same contract as
+    octo-dim.py's _save). `mutate` receives the current entry dict and edits it
+    in place. Non-fatal on any error (fail-open)."""
+    try:
+        with _registry_lock():
+            data = _load_registry()
+            now = _now_iso()
+            entry = data["sessions"].get(sid, {
+                "session_id": sid,
+                "branch": "",
+                "worktree": "",
+                "pid": os.getpid(),
+                "host": socket.gethostname(),
+                "started": now,
+                "lanes": [],
+            })
+            entry["heartbeat"] = now
+            mutate(entry)
+            data["sessions"][sid] = entry
+            REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+            fd, tmp = tempfile.mkstemp(dir=REGISTRY_DIR, prefix=".sessions.tmp.")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    json.dump(data, fh, indent=2)
+                os.replace(tmp, REGISTRY)
+            except Exception:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+    except Exception:
+        pass  # fail-open: registry write failure must never block the caller
 
 
 def _is_live(entry: dict, ttl: int = DEFAULT_TTL) -> bool:
@@ -91,7 +180,6 @@ def _is_live(entry: dict, ttl: int = DEFAULT_TTL) -> bool:
             hb_dt = hb_dt.replace(tzinfo=timezone.utc)
         now = datetime.now(timezone.utc)
         delta = (now - hb_dt).total_seconds()
-        # Heartbeat dated far in the future → clock skew / corrupt entry → not live
         if delta < -_FUTURE_SKEW:
             return False
         return delta <= ttl
@@ -99,33 +187,26 @@ def _is_live(entry: dict, ttl: int = DEFAULT_TTL) -> bool:
         return False
 
 
-# ── heartbeat update (best-effort) ───────────────────────────────────────────
+# ── output helpers ───────────────────────────────────────────────────────────
 
-def _update_heartbeat(sid: str) -> None:
-    """Touch this session's heartbeat in the registry. Non-fatal on any error."""
+def _emit(payload: dict) -> None:
     try:
-        now = _now_iso()
-        data = _load_registry()
-        entry = data["sessions"].get(sid, {
-            "session_id": sid,
-            "branch": "",
-            "worktree": "",
-            "pid": os.getpid(),
-            "host": socket.gethostname(),
-            "started": now,
-            "lanes": [],
-        })
-        entry["heartbeat"] = now
-        data["sessions"][sid] = entry
-        _save_registry(data)
+        print(json.dumps({"hookSpecificOutput": payload}))
     except Exception:
-        pass  # fail-open: heartbeat failure must never block the caller
+        pass  # stdout failure → fail-open
+
+
+def _deny(reason: str) -> None:
+    _emit({
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason,
+    })
 
 
 # ── main ─────────────────────────────────────────────────────────────────────
 
 def main() -> int:
-    # Parse stdin (same defensive pattern as grafo-gate.py)
     try:
         raw = sys.stdin.read()
         data = json.loads(raw)
@@ -134,24 +215,19 @@ def main() -> int:
 
     tool_name = (data.get("tool_name") or "")
     tool_input = data.get("tool_input") or {}
-
-    # Resolve own session id — payload field takes priority over env (FIX 1)
     my_sid = _resolve_session(data)
 
-    # Best-effort heartbeat update (non-blocking)
-    _update_heartbeat(my_sid)
-
-    # Determine target path for lane-conflict check
+    # Target path (lane tools only)
     target_path: str | None = None
-    if tool_name in ("Write", "Edit"):
-        target_path = tool_input.get("file_path") or None
-        if target_path:
+    if tool_name in _LANE_TOOLS:
+        raw_path = tool_input.get("file_path") or tool_input.get("notebook_path") or None
+        if raw_path:
             try:
-                target_path = str(Path(target_path).resolve())
+                target_path = str(Path(raw_path).resolve())
             except Exception:
                 target_path = None
 
-    # Load registry and find other LIVE sessions
+    # Load registry, find other LIVE sessions
     try:
         registry = _load_registry()
         sessions = registry.get("sessions", {})
@@ -164,16 +240,46 @@ def main() -> int:
         if sid != my_sid and _is_live(entry)
     }
 
+    # ── 1. ENFORCE: lane conflict → deny (unless operator override) ──────────
+    if target_path and other_live:
+        for sid, entry in other_live.items():
+            if target_path in (entry.get("lanes") or []):
+                if os.environ.get("OCTO_LANE_OVERRIDE") == "1":
+                    break  # operator override — fall through to warn
+                _deny(
+                    f"⛔ 4D lane: {target_path} is owned by live dimension "
+                    f"{sid[:12]}…. Two dimensions must not write one file. "
+                    f"Options: coordinate via the operator, wait for that "
+                    f"session to finish (TTL {DEFAULT_TTL}s), have the operator "
+                    f"run `octo-dim release {target_path} --from-any` or set "
+                    f"OCTO_LANE_OVERRIDE=1, or fork your own worktree "
+                    f"(`octo-dim worktree-init`)."
+                )
+                # Still record our heartbeat; the denied write claims nothing.
+                _upsert_session(my_sid, lambda e: None)
+                return 0
+
+    # ── 2. AUTO-CLAIM: free path + concurrent dimensions → first writer owns ──
+    if target_path and other_live:
+        def _claim(entry: dict, path=target_path) -> None:
+            lanes = entry.get("lanes") or []
+            if path not in lanes:
+                lanes.append(path)
+            entry["lanes"] = lanes
+        _upsert_session(my_sid, _claim)
+    else:
+        # Sole dimension or non-lane tool: heartbeat only.
+        _upsert_session(my_sid, lambda e: None)
+
     if not other_live:
         return 0  # sole dimension — no warning needed
 
-    # Build warning message
+    # ── 3. WARN: shared-tree awareness (as before) ────────────────────────────
     n = len(other_live)
     ids_branches = ", ".join(
         f"{sid[:12]}…({e.get('branch') or 'no-branch'})"
         for sid, e in other_live.items()
     )
-
     warning = (
         f"⚠ 4D: {n} other live dimension(s) share this working tree "
         f"[{ids_branches}]. "
@@ -181,29 +287,10 @@ def main() -> int:
         f"and consider `python3 ~/.claude/scripts/octo-dim.py worktree-init` "
         f"to fork your own dimension."
     )
-
-    # Strengthen warning if target_path is claimed by another session
     if target_path:
-        for sid, entry in other_live.items():
-            lanes = entry.get("lanes") or []
-            if target_path in lanes:
-                warning += (
-                    f" CONFLICT: {target_path!r} is claimed by session "
-                    f"{sid[:20]}… — coordinate before writing."
-                )
-                break  # one conflict note is enough
+        warning += f" Lane auto-claimed: {target_path} → this session."
 
-    # Emit in grafo-gate.py format
-    try:
-        print(json.dumps({
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "additionalContext": warning,
-            }
-        }))
-    except Exception:
-        pass  # stdout failure → fail-open
-
+    _emit({"hookEventName": "PreToolUse", "additionalContext": warning})
     return 0
 
 

--- a/scripts/octo-dim.py
+++ b/scripts/octo-dim.py
@@ -380,6 +380,38 @@ def cmd_claim(args) -> int:
     return 0
 
 
+def cmd_release(args) -> int:
+    """Remove a path from this session's lanes — or from EVERY session with
+    --from-any (operator coordination tool for un-sticking a lane conflict)."""
+    path = str(Path(args.path).resolve())
+    try:
+        data = _load()
+        touched = []
+        if getattr(args, "from_any", False):
+            targets = list(data["sessions"].items())
+        else:
+            sid = _resolve_session(args)
+            targets = [(sid, data["sessions"].get(sid))] if sid in data["sessions"] else []
+        for sid, entry in targets:
+            if not entry:
+                continue
+            lanes = entry.get("lanes") or []
+            if path in lanes:
+                lanes.remove(path)
+                entry["lanes"] = lanes
+                data["sessions"][sid] = entry
+                touched.append(sid)
+        if touched:
+            _save(data)
+            for sid in touched:
+                print(f"released: {path} ← session {sid}")
+        else:
+            print(f"(no session holds a lane on {path})")
+    except Exception as exc:
+        print(f"release warning (non-fatal): {exc}", file=sys.stderr)
+    return 0
+
+
 def cmd_unregister(args) -> int:
     sid = _resolve_session(args)
     try:
@@ -525,6 +557,11 @@ def build_parser() -> argparse.ArgumentParser:
     clm = sub.add_parser("claim", help="Add a path to this session's lanes")
     clm.add_argument("path", help="Absolute or relative path to claim")
 
+    rel = sub.add_parser("release", help="Remove a path from lanes (yours, or any with --from-any)")
+    rel.add_argument("path", help="Absolute or relative path to release")
+    rel.add_argument("--from-any", action="store_true", dest="from_any",
+                     help="Release the lane from EVERY session (operator coordination)")
+
     sub.add_parser("unregister", help="Remove this session from the registry")
 
     wi = sub.add_parser("worktree-init", help="Create a git worktree for this dimension")
@@ -551,6 +588,7 @@ HANDLERS = {
     "list": cmd_list,
     "prune": cmd_prune,
     "claim": cmd_claim,
+    "release": cmd_release,
     "unregister": cmd_unregister,
     "worktree-init": cmd_worktree_init,
     "approve-merge": cmd_approve_merge,


### PR DESCRIPTION
## Summary

- **ENFORCE**: `dimension-awareness-hook.py` now emits `permissionDecision: deny` when a target file is already claimed by another live session — fail-closed, exact `hookSpecificOutput` contract.
- **AUTO-CLAIM**: first writer in a shared tree claims the lane involuntarily (cerebellum principle — fires without anyone choosing to run it); claim only activates when `other_live` sessions exist.
- **WARN**: shared-tree awareness message preserved for all tool calls that don't trigger a deny.

## Contract

| Scenario | Output |
|---|---|
| Sole session, any tool | empty stdout (heartbeat written, no warn) |
| Shared tree, non-lane tool (Bash, Read…) | `additionalContext` warn |
| Shared tree, lane tool, free file | `additionalContext` warn + "Lane auto-claimed" |
| Shared tree, lane tool, file owned by other live session | `permissionDecision: deny` |
| Same as above + `OCTO_LANE_OVERRIDE=1` | `additionalContext` warn (override, no deny) |
| Stale session's lane (heartbeat > 900s old) | no block (TTL expired) |
| Corrupt/missing registry | fail-open (exit 0, no deny) |

Operator coordination: `octo-dim release <path> [--from-any]`
Operator override: `OCTO_LANE_OVERRIDE=1` (harness env — agent-proof by same mechanism as `OCTO_MERGE_APPROVE`).

## Security fix — BYP-1 (found + closed this session)

The previous `_resolve_session` checked the stdin **payload** `session_id` field first, then `CLAUDE_SESSION_ID` env. An agent could write `session_id=<owner>` in the hook payload to masquerade as the lane owner and silently bypass the conflict check.

**Fix**: inverted priority — `CLAUDE_SESSION_ID` env wins unconditionally; payload is an untrusted hint used only when env is absent. The harness sets the env; an agent cannot set harness env for Write/Edit calls (inline `FOO=1` scopes only Bash). Documented as a security note in the docstring.

## Other bypass checks (all closed by design)

| Bypass | Status |
|---|---|
| BYP-1: fake `session_id` in payload | **Closed** — env wins |
| BYP-2: dot-dot path (`/tmp/../tmp/file.py`) | Closed — `Path.resolve()` normalizes |
| BYP-3: symlink to claimed file | Closed — `Path.resolve()` follows symlinks |
| BYP-4: `NotebookEdit` uses `notebook_path` field | Covered — `_LANE_TOOLS` tuple + dual field lookup |
| BYP-5: fuzzy `OCTO_LANE_OVERRIDE` values (`"true"`, `" 1"`) | Closed — exact `== "1"` only |

## `octo-dim.py` additions

- `claim <path>` — manual lane claim
- `release <path> [--from-any]` — cooperative handoff (operator coordination)
- `prune` — already existed; prunes stale sessions (and their lanes) by TTL

## Registry concurrency

Hook writes use `_upsert_session` (lock → re-read → mutate → atomic replace) — same contract as `octo-dim.py`'s `_save`. Concurrent sessions never lose each other's entries. Lock block intentionally duplicated (hooks stay import-free and self-contained).

## Test results

```
Functional: 14/14 PASS
Bypass:      9/9  PASS
```

Tests cover: sole-session claim, cross-session deny (format verified), different-file allow+claim, stale TTL no-block, corrupt/missing registry fail-open, `OCTO_LANE_OVERRIDE=1` bypass, all five bypass scenarios above.

## Known limitation (documented in docstring)

A file already git-modified by a session that never wrote through this hook has no lane — the first post-enforcement writer claims it. Attribution of pre-existing uncommitted edits is impossible in a shared tree. Full isolation still means one worktree per session (`octo-dim worktree-init`).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)