### PR TITLE
ci(brain): counts-render drift guard + brain-ci lineage edge

### DIFF
--- a/.github/workflows/brain-pr-checks.yml
+++ b/.github/workflows/brain-pr-checks.yml
@@ -115,3 +115,31 @@ jobs:
             echo "::error::lineage graph is unsound — a seek over it would lie. Fix connectome/lineage.yaml."
             exit 1
           }
+
+  counts-render:
+    name: README/FAQ counts are rendered (no stale floors)
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install deps
+        run: pip install pyyaml
+
+      # Re-render the stat floors + canon facts, then fail if the tree moved.
+      # Why: the renderers only ran inside ai-push; a day of worktree-PR merges
+      # (2026-06-03) left README/FAQ floors stale until an operator noticed.
+      # This makes the render a merge requirement instead of a ritual.
+      - name: Render counts + canon, fail on drift
+        run: |
+          python3 scripts/sync-readme-counts.py --floor
+          python3 scripts/canon-render.py
+          if ! git diff --exit-code; then
+            echo '::error::Stale rendered counts/canon. Run: python3 scripts/sync-readme-counts.py --floor && python3 scripts/canon-render.py — then commit the result.'
+            exit 1
+          fi

--- a/connectome/lineage.yaml
+++ b/connectome/lineage.yaml
@@ -289,3 +289,20 @@ edges:
       Lights the unlit neuron filed by the 2026-06-04 GREP-FALLBACK. A new
       onboarding step (e.g. the arm lineage graph) must land in the skill AND
       its mirrors, or new arms are born without it.
+
+  - id: brain-ci
+    concept: "brain PR checks / required brain checks / CI gate octorato / counts-render check"
+    appears_in:
+      - .github/workflows/brain-pr-checks.yml   # los 4 jobs requeridos
+      - scripts/check-generic.py                # job check-generic
+      - scripts/generate_neural_map.py          # job connectome-rebuild
+      - scripts/lineage-doctor.py               # job lineage-sound
+      - scripts/sync-readme-counts.py           # job counts-render (junto con canon-render.py)
+      - scripts/canon-render.py                 # job counts-render
+    kind: appears_in
+    single_source: ".github/workflows/brain-pr-checks.yml"
+    note: >-
+      Cada check requerido del brain mapea a su script ejecutor. Renombrar un
+      job o mover un script sin reconciliar el otro lado rompe la protección
+      de rama (check requerido que nunca reporta) — la misma clase de deadlock
+      que el twin de Astro resolvió en un arm el 2026-06-04.

--- a/scripts/impact-radius.py
+++ b/scripts/impact-radius.py
@@ -114,7 +114,10 @@ def load_lineage():
 def _matches(target: str, edge: dict) -> bool:
     """Does this edge fire for the given path/concept target?"""
     t = target.strip().lower()
-    frm = (edge.get("from") or "").strip().lower()
+    # Field aliases: early arm seeds used source/target/members for from/to/
+    # appears_in. The reader tolerates both; the canonical schema is from/to/
+    # appears_in (see templates/arm/connectome/lineage.yaml).
+    frm = (edge.get("from") or edge.get("source") or "").strip().lower()
     if frm:
         if t == frm or t.startswith(frm) or (frm.endswith("/") and t.startswith(frm)):
             return True
@@ -123,7 +126,7 @@ def _matches(target: str, edge: dict) -> bool:
     concept = (edge.get("concept") or "").strip().lower()
     if concept and (t in concept or concept in t) and t:
         return True
-    for m in (edge.get("appears_in") or []):
+    for m in (edge.get("appears_in") or edge.get("members") or []):
         if t == str(m).strip().lower():
             return True
     return False
@@ -134,10 +137,11 @@ def _downstream(target: str, edge: dict):
     kind = edge.get("kind", "?")
     offrepo = bool(edge.get("offrepo"))
     out = []
-    for s in (edge.get("to") or []):
+    tos = edge.get("to") or edge.get("target") or []
+    for s in (tos if isinstance(tos, list) else [tos]):
         out.append((str(s), kind, offrepo))
     # appears_in: the OTHER copies plus the single source.
-    members = [str(m) for m in (edge.get("appears_in") or [])]
+    members = [str(m) for m in (edge.get("appears_in") or edge.get("members") or [])]
     if members:
         tl = target.strip().lower()
         for m in members:


### PR DESCRIPTION
Closes the loop on today's stale-README finding: the floor/canon renderers only ran inside `ai-push`, so a day of worktree-PR merges left README/FAQ stale.

- New job `counts-render` in brain-pr-checks.yml: re-renders and fails on `git diff`, printing the exact fix command. Validated locally: clean pass on current master.
- New lineage edge `brain-ci`: each required check ↔ its executor script (same deadlock class the Astro twin fixed arm-side today). lineage-doctor: sound, 18 edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)