### PR TITLE
fix(brain): hooks.json timeouts within schema max

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -124,7 +124,7 @@
         {
           "command": "python3 ~/.claude/scripts/session-isolation-hook.py",
           "statusMessage": "♦ 4D: dimension isolation (auto-fork)...",
-          "timeout": 15,
+          "timeout": 5,
           "type": "command"
         }
       ]
@@ -136,7 +136,7 @@
         {
           "command": "python3 ~/.claude/scripts/cadence-stop-hook.py",
           "statusMessage": "✍ cadence check on the reply...",
-          "timeout": 10,
+          "timeout": 5,
           "type": "command"
         },
         {


### PR DESCRIPTION
Two integers: 15→5 and 10→5. Closes the last brain_doctor FAIL (hooks-runtime-sync schema violation introduced in #118).

🤖 Generated with [Claude Code](https://claude.com/claude-code)