### PR TITLE
feat(brain): auto semver label + 3 upward-learning skills

### DIFF
--- a/scripts/ai_sync.py
+++ b/scripts/ai_sync.py
@@ -378,9 +378,18 @@ def _push_via_pr(branch: str, target: str, msg: str) -> int:
         return 1
     info("✓ Merged + branch deleted")
 
-    git("checkout", target)
-    git("pull", "--ff-only")
+    rc_co, _, _ = git("checkout", target)
+    rc_pl, _, e = git("pull", "--ff-only")
+    if rc_co != 0 or rc_pl != 0:
+        warn(f"⚠ {target} sync failed post-merge; skipping semver tag: {e}")
+        return 1
     info(f"✓ Local {target} synced")
+    # Now on {target} at the squash-merged commit — the correct point to move
+    # the semver label for the PR flow (mirror of the direct-push call site).
+    # The gh-missing early return above never reaches here, so we never tag an
+    # un-merged commit.
+    script_step("scripts/brain-version-bump.py", "--apply", "--push",
+                label="🏷  Moving semver label...")
     return 0
 
 
@@ -531,6 +540,13 @@ def push(args) -> int:
             warn(f"⚠ Push failed: {e}")
             return 1
         info("✓ Pushed to remote")
+        # Move the semver label by change-class (advisory, never fatal).
+        # Direct-push path only: in the PR flow HEAD is the feature branch, so
+        # tagging here would label an un-merged commit. The bump size (patch/
+        # minor/major) is derived from the conventional-commit types since the
+        # last tag — see scripts/brain-version-bump.py.
+        script_step("scripts/brain-version-bump.py", "--apply", "--push",
+                    label="🏷  Moving semver label...")
 
     # Refresh the local connectome. neural_map.json is gitignored (per-machine,
     # regenerated on demand) — so we rebuild it locally for this machine's query/

--- a/scripts/brain-version-bump.py
+++ b/scripts/brain-version-bump.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""brain-version-bump.py - move the brain's semver label by change class.
+
+The brain carries two labels. The README count floor moves only when the real
+count crosses a ten boundary (see sync-readme-counts.py --floor), so small
+changes never churn it. The semver git tag is the other label, and this tool
+moves it on every push that has commits, sizing the bump by the
+conventional-commit type of the commits since the last tag:
+
+    major  ->  a commit typed with `!` (feat!: / fix!:) or a `BREAKING CHANGE`
+               trailer in the body
+    minor  ->  any `feat` commit
+    patch  ->  any other conventional commit (fix/docs/chore/refactor/perf/...)
+    none   ->  no commits since the last tag, or nothing conventional
+
+That is the operator's own model: the label moves every time there are
+changes, and WHICH digit moves depends on the change.
+
+Modes:
+    (default)   print current -> next + reason. Writes nothing.
+    --check     exit 1 if a bump is pending (CI / visibility). Writes nothing.
+    --apply     create the annotated tag locally.
+    --push      with --apply, also push the tag to origin.
+
+All git calls are pinned to the repo root via `-C`, so the result does not
+depend on the caller's working directory (ai-push runs it as a post-push step).
+"""
+import re
+import subprocess
+import sys
+
+TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+# Conventional-commit header: type(scope)!: subject
+CC_RE = re.compile(r"^(?P<type>[a-z]+)(?P<scope>\([^)]*\))?(?P<bang>!)?:", re.I)
+# Breaking-change trailer (spec form): a line starting with BREAKING CHANGE: or
+# BREAKING-CHANGE:. Anchored + multiline so prose like "NONBREAKING CHANGE foo"
+# in a subject does NOT trip a major bump, and the hyphen variant is caught.
+BREAKING_RE = re.compile(r"^BREAKING[ -]CHANGE:", re.M)
+
+# Change-class policy (config-as-code). type -> bump when no `!`/BREAKING.
+MINOR_TYPES = {"feat"}
+# everything else conventional is a patch; non-conventional commits are ignored
+# for sizing but still count as "there were changes" -> patch floor.
+RANK = {"none": 0, "patch": 1, "minor": 2, "major": 3}
+
+
+def git(root, *args):
+    r = subprocess.run(["git", "-C", root, *args],
+                       capture_output=True, text=True)
+    return r.returncode, r.stdout.strip(), r.stderr.strip()
+
+
+def repo_root():
+    r = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        sys.stderr.write("brain-version-bump: not a git repo\n")
+        sys.exit(2)
+    return r.stdout.strip()
+
+
+def tag_exists(root, tag):
+    code, _, _ = git(root, "rev-parse", "-q", "--verify", f"refs/tags/{tag}")
+    return code == 0
+
+
+def latest_tag(root):
+    _, out, _ = git(root, "tag", "--sort=-v:refname")
+    for line in out.splitlines():
+        if TAG_RE.match(line.strip()):
+            return line.strip()
+    return None
+
+
+def commits_since(root, tag):
+    rng = f"{tag}..HEAD" if tag else "HEAD"
+    # %x1e record separator, %x1f field separator: subject<US>body
+    code, out, _ = git(root, "log", rng, "--no-merges",
+                       "--format=%s%x1f%b%x1e")
+    if code != 0 or not out:
+        return []
+    recs = []
+    for chunk in out.split("\x1e"):
+        chunk = chunk.strip("\n")
+        if not chunk.strip():
+            continue
+        subj, _, body = chunk.partition("\x1f")
+        recs.append((subj.strip(), body.strip()))
+    return recs
+
+
+def classify(commits):
+    """Return ('none'|'patch'|'minor'|'major', reason)."""
+    if not commits:
+        return "none", "no commits since last tag"
+    bump = "patch"
+    reason = f"{len(commits)} commit(s), no feat/breaking -> patch"
+    for subj, body in commits:
+        m = CC_RE.match(subj)
+        is_breaking = bool(m and m.group("bang")) or \
+            bool(BREAKING_RE.search(subj)) or bool(BREAKING_RE.search(body))
+        if is_breaking:
+            return "major", f"breaking change in: {subj!r}"
+        if m and m.group("type").lower() in MINOR_TYPES:
+            if RANK["minor"] > RANK[bump]:
+                bump = "minor"
+                reason = f"feat commit: {subj!r}"
+    return bump, reason
+
+
+def next_version(tag, bump):
+    if tag is None:
+        major, minor, patch = 0, 0, 0
+    else:
+        major, minor, patch = map(int, TAG_RE.match(tag).groups())
+    if bump == "major":
+        return f"v{major + 1}.0.0"
+    if bump == "minor":
+        return f"v{major}.{minor + 1}.0"
+    if bump == "patch":
+        return f"v{major}.{minor}.{patch + 1}"
+    return tag  # none
+
+
+def main():
+    apply = "--apply" in sys.argv
+    push = "--push" in sys.argv
+    check = "--check" in sys.argv
+
+    root = repo_root()
+    tag = latest_tag(root)
+    commits = commits_since(root, tag)
+    bump, reason = classify(commits)
+    nxt = next_version(tag, bump)
+
+    cur = tag or "(none)"
+    if bump == "none":
+        print(f"brain-version: {cur} (no bump pending)")
+        return 0
+
+    # Collision guard: if the computed name already exists (a partial prior run,
+    # a tag minted on another branch, a reset), walk forward by the same class
+    # until the name is free — otherwise --apply would no-op forever on a stuck
+    # version.
+    while tag_exists(root, nxt):
+        nxt = next_version(nxt, bump)
+
+    print(f"brain-version: {cur} -> {nxt}  [{bump}]  {reason}")
+
+    if check:
+        return 1  # a bump is pending
+
+    if apply:
+        msg = f"brain {nxt} ({len(commits)} commit(s) since {cur}: {bump})"
+        code, _, e = git(root, "tag", "-a", nxt, "-m", msg)
+        if code != 0:
+            # "already exists" is the benign idempotent case (a race or a
+            # partial prior run). Any OTHER failure (bad object store, read-only
+            # .git) must surface, still without breaking ai-push.
+            if "already exists" in e:
+                return 0
+            sys.stderr.write(f"brain-version: tag {nxt} failed ({e})\n")
+            return 0
+        print(f"  tagged {nxt}")
+        if push:
+            code, _, e = git(root, "push", "origin", nxt)
+            if code != 0:
+                sys.stderr.write(f"brain-version: tag push failed ({e})\n")
+                return 0
+            print(f"  pushed {nxt}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/deterministic-shutdown-backstop/SKILL.md
+++ b/skills/deterministic-shutdown-backstop/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: deterministic-shutdown-backstop
+description: "A long-lived service that hangs INTERMITTENTLY on SIGTERM (non-reproducible, the init system kills it at the timeout, a false OnFailure alert fires and then self-recovers) is not a bug to chase. Install a deterministic daemon-timer backstop (os._exit after N seconds) inside the shutdown path. The race is unfixable by inspection; the backstop is."
+metadata:
+  short-description: "Intermittent non-reproducible hang on shutdown: don't chase the race, arm a daemon-timer os._exit backstop so teardown is bounded and the false OnFailure alert stops."
+---
+
+# Deterministic Shutdown Backstop
+
+## What
+
+A long-running service (a worker supervisor, an orchestrator's blocking
+`serve()` loop, an event-consumer daemon) hangs on shutdown only SOME of
+the time. The symptom chain is:
+
+1. The init system (systemd, k8s, supervisord) sends SIGTERM.
+2. The process's own shutdown handler stalls instead of exiting.
+3. The init system waits its grace period (commonly 30s), then SIGKILLs.
+4. An `OnFailure` / restart alert fires, looks like an incident.
+5. By the time anyone looks, the service is already back up. It "fixed
+   itself." The next 20 restarts are clean. Then it happens again.
+
+Non-reproducible in a minimal repro (a bare `serve()` shuts down in ~2s),
+so you cannot validate a surgical fix. Upgrading the framework version
+does not help because the hang is in the interaction between a synchronous
+stop-and-wait call and a network client talking to a server that is
+itself already dying.
+
+## Why this happens
+
+The shutdown handler does something that can block UNBOUNDEDLY:
+
+- A synchronous `stop().result()` that waits on a future which never
+  resolves because the thing it waits on is also shutting down.
+- An events/telemetry flush that tries to reach a server (ConnectionRefused
+  against a moribund endpoint) and retries with backoff inside the SIGTERM
+  window.
+- A lock or queue drain with no deadline.
+
+Any one of these turns "exit now" into "exit eventually, maybe." Because
+it depends on timing between two dying components, it is a race: it shows
+up under load and vanishes under inspection. You cannot prove a fix
+correct because you cannot make it fail on demand.
+
+## The fix: a bounded backstop, not a better race
+
+Stop trying to make the graceful path fast. ACCEPT that it can hang, and
+GUARANTEE an upper bound on teardown with a separate, dumb timer that does
+not depend on any of the blocking machinery:
+
+```python
+import os, threading, signal
+
+SHUTDOWN_DEADLINE_S = 20  # < the init system's grace period (e.g. 30s)
+
+def _arm_backstop():
+    # daemon=True so the timer never KEEPS the process alive on its own.
+    t = threading.Timer(SHUTDOWN_DEADLINE_S, lambda: os._exit(0))
+    t.daemon = True
+    t.start()
+    return t
+
+def handle_sigterm(signum, frame):
+    _arm_backstop()          # FIRST: guarantee we exit within the deadline.
+    graceful_stop()          # THEN attempt the clean path; if it hangs, the timer wins.
+
+signal.signal(signal.SIGTERM, handle_sigterm)
+```
+
+Key properties:
+
+- **`os._exit`, not `sys.exit`.** `sys.exit` raises an exception that the
+  hung handler can swallow. `os._exit` is immediate and uncatchable. That
+  is the point: the backstop must not be blockable by the thing it is
+  backstopping.
+- **Deadline strictly under the init system's grace period.** If systemd
+  kills at 30s, fire at ~20s. You want a clean self-exit (exit 0) recorded,
+  not a SIGKILL that trips the failure alert.
+- **`daemon=True`.** The timer must never be the reason the process stays
+  alive; it only fires if the process is still up at the deadline.
+- **Arm the timer BEFORE calling the graceful stop**, so a hang in the
+  graceful stop is already covered.
+
+## When to reach for this
+
+- Intermittent hang on SIGTERM / SIGINT that you cannot reproduce.
+- A false-positive restart/OnFailure alert that always self-clears.
+- Surgery is unvalidatable because the failure is a timing race between two
+  shutting-down components.
+
+Do NOT use it to paper over a graceful path that ALWAYS hangs (that is a
+real deadlock to fix). The backstop is for the unreproducible tail, where
+chasing the race costs more than bounding it.
+
+## Anti-pattern
+
+Bumping the framework version and hoping. If the hang is in the
+stop-and-wait + dying-network-client interaction, the new version usually
+ships the same shape. Bound the teardown instead of trusting the upstream
+fix.

--- a/skills/fb-page-dual-id/SKILL.md
+++ b/skills/fb-page-dual-id/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: fb-page-dual-id
+description: "A Facebook Page has TWO different identifiers: the URL ID seen in `profile.php?id=N` (and in the page's vanity URL) and the Graph API ID returned by `me/accounts` / used in API calls. They are NOT interchangeable. Worse, the New Pages Experience reuses the `profile.php?id=N` URL shape for Pages too, so the URL no longer tells you whether a target is a Page or a personal Profile. Store and match on the Graph API ID."
+metadata:
+  short-description: "FB Page URL ID (profile.php?id=N) != Graph API ID (me/accounts.id); New Pages Experience reuses the profile.php URL so the URL no longer distinguishes Page from Profile. Persist the Graph API ID for all API calls."
+---
+
+# Facebook Page Dual ID
+
+## What
+
+When you automate posting to a Facebook Page through the Graph API, you
+will encounter two numbers that both look like "the Page ID" and are not
+the same:
+
+- **URL ID** - the number in `facebook.com/profile.php?id=N`, also what a
+  human copies from the address bar.
+- **Graph API ID** - the `id` returned by `GET /me/accounts` (the list of
+  Pages the token can manage), and the one every Graph endpoint expects in
+  `POST /{page-id}/feed`, photo uploads, insights, etc.
+
+Passing the URL ID to a Graph endpoint fails or targets the wrong object.
+All API persistence and matching must use the Graph API ID.
+
+## The New Pages Experience trap
+
+Historically you could tell a Page from a personal Profile by the URL: a
+Page had a vanity slug, a Profile had `profile.php?id=N`. That heuristic is
+DEAD. The New Pages Experience reuses the `profile.php?id=N` URL form for
+Pages too. So:
+
+- You can no longer infer "Page vs Profile" from the URL shape.
+- A `profile.php?id=N` link may be a Page, and that `N` is the URL ID, not
+  the Graph API ID.
+
+To classify and to call the API correctly, resolve through the token:
+`GET /me/accounts` returns the managed Pages with their Graph API IDs.
+Match against that list, not against the URL.
+
+## The rule
+
+1. **Persist the Graph API ID** (`me/accounts[].id`) as the canonical Page
+   identifier in any datastore, config, or mapping. Never persist the URL
+   ID as the thing you call the API with.
+2. **Never derive Page-ness from the URL.** Resolve via `me/accounts`.
+3. If a human hands you a `profile.php?id=N` link, treat `N` as a URL ID to
+   be resolved, not as the API target.
+
+## Symptom that points here
+
+- A feed/photo POST 400s with an object-not-found or permissions error
+  even though the token clearly manages the Page.
+- A "Page" you stored stops matching, or you cannot tell a Page from a
+  Profile by its link anymore.
+
+In both cases, re-fetch `me/accounts`, confirm the Graph API ID, and store
+that. The URL ID was a red herring.

--- a/skills/long-lived-negative-dns-cache/SKILL.md
+++ b/skills/long-lived-negative-dns-cache/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: long-lived-negative-dns-cache
+description: "A long-running process (a cron supervisor, a daemon, a worker pool parent) caches a NEGATIVE DNS result after a transient network blip and then never retries, so every downstream call fails forever even though the network recovered seconds later. A wrapper bug can log a fake `exit=0`, hiding it. Symptom: 'nothing runs anymore' with no error. Fix: restart the process, then bound the DNS/connection cache TTL."
+metadata:
+  short-description: "Long-lived process caches a failed DNS lookup after a network blip and never re-resolves; a wrapper logs fake exit=0 masking it. 'Nothing runs' with no error. Restart + cap the negative-cache TTL."
+---
+
+# Long-Lived Process Negative DNS Cache
+
+## What
+
+A process that stays up for days or weeks (a Python cron supervisor, a
+scheduler parent, a connection-pooling daemon) suddenly stops doing useful
+work. No error in the logs. No crash. The init system shows it `active`.
+Restarting it fixes everything instantly.
+
+The trigger was a brief network blip (a few seconds of no connectivity:
+laptop sleep, Wi-Fi handoff, VPN reconnect, host migration). During that
+window the process tried to resolve a hostname, got a failure, and CACHED
+the failure. After the network came back, the process keeps serving the
+cached negative result and never re-resolves. Every outbound call to that
+host now fails for the lifetime of the process.
+
+## Why this happens
+
+Two layers compound:
+
+### Layer 1 - the negative cache that never expires
+
+Some resolvers, HTTP client libraries, or connection pools cache a
+resolution FAILURE in-process with no TTL, or with a TTL far longer than
+the blip. A short-lived process never hits this (it re-resolves on the
+next run). A long-lived one caches once and is stuck until restart. This
+is the inverse of the usual "stale positive DNS" problem: here the stale
+entry is a NEGATIVE one.
+
+### Layer 2 - the wrapper that hides it
+
+A supervising wrapper (a shell loop, a `try/except` that logs and
+continues, a task runner that swallows the child's real status) reports a
+fake `exit=0` or "ok" even though the inner work never reached the host.
+So monitoring sees green while nothing actually happens. The only honest
+signal is "the expected side effects stopped appearing" (no new rows, no
+published posts, no fired jobs).
+
+## The fix
+
+1. **Immediate:** restart the process. `systemctl --user restart <unit>`
+   (or the equivalent). It re-resolves on startup and recovers.
+2. **Durable - bound the negative cache.** Cap the resolver / client
+   negative-cache TTL so a blip self-heals within minutes:
+   - Python `socket`/`urllib3`: avoid module-level cached resolvers that
+     outlive a request; create the client per-batch, or set a connection
+     pool with a finite `ttl`.
+   - System resolver (`systemd-resolved`, `nscd`): cap negative TTL.
+   - For schedulers, prefer re-resolving per-tick over caching the host
+     across ticks.
+3. **Make the wrapper honest.** The supervisor must propagate the child's
+   real exit status, not log a synthetic `exit=0`. A masked failure is
+   worse than a loud one because it burns days before anyone notices.
+
+## How to diagnose
+
+- Symptom is "nothing runs / nothing publishes" with NO error and the
+  service still `active`.
+- A restart fixes it instantly and completely. That alone strongly implies
+  in-process cached state (DNS, connection, auth) rather than a code bug.
+- Correlate the stop time with a known network event (sleep, VPN, host
+  move). The blip is usually minutes before the silence began.
+
+## Anti-pattern
+
+Trusting `exit=0` / "active" as proof of work. For long-lived background
+processes, health = "the side effects are still appearing," not "the
+process is up." Pair this with a side-effect heartbeat sentinel where it
+matters.


### PR DESCRIPTION
## What
- **Auto semver label**: `ai-push` now moves the brain's semver git tag by change-class. `feat!`/`BREAKING CHANGE:` → major, `feat:` → minor, anything else → patch, no commits → no bump. New `scripts/brain-version-bump.py` (modes `--check`/`--apply`/`--push`).
- Wired at **two call sites** in `scripts/ai_sync.py`: the direct-push path and the post-squash-merge point in the PR flow (so it works even though master is PR-protected). Advisory/non-fatal: a tag failure never breaks `ai-push`.
- **3 upward-learning skills** distilled generic from arm lessons: `deterministic-shutdown-backstop`, `long-lived-negative-dns-cache`, `fb-page-dual-id`.

## Verification
- `py_compile` clean; 7/7 classify unit tests pass; dry-run computes `v3.2.0 → v3.3.0 [minor]`.
- Two independent Code Reviewer passes; all findings fixed (idempotency catch narrowed, tag-collision guard, anchored BREAKING regex, post-merge sync return-code guard).
- `check-generic` clean; count floors in sync (210+/160+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)