### PR TITLE
feat(brain): client-doc-lint reflex + cotizacion-legal-baseline

### DIFF
--- a/connectome/lineage.yaml
+++ b/connectome/lineage.yaml
@@ -357,3 +357,17 @@ edges:
       linter regexes together — the linter quoting the blocklist means a
       one-sided edit silently splits canon from enforcement. Edge added
       2026-06-04 after the seek fell back to grep (unlit neuron).
+
+  - id: client-doc-lint
+    concept: "client deliverable pre-send lint (accents / em-dash / stale dates)"
+    appears_in:
+      - scripts/client-doc-lint.py
+      - scripts/client-doc-lint-hook.py
+      - skills/client-doc-lint/SKILL.md
+      - hooks.json
+    kind: appears_in
+    single_source: "scripts/client-doc-lint.py is the engine; the hook wraps it, the skill documents it, hooks.json registers it"
+    note: >-
+      Change the lint's CLI (flags, checks, exit codes) and reconcile all four:
+      the engine, the PostToolUse(Bash) wrapper, the skill doc, and the
+      hooks.json registration. Edge added 2026-06-09 so the node is not unlit.

--- a/hooks.json
+++ b/hooks.json
@@ -53,6 +53,17 @@
         }
       ],
       "matcher": "Write|Edit"
+    },
+    {
+      "hooks": [
+        {
+          "command": "python3 ~/.claude/scripts/client-doc-lint-hook.py",
+          "statusMessage": "✍ client-doc-lint (entregable cliente)...",
+          "timeout": 20,
+          "type": "command"
+        }
+      ],
+      "matcher": "Bash"
     }
   ],
   "PreToolUse": [

--- a/scripts/client-doc-lint-hook.py
+++ b/scripts/client-doc-lint-hook.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""client-doc-lint-hook.py — PostToolUse(Bash) reflex wrapper for client-doc-lint.
+
+Fires after a Bash command. If the command produced/touched a CLIENT deliverable
+PDF (filename matches propuesta|cotiza|contrato|propos), it runs client-doc-lint
+on that PDF and, only when the lint FAILS, surfaces the verdict as
+additionalContext so the model fixes it before declaring "listo para enviar".
+
+Design (per command-boundary-hook-matching + hook-profile-gating + reflexes-over-discipline):
+  - ADVISORY ONLY: always exit 0, never blocks the tool.
+  - Boundary-safe: ignores echo/comment/commit-message lines so a .pdf MENTIONED
+    in a string does not false-fire; only acts on real .pdf paths that EXIST.
+  - Scoped: only client-document filenames, to stay quiet on unrelated PDFs.
+  - Fail-open: any internal error → exit 0 silently (a hook must never crash a tool).
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+LINT = SCRIPT_DIR / "client-doc-lint.py"
+CLIENT_DOC = re.compile(r"(propuesta|cotiza|contrato|propos)", re.I)
+PDF_TOKEN = re.compile(r"""(?:^|[\s'"=])((?:/|\.{0,2}/|~)?[^\s'"]+\.pdf)""", re.I)
+SKIP_LINE = re.compile(r"^\s*(echo|#|cat\b|printf)|commit\s+-m|-m\s+['\"]", re.I)
+
+
+def emit(msg: str) -> None:
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PostToolUse", "additionalContext": msg}}))
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        return 0
+    if data.get("tool_name") != "Bash":
+        return 0
+    cmd = (data.get("tool_input") or {}).get("command", "") or ""
+    if not LINT.exists():
+        return 0
+
+    # Boundary-safe: drop lines that only MENTION a pdf (echo/commit/comment).
+    paths = []
+    for line in cmd.splitlines():
+        if SKIP_LINE.search(line):
+            continue
+        for m in PDF_TOKEN.finditer(line):
+            p = m.group(1).replace("~", str(Path.home()), 1)
+            if CLIENT_DOC.search(Path(p).name):
+                paths.append(p)
+    seen, fails = set(), []
+    for p in paths:
+        if p in seen:
+            continue
+        seen.add(p)
+        fp = Path(p)
+        if not fp.exists():
+            continue
+        try:
+            r = subprocess.run([sys.executable, str(LINT), str(fp)],
+                               capture_output=True, text=True, timeout=90)
+        except Exception:
+            continue
+        if r.returncode != 0:
+            fails.append(r.stdout.strip())
+    if fails:
+        emit("client-doc-lint marcó FAIL en un entregable de cliente recién "
+             "generado. Corrige ANTES de declararlo listo para enviar:\n\n"
+             + "\n\n".join(fails))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/client-doc-lint.py
+++ b/scripts/client-doc-lint.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""client-doc-lint.py — pre-send QA reflex for generated CLIENT deliverables.
+
+cadence-lint.py covers PROSE SOURCE text. This linter covers the GENERATED
+ARTIFACT (a PDF/DOCX cotización, propuesta, contrato) right before "listo para
+enviar". It exists because in one session a whole Spanish client proposal was
+generated with ZERO accents AND an already-past kickoff date, and both slipped
+through two regeneration rounds until a manual visual render caught them. An
+instruction ("be careful with accents") depends on discipline and never reaches
+a sub-agent's doc-gen; this turns the regex-provable subset into a REFLEX.
+
+Checks (Spanish client docs):
+  1 accents   — a long Spanish doc with a near-zero accent ratio = stripped
+                accents (looks unprofessional). FAIL.
+  2 em-dash   — any '—' in the rendered text (human-cadence rule 1). FAIL.
+  3 stale     — a forward-looking line (kickoff/agendar/semana del ...) whose
+                date is already in the past relative to --today. FAIL.
+  4 figures   — informational inventory of every $ amount found, so a human
+                can eyeball consistency across sections (no auto-verdict).
+
+Usage:
+  client-doc-lint.py <file.pdf|.txt|.md>     CLI report; exit 1 on any FAIL
+  ... | client-doc-lint.py                   lint stdin text
+  client-doc-lint.py <file> --today 2026-06-09   pin "today" (tests/repro)
+  client-doc-lint.py <file> --lang es        language for accent check (es default)
+
+Requires `pdftotext` (poppler-utils) for .pdf input.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
+ACCENTED = "áéíóúüñÁÉÍÓÚÜÑ"
+MONTHS = {
+    "enero": 1, "febrero": 2, "marzo": 3, "abril": 4, "mayo": 5, "junio": 6,
+    "julio": 7, "agosto": 8, "septiembre": 9, "setiembre": 9, "octubre": 10,
+    "noviembre": 11, "diciembre": 12,
+}
+# Forward-intent keywords: a date on these lines is meant to be in the FUTURE.
+FORWARD = re.compile(r"(kickoff|agend|semana del|arranqu|antes del|antes de fin)", re.I)
+# Reference/emission lines legitimately carry past dates (FX, DOF, emission).
+REFERENCE = re.compile(r"(FIX|DOF|tipo de cambio|emisi[óo]n|referencia|Banxico|exhibici[óo]n)", re.I)
+
+
+def read_text(path: str) -> str:
+    if path == "-":
+        return sys.stdin.read()
+    p = Path(path)
+    if not p.exists():
+        sys.exit(f"client-doc-lint: no existe {path}")
+    if p.suffix.lower() == ".pdf":
+        try:
+            out = subprocess.run(["pdftotext", str(p), "-"], capture_output=True,
+                                 text=True, timeout=60)
+        except FileNotFoundError:
+            sys.exit("client-doc-lint: falta pdftotext (apt install poppler-utils)")
+        if out.returncode != 0:
+            sys.exit(f"client-doc-lint: pdftotext falló: {out.stderr.strip()}")
+        return out.stdout
+    return p.read_text(encoding="utf-8", errors="replace")
+
+
+def check_accents(text: str, lang: str) -> tuple[bool, str]:
+    if lang != "es":
+        return True, "accents: omitido (lang != es)"
+    letters = sum(1 for c in text if c.isalpha())
+    accented = sum(1 for c in text if c in ACCENTED)
+    ratio = accented / letters if letters else 0
+    if letters > 800 and ratio < 0.005:
+        return False, (f"accents: FAIL — {accented} acentos en {letters} letras "
+                       f"(ratio {ratio:.3%}); un texto en español sano ronda 3-6%. "
+                       f"Probable pérdida de acentos.")
+    return True, f"accents: OK — ratio {ratio:.2%} ({accented}/{letters})"
+
+
+def check_emdash(text: str) -> tuple[bool, str]:
+    n = text.count("—")
+    if n:
+        sample = [ln.strip() for ln in text.splitlines() if "—" in ln][:3]
+        return False, "em-dash: FAIL — " + str(n) + " ocurrencia(s). Ej: " + " | ".join(sample)
+    return True, "em-dash: OK — 0"
+
+
+def _parse_dates(line: str, today: _dt.date):
+    """Yield (date, has_year) for full and week-style Spanish dates in a line."""
+    mes = "|".join(MONTHS)
+    for m in re.finditer(rf"(\d{{1,2}})\s+de\s+({mes})\s+de\s+(\d{{4}})", line, re.I):
+        yield _dt.date(int(m.group(3)), MONTHS[m.group(2).lower()], int(m.group(1))), True
+    for m in re.finditer(rf"semana del\s+(\d{{1,2}})\s+de\s+({mes})(?!\s+de\s+\d)", line, re.I):
+        yield _dt.date(today.year, MONTHS[m.group(2).lower()], int(m.group(1))), False
+
+
+def check_stale(text: str, today: _dt.date) -> tuple[bool, str]:
+    bad = []
+    for ln in text.splitlines():
+        if not FORWARD.search(ln) or REFERENCE.search(ln):
+            continue
+        for d, _hy in _parse_dates(ln, today):
+            if d < today:
+                bad.append(f"{d.isoformat()} :: {ln.strip()[:90]}")
+    if bad:
+        return False, "stale-dates: FAIL — fecha futura ya vencida:\n    " + "\n    ".join(bad[:5])
+    return True, f"stale-dates: OK (hoy {today.isoformat()})"
+
+
+def figures(text: str) -> str:
+    found = sorted(set(re.findall(r"\$[\d][\d,]*(?:\.\d{2})?", text)))
+    return f"figures: {len(found)} montos distintos → " + ", ".join(found[:20]) + (
+        " ..." if len(found) > 20 else "")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("file", nargs="?", default="-")
+    ap.add_argument("--today", help="YYYY-MM-DD (default: hoy del sistema)")
+    ap.add_argument("--lang", default="es")
+    a = ap.parse_args()
+    today = (_dt.date.fromisoformat(a.today) if a.today else _dt.date.today())
+
+    text = read_text(a.file)
+    results = [check_accents(text, a.lang), check_emdash(text), check_stale(text, today)]
+    print(f"── client-doc-lint: {a.file} ──")
+    ok_all = True
+    for ok, msg in results:
+        print(("  ✓ " if ok else "  ✗ ") + msg)
+        ok_all = ok_all and ok
+    print("  · " + figures(text))
+    print("VERDICT:", "PASS (listo para enviar)" if ok_all else "FAIL (corregir antes de enviar)")
+    return 0 if ok_all else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/client-doc-lint/SKILL.md
+++ b/skills/client-doc-lint/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: client-doc-lint
+description: Pre-send QA reflex for GENERATED client deliverables (cotización, propuesta, contrato PDF/DOCX). Lints the rendered artifact for stripped accents, em-dash, already-past forward dates (kickoff/vigencia), and inventories every $ amount for human eyeballing. Run it before declaring any client doc "listo para enviar". Complements cadence-lint.py (which lints prose SOURCE, not the rendered output).
+metadata:
+  type: reference
+---
+
+# client-doc-lint · el doc no se manda sin pasar el lint
+
+**Por qué existe.** En una sesión se generó una propuesta completa en español para
+un cliente **sin un solo acento** y con una **fecha de kickoff ya vencida**, y ambos
+errores cruzaron dos rondas de regeneración hasta que un render visual manual los
+cachó. Un instrucción ("cuida los acentos") depende de disciplina y nunca llega al
+doc-gen de un sub-agente. Esto vuelve reflejo lo que un regex sí puede probar.
+
+`cadence-lint.py` cubre la **prosa fuente**. `client-doc-lint.py` cubre el
+**artefacto generado** (el PDF/DOCX que se envía).
+
+## Uso
+```bash
+python3 ~/.claude/scripts/client-doc-lint.py <archivo.pdf|.txt|.md>     # exit 1 si algo FALLA
+python3 ~/.claude/scripts/client-doc-lint.py <archivo.pdf> --today 2026-06-09   # fijar "hoy"
+cat doc.txt | python3 ~/.claude/scripts/client-doc-lint.py
+```
+Requiere `pdftotext` (poppler-utils) para PDF.
+
+## Qué revisa
+1. **accents**: doc largo en español con ratio de acentos casi cero = acentos perdidos, FAIL. (Español sano ronda 3-6%; bandera por debajo de 0.5% en docs > 800 letras.)
+2. **em-dash**: cualquier guion largo (em-dash) en el texto renderizado (human-cadence regla 1), FAIL.
+3. **stale-dates**: una línea con intención futura (kickoff / agendar / semana del / antes del) cuya fecha ya pasó respecto a `--today`, FAIL. Ignora líneas de referencia (FIX/DOF/emisión) que legítimamente citan fechas pasadas.
+4. **figures**: inventario informativo de todos los montos `$` para que un humano verifique consistencia entre secciones (sin veredicto automático).
+
+## Cuándo (reflejo)
+Antes de decir "listo para enviar" sobre CUALQUIER entregable de cliente generado
+por código o por sub-agente. Si el lint marca FAIL, se corrige y se reemite ANTES
+de mandar. Para entregables visuales, el lint NO sustituye el render + Read propio
+(tablas cortadas, layout): es la primera barrera barata, no la única.
+
+Relacionado: [[cadence-lint]] (prosa fuente), [[human-cadence]] (las 10 no-reglas),
+[[cotizacion-legal-baseline]] (clausulado base), [[reflexes-over-discipline]].

--- a/skills/cotizacion-legal-baseline/SKILL.md
+++ b/skills/cotizacion-legal-baseline/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: cotizacion-legal-baseline
+description: Clausulado legal base (México B2B) que TODA cotización o propuesta de servicios debe incluir desde el borrador 1, no después de que un review lo cache. Cubre propiedad intelectual (obra por encargo), tratamiento de datos personales (LFPDPPP, encargado), confidencialidad/NDA, límite de responsabilidad, garantía y soporte post-entrega, y responsabilidad de licenciamiento. Texto genérico reutilizable, sin datos de cliente.
+metadata:
+  type: reference
+---
+
+# Clausulado base de cotización (México B2B)
+
+**Por qué existe.** En una sesión, un review de 6 especialistas tuvo que agregar
+cláusulas legales que el primer borrador omitía (PI, LFPDPPP, límite de
+responsabilidad). Una cotización de servicios debe **nacer** con este clausulado,
+no adquirirlo por suerte. Operacionaliza el canon "legal & copyright always-on".
+
+Inserta una sección **Términos y Condiciones** con estos bloques (ajusta nombres
+de partes y montos; el resto es boilerplate genérico). Revisión jurídica formal
+sigue siendo del operador; esto es piso profesional, no asesoría legal.
+
+### Propiedad Intelectual
+El desarrollo se realiza bajo la figura de **obra por encargo**. Cubierto el pago
+total, el cliente adquiere los derechos patrimoniales sobre la aplicación, los
+datos, los flujos y los reportes desarrollados específicamente para el proyecto.
+El proveedor conserva la titularidad de sus **componentes preexistentes**
+(librerías, plantillas, métodos genéricos) y se reserva el derecho de reutilizarlos.
+*(Por defecto, Art. 84 LFDA deja la titularidad en el autor; sin esta cláusula el código no queda del cliente.)*
+
+### Tratamiento de Datos Personales (LFPDPPP)
+Cuando el sistema procese datos personales de terceros (empleados, clientes del
+cliente), el cliente es el **responsable** y el proveedor el **encargado** conforme
+al **Art. 50 del Reglamento de la LFPDPPP**. El proveedor usa los datos solo para
+el desarrollo/pruebas/entrega contratados, no los comparte y los elimina de sus
+entornos al cierre. El cliente es responsable de que su Aviso de Privacidad
+contemple el tratamiento. A solicitud, se formaliza convenio de encargo.
+**Un NDA NO sustituye esto.** Acordar antes de recibir cualquier dataset con datos personales.
+
+### Confidencialidad
+Aplica el NDA firmado y vigente, **citado por fecha** y confirmado que cubre el
+alcance del proyecto. Datos, estructura y código entregado son confidenciales.
+
+### Limitación de Responsabilidad
+La responsabilidad total del proveedor no excede el monto efectivamente pagado.
+No responde por daños indirectos, lucro cesante ni pérdida de datos posterior a la
+entrega y aceptación.
+
+### Garantía y Soporte Post-Entrega
+Corrección sin costo de defectos de construcción de lo entregado por **N días
+hábiles** tras la aceptación del UAT. Fuera de garantía: cambios de plataforma del
+proveedor de nube, cambios organizacionales del cliente, fallos por licenciamiento
+no contratado, y funciones fuera de alcance. Soporte extendido se cotiza aparte.
+
+### Licenciamiento
+El licenciamiento de terceros (ej. Power Apps Premium, Dataverse) es
+responsabilidad y costo del cliente. El trabajo que dependa de esa licencia no
+inicia sin confirmación de su adquisición; el proveedor no asume retrasos por su
+no contratación oportuna.
+
+### Pago y tipo de cambio (si aplica USD→MXN)
+Plazo claro: "N días naturales desde la factura del anticipo y, para el saldo,
+desde el **acta de aceptación del UAT firmada**." Ajuste cambiario **por
+exhibición**, FIX Banxico del día hábil anterior a cada transferencia, recalculo si
+la variación supera 5%. Facturación CFDI 4.0.
+
+---
+Antes de enviar, pasa el doc por [[client-doc-lint]]. Relacionado:
+[[financial-formula-verification]], [[legal-compliance]] (si existe), canon "legal & copyright always-on".


### PR DESCRIPTION
Pre-send QA reflex for generated client deliverables + MX legal clause baseline.

- `scripts/client-doc-lint.py`: lints rendered PDF/DOCX for stripped accents, em-dash, already-past forward dates (kickoff/vigencia), and inventories $ amounts. Complements cadence-lint.py (prose source).
- `scripts/client-doc-lint-hook.py` + hooks.json: PostToolUse(Bash) advisory reflex, boundary-safe, fail-open.
- `skills/client-doc-lint`, `skills/cotizacion-legal-baseline`: docs + reusable MX B2B clause set (IP obra-por-encargo, LFPDPPP encargado, responsabilidad, garantia, licenciamiento).
- connectome/lineage.yaml: lights the client-doc-lint node.

Proven catching real misses (15 em-dash + a past kickoff date in a prior proposal). QA gate approved by carlos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)