### PR TITLE
feat(brain): whatsapp-mcp bridge gotchas (403 directpath fix + install lessons)

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -4,7 +4,7 @@ Plain answers to the questions people (and the AI agents that read this repo) ac
 
 ## What is Octorato?
 
-Octorato is an **open-source AI agent operating system**: one file-native "brain" — rules, 210+ skills (HOW), 160+ specialist agents (WHO), and memory, all plain markdown under git — that a single operator runs across many sealed client "arms." It adds per-client token attribution and hard budget halts (FinOps), so a consultant or small agency can bill many clients fairly from one brain. Licensed MIT.
+Octorato is an **open-source AI agent operating system**: one file-native "brain" — rules, 220+ skills (HOW), 160+ specialist agents (WHO), and memory, all plain markdown under git — that a single operator runs across many sealed client "arms." It adds per-client token attribution and hard budget halts (FinOps), so a consultant or small agency can bill many clients fairly from one brain. Licensed MIT.
 
 ## What is an "AI agent operating system"?
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ An open-source AI agent operating system where a single human operator directs a
 
 With nothing but natural language, you can direct a team of AI specialists to build and ship software, and bill the client honestly when it ships.
 
-**Live framework**: 210+ skills, 160+ agent personas across 13 divisions, enforcement scripts, multi-machine sync, a neural connectome that learns over time, and a FinOps pipeline that tags every trace event with the client who incurred it — with per-arm USD rollup and a `PreToolUse` budget halt **shipped, opt-in** (configure `budgets.yaml` to arm caps; run the `anthropic-enterprise-analytics` pull to reconcile estimate against billed cost). See [roadmap below](#finops-roadmap).
+**Live framework**: 220+ skills, 160+ agent personas across 13 divisions, enforcement scripts, multi-machine sync, a neural connectome that learns over time, and a FinOps pipeline that tags every trace event with the client who incurred it — with per-arm USD rollup and a `PreToolUse` budget halt **shipped, opt-in** (configure `budgets.yaml` to arm caps; run the `anthropic-enterprise-analytics` pull to reconcile estimate against billed cost). See [roadmap below](#finops-roadmap).
 
 **Shipped with it**: live products built and maintained agent-first on this brain — see [Built with Octorato](SHOWCASE.md).
 
@@ -316,7 +316,7 @@ The archived specs become institutional memory — future tasks reference past d
                         ┌────────▼────────┐
                         │   BRAIN         │
                         │  ~/.claude/     │
-                        │  210+ Skills     │
+                        │  220+ Skills     │
                         │  160+ Agents     │
                         │  N Client Arms  │
                         │  HOOKS — enforcement reflexes           │
@@ -419,7 +419,7 @@ graph TB
     classDef div fill:#21262D,stroke:#30363D,stroke-width:1px,color:#C9D1D9,font-size:12px
 
     CEO["Human Operator"]:::ceo
-    BRAIN["BRAIN — 210+ Skills · 160+ specialist agents · N Arms"]:::brain
+    BRAIN["BRAIN — 220+ Skills · 160+ specialist agents · N Arms"]:::brain
     CEO --> BRAIN
 
     BRAIN --> ENG["Engineering — 28"]:::div
@@ -696,7 +696,7 @@ ai-pull --status
 │   ├── paid-media/          ← 7 agents
 │   ├── strategy/            ← NEXUS orchestration playbooks and runbooks
 │   └── examples/            ← Multi-agent workflow examples
-├── skills/                  ← 210+ reusable techniques
+├── skills/                  ← 220+ reusable techniques
 ├── scripts/
 │   ├── ai_sync.py                 ← Multi-machine sync engine (pull/push/sync/status verbs)
 │   ├── generate_neural_map.py     ← Connectome generator (TF-IDF + cosine + Hebbian)

--- a/skills/whatsapp-mcp-bridge-gotchas/SKILL.md
+++ b/skills/whatsapp-mcp-bridge-gotchas/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: whatsapp-mcp-bridge-gotchas
+description: "Hard-won fixes for standing up the lharries/whatsapp-mcp bridge (whatsmeow + WhatsApp Web multidevice) read-only and encrypted. Covers the 403 media-download root cause (direct path stripped of its CDN auth query), the 405 client-outdated fix (bump whatsmeow + add context.Context to changed APIs), QR-vs-phone-code pairing, encrypt-at-rest without sudo (gocryptfs static binary), and read-only enforcement. Load before installing or debugging a personal WhatsApp MCP."
+metadata:
+  type: reference
+---
+
+# WhatsApp MCP bridge (lharries/whatsmeow) gotchas
+
+Lived 2026-06-10 standing up `lharries/whatsapp-mcp` for a personal number, read-only and encrypted. The repo works but ships against a pinned whatsmeow that WhatsApp now rejects, and its media download is broken in a subtle way. The fixes below are the root causes, not workarounds.
+
+## 1. 403 on media download (the big one). Root cause: stripped CDN auth
+**Symptom:** `/api/download` returns `download failed with status code 403` for every image/audio/doc, including a message received live (so it is NOT URL expiry).
+
+**Root cause:** the bridge stores the full media `url` and reconstructs the direct path with `extractDirectPathFromURL`, which **strips the query string** (`?ccb=...&oh=...&oe=...&_nc_sid=...`). Those query params are the **CDN auth tokens**. whatsmeow's `Download` builds the download URL as `mediaHost + directPath`, so a path without its query is unauthenticated and the CDN returns 403.
+
+**Fix (one line):** in `extractDirectPathFromURL`, keep the query. Return `"/" + parts[1]` WITHOUT the `strings.SplitN(pathPart, "?", 2)[0]` strip. This recovers history-synced media too (no need to re-forward the message), because the stored URL already carries valid tokens.
+
+## 2. 405 "Client outdated" on connect. Bump whatsmeow + add context
+**Symptom:** bridge connects then `Client outdated (405) connect failure (client version: ...)`, websocket closes.
+
+**Fix:** the pinned whatsmeow is stale. `go get go.mau.fi/whatsmeow@latest && go get go.mau.fi/util@latest && go mod tidy`, rebuild. The current whatsmeow API added a `context.Context` first arg to several calls the bridge uses; add `context.Background()` to: `client.Download`, `client.GetGroupInfo`, `client.Store.Contacts.GetContact`, `sqlstore.New`, `container.GetFirstDevice`. Build errors point to each line.
+
+## 3. Pairing: prefer the phone code over the QR
+The terminal QR (qrterminal half-block) is often unscannable from a chat surface and rotates every ~20s, so it times out. **Phone-number pairing is far more reliable.** whatsmeow supports `client.PairPhone(ctx, phone, true, whatsmeow.PairClientChrome, "Chrome (Linux)")`, which returns an 8-char code the operator types in WhatsApp > Linked Devices > Link with phone number. Patch the QR loop to call it when an env like `WA_PAIR_PHONE=<intl digits>` is set. The bridge links as its own device; the operator's WhatsApp Web in a browser stays logged in (multidevice allows several).
+
+## 4. Encrypt at rest without sudo
+`gocryptfs` built from source needs `libssl-dev` (sudo). Skip that: download the **prebuilt static binary** from the gocryptfs GitHub releases (`*_linux-static_amd64.tar.gz`), it has no deps and FUSE is usually present (`/dev/fuse` + `fusermount`). Init a cipher dir, mount it, and `ln -s <mount> whatsapp-bridge/store` so the bridge writes messages.db + the whatsmeow session encrypted. Passphrase via `-passfile` from a 600 file or, better, the SO keyring (`secret-tool`).
+
+## 5. Read-only enforcement (three layers)
+1. **Strip the send tools from the server source** (`main.py`): remove `send_message`, `send_file`, `send_audio_message` so they are absent from the MCP schema. Strongest layer.
+2. **Harness deny** in `settings.json` `permissions.deny`: `mcp__whatsapp__send_message`, `mcp__whatsapp__send_file`, `mcp__whatsapp__send_audio_message`.
+3. Open the messages DB read-only where the server reads it.
+
+## 6. Operational
+The Go bridge must stay alive (whatsmeow keeps the multidevice session); run it as a `systemd --user` service with `loginctl enable-linger`. The gocryptfs mount must be remounted on boot too. Both are prerequisites for the MCP server to read.
+
+Related: [[mcp-stack-setup]], [[phi-aware-rag-ingestion]] (sensitive-data ingestion), [[sops-age-git-encryption]].


### PR DESCRIPTION
Reference skill capturing root-cause fixes from standing up lharries/whatsapp-mcp read-only + encrypted:

- **403 media download** (the big one): extractDirectPathFromURL stripped the CDN auth query (ccb/oh/oe/_nc_sid). whatsmeow builds host+directPath, so the unauthenticated path 403s. Fix: keep the query. Recovers history media too.
- **405 client outdated**: bump whatsmeow@latest + add context.Context to Download/GetGroupInfo/Store.Contacts.GetContact/sqlstore.New/GetFirstDevice.
- **Pairing**: phone code (PairPhone) over the flaky terminal QR.
- **Encrypt at rest without sudo**: gocryptfs prebuilt static binary over the bridge store dir.
- **Read-only**: strip send tools from server + harness deny + ro DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)