### PR TITLE
feat(brain): theory-plus-practice-prompts skill + Windows Edge focus gotcha for browser-bearer auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 >
 > <sub>the Octopus Brain Framework</sub>
 
-> **Octorato is an open-source AI agent operating system: one file-native "brain" — <!--canon:skills.count-->210+<!--/canon--> skills and <!--canon:agents.count-->160+<!--/canon--> specialist agents in plain markdown under git — that one operator runs across many isolated client "arms."**
+> **Octorato is an open-source AI agent operating system: one file-native "brain" — <!--canon:skills.count-->220+<!--/canon--> skills and <!--canon:agents.count-->160+<!--/canon--> specialist agents in plain markdown under git — that one operator runs across many isolated client "arms."**
 
 [![License: MIT](https://img.shields.io/github/license/CarlosCaPe/octorato)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/CarlosCaPe/octorato?style=social)](https://github.com/CarlosCaPe/octorato/stargazers)

--- a/content/EXAMPLE.md
+++ b/content/EXAMPLE.md
@@ -10,6 +10,6 @@ Octorato is <!--canon:octorato.tagline-->an organic, file-native AI agent operat
 
 The source lives at <!--canon:repo.url-->https://github.com/CarlosCaPe/octorato<!--/canon-->.
 
-It ships <!--canon:skills.count-->210+<!--/canon--> skills and
+It ships <!--canon:skills.count-->220+<!--/canon--> skills and
 <!--canon:agents.count-->160+<!--/canon--> specialist agents — these two RECOMPUTE
 from `brain-stats.py`, so they can never be hand-edited into a lie.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -8,7 +8,7 @@
 > agents across clients, projects, and machines — without ever mixing their data
 > or their bills.
 
-**Live:** <!--canon:skills.count-->210+<!--/canon--> skills · <!--canon:agents.count-->160+<!--/canon--> agent personas across
+**Live:** <!--canon:skills.count-->220+<!--/canon--> skills · <!--canon:agents.count-->160+<!--/canon--> agent personas across
 13 divisions · hook-enforced gates · multi-machine sync · a neural
 connectome that learns over time · a FinOps pipeline that tags every trace event
 with the client who incurred it.
@@ -42,7 +42,7 @@ Each page is an organ. This brain routes you to whichever one you need.
 
 1. **[[Architecture]]** — the anatomy atlas: CLASS / OBJECT / ARM, the activation stack, and why an octopus.
 2. **[[The-4D-Paradigm]]** — the nervous signal: every action follows Describe → Delegate → Diligent → Disclose.
-3. **[[Skills]]** — the synapse catalog: <!--canon:skills.count-->210+<!--/canon--> learned techniques (the *HOW*).
+3. **[[Skills]]** — the synapse catalog: <!--canon:skills.count-->220+<!--/canon--> learned techniques (the *HOW*).
 4. **[[Agents]]** — the neuron roster: <!--canon:agents.count-->160+<!--/canon--> specialist personas (the *WHO*).
 5. **[[Self-Growth]]** — neurogenesis and pruning: the daily auto-curation loop.
 6. **[[Security]]** — the immune system: why the brain stays generic, and how that's enforced.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -3,7 +3,7 @@
 - **[[Home]]** (central brain)
 - **[[Architecture]]** (anatomy)
 - **[[The-4D-Paradigm]]** (nervous system)
-- **[[Skills]]** (<!--canon:skills.count-->210+<!--/canon-->) · [[Skills-System]]
+- **[[Skills]]** (<!--canon:skills.count-->220+<!--/canon-->) · [[Skills-System]]
 - **[[Agents]]** (<!--canon:agents.count-->160+<!--/canon-->) · [[Agents-System]]
 - **[[Arms-and-Sync]]** (limbs)
 - **[[Self-Growth]]** (neurogenesis)

--- a/skills/browser-bearer-graph-auth/SKILL.md
+++ b/skills/browser-bearer-graph-auth/SKILL.md
@@ -146,6 +146,59 @@ const TEAMS_SHELL_PATTERNS = [
 | Using this for scopes that are admin-blocked (`OnlineMeetingTranscript.Read.All`, `ChannelMessage.Read.All`) | No browser dance helps — those need admin-consented App Registration |
 | Hiding this auth path in client-facing docs | Disclose. The hidden risk is the unmanaged risk. |
 | Continuing this past POC into "production" | The risk profile changes. App Registration is mandatory by then. |
+| Launching the interactive Edge window with `viewport: { width, height }` + no `--start-maximized` on Windows | Playwright spawns the Edge window without claiming foreground focus; on Windows it lands BEHIND the operator's other windows (especially Cursor/VSCode in full-screen). The operator thinks the script froze, kills it, and the flow fails forever. See "Windows window-focus gotcha" below. |
+
+## Windows window-focus gotcha (hard-learned 2026-06-05)
+
+**Symptom**: operator runs the interactive auth flow, the Node process clearly spawned Edge child processes (visible in Task Manager), the persistent-session dir was just written to — but the operator says "no veo ese edge" / "I don't see the window" and kills the process. Token never refreshes. Reproduces 100% of the time when the operator's primary window is a maximized IDE.
+
+**Root cause**: `chromium.launchPersistentContext(SESSION_DIR, { headless: false, channel: 'msedge', viewport: { width: 1280, height: 900 }, args: ['--disable-blink-features=AutomationControlled'] })` on Windows does TWO things wrong simultaneously:
+
+1. **Fixed `viewport` overrides OS window sizing** — Edge ends up as a small window (~1280×900) that's easy to lose behind a maximized IDE.
+2. **No `--start-maximized` / `--new-window` / `--window-position`** — Playwright doesn't reclaim foreground focus, so the OS opens Edge in z-order behind the active window.
+
+The combination is silent: no error, no log, the script just waits at `await page.goto(...)` while the user stares at their IDE.
+
+**Fix in the calling Playwright code**:
+
+```js
+// In the function that launches the persistent context:
+const visibleArgs = headless
+  ? ['--disable-blink-features=AutomationControlled']
+  : [
+      '--disable-blink-features=AutomationControlled',
+      '--start-maximized',          // make the window obvious
+      '--window-position=120,80',   // offset from corner so it isn't hidden by taskbar
+      '--new-window',                // refuse to merge into an existing Edge process
+    ];
+
+const context = await chromium.launchPersistentContext(SESSION_DIR, {
+  headless,
+  channel: 'msedge',
+  // CRITICAL: null viewport in interactive mode — fixed viewport defeats --start-maximized
+  viewport: headless ? { width: 1280, height: 900 } : null,
+  args: visibleArgs,
+});
+
+const page = context.pages()[0] || await context.newPage();
+// Pull the window forward BEFORE navigation so user sees it emerge.
+if (!headless) {
+  try { await page.bringToFront(); } catch {}
+}
+await page.goto(URL, ...);
+if (!headless) {
+  try { await page.bringToFront(); } catch {}  // again after redirects
+}
+```
+
+**Fix in the operator UX layer** (the launcher script that calls this):
+- Print a **loud, framed warning BEFORE** launching Edge: "Playwright-spawned Edge can open BEHIND your other windows. ALT+TAB or check taskbar."
+- Emit a **heartbeat every 10s** in the wait loop while no URL movement is detected — operator needs to know the script is alive while they hunt for the window.
+- If 30s pass with zero URL change in interactive mode, print an escalation message: "No URL activity yet — is the Edge window still hidden? ALT+TAB now."
+
+**Operator instruction in any RUNBOOK**: explicitly tell the human "the Edge window may open behind Cursor/VSCode — ALT+TAB before you assume the script froze."
+
+This gotcha cost ~45 minutes of session time before being diagnosed; the brain MUST surface it preemptively whenever a new arm wires up `auth-via-browser.js`-style flows.
 
 ## Composability
 

--- a/skills/theory-plus-practice-prompts/SKILL.md
+++ b/skills/theory-plus-practice-prompts/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: theory-plus-practice-prompts
+description: Every long-form technical document combining a framework explanation with a use-case demonstration MUST carry executable real-data prompts alongside the conceptual claims. No theory without prompts. No prompts without theory. The medium imitates the substrate. Triggers — authoring a Confluence POC page, an arm-level whitepaper, a client deliverable, a developer-facing onboarding doc, ANY artifact that asks the reader to act on what they read.
+---
+
+# theory-plus-practice-prompts
+
+## The canon
+
+> Every long-form technical document combining a framework explanation with a use-case demonstration must carry executable real-data prompts alongside the conceptual claims.
+>
+> **No theory without prompts. No prompts without theory. The medium imitates the substrate.**
+
+## The lesson that provoked this skill
+
+ADH POC, 2026-06-05. Operator (Carlos) published a 111-line intro page to ADH's Confluence. Single page, conceptual framing, well-written, zero prompts. Sponsor read it. Reaction: *"estoy en shock... está súper pequeño eso y llevamos semanas trabajando"* (I'm in shock... this is super small and we've been working weeks).
+
+Underdelivery wasn't word count. It was **the absence of executable substance**. The page explained Octorato; it didn't show Octorato operating on ADH.
+
+Operator pivoted: *"sería super bueno citar ejemplos de prompts (incluso similares a los usados en la vida real) para que ellos se enseñen a usarlos, prácticamente que quede como guía, no solo teoría"* (would be great to cite prompt examples — even similar to ones used in real life — so they learn to use them, practically becomes a guide, not just theory).
+
+The burst that followed published 10 child pages totaling 2,501 lines / 142 KB — every page combining framework narrative WITH copy-paste-ready prompts hitting `@pmdgithub`, `APR-*`, `ResolveMSSQLDatabases`, real ADH terminology. Plus a dedicated `Prompt Cookbook` page consolidating 30+ prompts across 6 scenarios.
+
+**The skill captures the pattern so this lesson doesn't have to be re-learned on the next arm.**
+
+## Why this is structurally correct (three reasons)
+
+### 1. Theory alone = academic. Practice alone = magic. Together = pedagogy.
+
+| Solo theory | Solo prompts | Theory + practice |
+|---|---|---|
+| "MCP is an open standard for AI agents to talk to external systems." | "Paste this into Cursor: `'...'`" | Reader sees the **why** (theory) AND the **how** (prompt) in one session. Learns the pattern by reading + doing in one place. |
+| Read once, forgotten. | Looks like a trick — reader executes without understanding, can't generalize, can't argue with the design. | **Generates capacity to extend**, not just capacity to imitate. |
+
+### 2. Real-data prompts make the framework non-dismissible
+
+Prompts that use real client terminology (`@pmdgithub`, `APR-*`, `ResolveMSSQLDatabases`) cannot be dismissed with *"sure, but our setup is different."* **The setup IS theirs. The proof is IN the prompt.**
+
+This converts the document from:
+
+> *"X could work for [client]"* (hypothesis)
+>
+> →
+>
+> *"X works AT [client] — here are the queries with their repos, their tickets, their systems"* (demonstration)
+
+The difference between selling a hypothesis and demonstrating a result. The second is defensible in a standup the day after publishing. The first reads like marketing.
+
+### 3. The medium imitates the substrate
+
+A framework whose own brain has 200+ skills (each skill = `<description of what it does> + <examples of when to invoke>`) cannot publish documentation about itself as theory-only without betraying its own pattern. The format of the docs must mirror the format of the framework. Coherence between message and medium.
+
+For Octorato specifically: the published POC should read **as a skill of Octorato being read from the inside, not as a whitepaper about Octorato being read from the outside.** The intro establishes; the child pages demonstrate; the cookbook operates.
+
+## Mandatory pattern for long-form technical documents
+
+### Document-level structure
+
+Every framework-explanation document combines THREE layers:
+
+1. **Conceptual narrative** — what the framework is, why it exists, what assumptions it rests on
+2. **Use-case demonstration** — how it applies to the specific client / domain / problem
+3. **Executable prompts** — real queries that hit real systems with real terminology
+
+Failure modes:
+- Layer 1 only → academic, decays into shelfware in 6 weeks
+- Layer 2 only → demo material, fades when the demo is over
+- Layer 3 only → looks like cheating, no defensible architecture behind it
+- **All three** → pedagogically complete; survives both the casual reader (skims theory + prompts) and the skeptic (reads everything, finds nothing to dismiss)
+
+### Page-level structure
+
+Each substantive page within a multi-page deliverable carries a `Try these prompts` (or equivalent) section. Minimum 3 prompts. Maximum: as many as illuminate distinct scenarios.
+
+Each prompt has uniform anatomy:
+
+```
+ID — short name (e.g., R1, P4, X2 — keyed to the page's scenario)
+
+Prompt: "<the exact text to paste into Cursor / Claude Desktop / agent>"
+Planes: which MCP server(s) / tool(s) it exercises
+Tools: which underlying tools the agent will likely invoke
+Why it's hard today: 1-2 lines on the manual alternative
+Expected shape: what success looks like (sample output structure)
+Variations: optional — adjacent prompts for related questions
+```
+
+Uniform structure means the reader learns the shape once and reads every subsequent prompt in seconds.
+
+### Suite-level structure (the cookbook)
+
+If the deliverable has more than ~3 substantive pages with prompts each, **consolidate into a dedicated cookbook page** — one page that organizes all prompts by scenario (Onboarding / Day-to-day / Planning / Archaeology / Compliance / Cross-cutting / etc.). The cookbook is:
+
+- The hands-on entry point for engineers who want to act, not read
+- The reference reviewers cite when discussing specific capabilities
+- The artifact most likely to be bookmarked and revisited
+
+## Anti-patterns (what NOT to do)
+
+| Anti-pattern | Why it fails | What to do instead |
+|---|---|---|
+| *"We'll add example prompts later"* | Later never comes. The doc decays into shelfware before the prompts are added. | Add prompts in the FIRST published version, even if rough. Better drafts beat empty promises. |
+| Generic prompts (e.g., `"list all repos in the org"`) | Reader can't tell if the framework knows their specific setup. | Use real client repos / project keys / system names. If you can't, the framework hasn't been studied deeply enough yet. |
+| Prompts buried in an appendix | Reader has to leave the page to act. | Embed prompts inline with the theory they exemplify. |
+| Prompts without expected-shape annotations | Reader has no way to know if their result is correct. | Always show what success looks like. Empty results are a finding too — document them. |
+| Theory page + separate prompt cookbook page with NO cross-references | Theory readers never reach the cookbook; cookbook users never see the theory. | Every theory page links FORWARD to the cookbook entries it exemplifies. Cookbook entries link BACKWARD to the theory pages they implement. |
+| Prompts that require the substrate to be perfect | Brittle — one bug breaks the demo. | Include prompts that probe FAILURE modes too. *"Try X. Expected result: honest 403 with the gated scope named — not a fabricated response."* Honest failure is part of the value. |
+| Single mega-prompt that "does everything" | Reader can't disentangle the demonstration. | Smaller, scenario-keyed prompts that each demonstrate ONE primitive of the framework. |
+
+## When this skill applies
+
+| Context | Apply? |
+|---|---|
+| Client POC / assessment document | **Yes — always.** This is the canonical case. |
+| Internal whitepaper about a framework | **Yes.** Even internal readers benefit from theory + practice. |
+| Onboarding documentation for a new tool | **Yes.** First-week engineers learn faster by doing than by reading. |
+| Compliance / regulatory write-up | **Yes — adapt.** Prompts in this context demonstrate the audit trail, the routing decisions, the failure modes — not the "happy path" capability. |
+| Quick Slack post about a feature | No — too small. Apply only to documents that ask the reader to act on what they read. |
+| Marketing copy | No — different audience, different success criteria. |
+| API reference for a library | Partially — the API reference IS the practice; examples should be runnable. The "theory" layer is the design rationale section. |
+
+## Verification checklist for any document this skill applies to
+
+Before publishing, check:
+
+- [ ] At least 3 executable prompts per substantive page (more if the page covers multiple scenarios)
+- [ ] Every prompt uses real client/system terminology — no `<placeholder>` text
+- [ ] Every prompt has expected-shape annotation
+- [ ] Every prompt has "why it's hard today" so the value is explicit
+- [ ] Cross-references between theory pages and cookbook (forward and backward)
+- [ ] At least one prompt demonstrates an HONEST FAILURE mode (a 403, an empty result, a graceful refusal — proves the framework doesn't fabricate)
+- [ ] Cookbook page exists if >3 substantive pages with prompts each
+- [ ] No "to be added in v2" placeholders for prompts — if it's not there, it doesn't ship
+
+## Companion skills
+
+- **`human-cadence`** — for the prose between prompts. Prompts are precise by nature; the narrative connecting them should not drift into AI-tells.
+- **`source-citation-tagging`** — every claim in the theory layer must carry a source tag so reviewers can challenge specific assertions by source.
+- **`octorato-harmony`** — the prompts themselves must use the canonical literal for each name. `@pmdgithub` everywhere; not `@pmdgithub` in one place and `pmdGitHub` in another.
+- **`no-history-in-docs`** — changelogs at the bottom of the page. Iteration artifacts ("added in v3") do not appear in the body.
+- **`harmonization-over-accretion`** — when adding new prompts in revisions, harmonize with existing ones (same anatomy, same naming scheme). Don't accrete inconsistent formats.
+
+## Historical note
+
+This skill was authored on 2026-06-05 directly from the ADH POC Confluence burst. Specifically: the operator's correction `"sería super bueno citar ejemplos de prompts (incluso similares a los usados en la vida real) para que ellos se enseñen a usarlos, prácticamente que quede como guía, no solo teoría"` is the exact phrasing this skill canonizes. The first published deliverable to apply this skill end-to-end is the ADH POC Confluence tree at parent page 3089432578 + 10 children (2026-06-05 23:00-23:50 CT), with the cookbook child page (3089596434) as the practical reference.
+
+Future evolution: if the cookbook page grows beyond ~50 prompts, consider splitting by scenario into separate cookbook pages (Onboarding cookbook / Archaeology cookbook / etc.) rather than letting one page grow unboundedly. The 50-prompt threshold is provisional — revise when first hit.


### PR DESCRIPTION
﻿Two upward-learning artifacts from the ADH POC session (2026-06-05):

1. NEW skill `theory-plus-practice-prompts` ΓÇö canon for any long-form
   technical document combining framework explanation with use-case
   demonstration: must carry executable real-data prompts alongside
   conceptual claims (`no theory without prompts, no prompts without
   theory; the medium imitates the substrate`). Born from the 111-line
   theory-only Confluence intro page underdelivery and the 2,501-line /
   10-page pivot that landed the pattern in real ADH terminology
   (@pmdgithub, APR-*, ResolveMSSQLDatabases). Triggers on Confluence
   POC pages, arm-level whitepapers, client deliverables, and any
   artifact asking the reader to act on what they read.

2. UPDATE to `browser-bearer-graph-auth` ΓÇö adds the Windows
   window-focus gotcha section. Playwright launchPersistentContext on
   Windows opens Edge BEHIND maximized IDEs when `viewport:{w,h}` is
   fixed and no `--start-maximized` / `--new-window` /
   `--window-position` flag is set; operator stares at IDE while the
   script silently waits at page.goto. Documents the fix (null viewport
   in interactive mode + `--start-maximized --new-window
   --window-position=120,80` + `page.bringToFront()` pre- and
   post-navigation) plus the operator UX layer (loud pre-launch warning,
   heartbeat every 10s in wait loop, 30s escalation message,
   RUNBOOK-level ALT+TAB instruction). Cost ~45 minutes of session time
   before being diagnosed.

Co-authored-by: Cursor <cursoragent@cursor.com>
