### PR TITLE
ci(brain): bump semver autolabel on every merge to master

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,44 @@
+name: Brain Version Bump
+
+# Moves the semver autolabel (vX.Y.Z) on every merge to master, sized by the
+# conventional-commit type of the commits since the last tag (feat -> minor,
+# fix/chore/... -> patch, `!`/BREAKING -> major), then emits the GitHub Release.
+#
+# Why this exists: brain-version-bump.py used to run only as a post-push step of
+# `ai-push`. The repo is PR-first with auto-deploy on main, so almost everything
+# lands via PR-merge, which bypasses ai-push entirely. The autolabel got stuck
+# (e.g. three feat merges left the tag frozen at v3.3.0 while content moved on).
+# Running the bump server-side on every push to master decouples the label from the
+# manual push path, so it can never silently lag again.
+#
+# Loop-safe: this job pushes a TAG, and a tag push does not trigger an
+# `on: push: branches` workflow, so it never re-triggers itself.
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: write   # push the annotated tag + create the Release
+
+concurrency:
+  group: brain-version-bump
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history + all tags, needed by classify()
+
+      - name: Configure git identity for the annotated tag
+        run: |
+          git config user.name "octorato-bot"
+          git config user.email "octorato-bot@users.noreply.github.com"
+
+      - name: Bump the semver tag and emit the Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/brain-version-bump.py --apply --push

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 >
 > <sub>the Octopus Brain Framework</sub>
 
-> **Octorato is an open-source AI agent operating system: one file-native "brain" — <!--canon:skills.count-->210+<!--/canon--> skills and <!--canon:agents.count-->160+<!--/canon--> specialist agents in plain markdown under git — that one operator runs across many isolated client "arms."**
+> **Octorato is an open-source AI agent operating system: one file-native "brain" — <!--canon:skills.count-->220+<!--/canon--> skills and <!--canon:agents.count-->160+<!--/canon--> specialist agents in plain markdown under git — that one operator runs across many isolated client "arms."**
 
 [![License: MIT](https://img.shields.io/github/license/CarlosCaPe/octorato)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/CarlosCaPe/octorato?style=social)](https://github.com/CarlosCaPe/octorato/stargazers)

--- a/content/EXAMPLE.md
+++ b/content/EXAMPLE.md
@@ -10,6 +10,6 @@ Octorato is <!--canon:octorato.tagline-->an organic, file-native AI agent operat
 
 The source lives at <!--canon:repo.url-->https://github.com/CarlosCaPe/octorato<!--/canon-->.
 
-It ships <!--canon:skills.count-->210+<!--/canon--> skills and
+It ships <!--canon:skills.count-->220+<!--/canon--> skills and
 <!--canon:agents.count-->160+<!--/canon--> specialist agents — these two RECOMPUTE
 from `brain-stats.py`, so they can never be hand-edited into a lie.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -8,7 +8,7 @@
 > agents across clients, projects, and machines — without ever mixing their data
 > or their bills.
 
-**Live:** <!--canon:skills.count-->210+<!--/canon--> skills · <!--canon:agents.count-->160+<!--/canon--> agent personas across
+**Live:** <!--canon:skills.count-->220+<!--/canon--> skills · <!--canon:agents.count-->160+<!--/canon--> agent personas across
 13 divisions · hook-enforced gates · multi-machine sync · a neural
 connectome that learns over time · a FinOps pipeline that tags every trace event
 with the client who incurred it.
@@ -42,7 +42,7 @@ Each page is an organ. This brain routes you to whichever one you need.
 
 1. **[[Architecture]]** — the anatomy atlas: CLASS / OBJECT / ARM, the activation stack, and why an octopus.
 2. **[[The-4D-Paradigm]]** — the nervous signal: every action follows Describe → Delegate → Diligent → Disclose.
-3. **[[Skills]]** — the synapse catalog: <!--canon:skills.count-->210+<!--/canon--> learned techniques (the *HOW*).
+3. **[[Skills]]** — the synapse catalog: <!--canon:skills.count-->220+<!--/canon--> learned techniques (the *HOW*).
 4. **[[Agents]]** — the neuron roster: <!--canon:agents.count-->160+<!--/canon--> specialist personas (the *WHO*).
 5. **[[Self-Growth]]** — neurogenesis and pruning: the daily auto-curation loop.
 6. **[[Security]]** — the immune system: why the brain stays generic, and how that's enforced.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -3,7 +3,7 @@
 - **[[Home]]** (central brain)
 - **[[Architecture]]** (anatomy)
 - **[[The-4D-Paradigm]]** (nervous system)
-- **[[Skills]]** (<!--canon:skills.count-->210+<!--/canon-->) · [[Skills-System]]
+- **[[Skills]]** (<!--canon:skills.count-->220+<!--/canon-->) · [[Skills-System]]
 - **[[Agents]]** (<!--canon:agents.count-->160+<!--/canon-->) · [[Agents-System]]
 - **[[Arms-and-Sync]]** (limbs)
 - **[[Self-Growth]]** (neurogenesis)


### PR DESCRIPTION
## Why
The semver autolabel (`vX.Y.Z` git tag + GitHub Release) is moved by `scripts/brain-version-bump.py`, which ran **only** as a post-push step of `ai-push`. This repo is PR-first with auto-deploy on `master`, so almost everything lands via PR-merge, which bypasses `ai-push`. Result today: three `feat` merges (#133, #134, #135) left the tag frozen at v3.3.0 while content moved on. (Caught up to v3.4.0 manually.)

## What
A GitHub Action that runs the same bump server-side on every push to `master`, so the label can never silently lag again.

- `on: push: branches: [master]` -> runs `brain-version-bump.py --apply --push`
- `fetch-depth: 0` so classify() sees full history + tags
- git identity set for the annotated tag; `GH_TOKEN` + `contents: write` for tag push + Release
- **Loop-safe:** the job pushes a *tag*, which does not trigger an `on: push: branches` workflow

## Verified
- `brain-version-bump.py` dry-run already confirmed the model (v3.3.0 -> v3.4.0 [minor]); the script is idempotent (collision guard + `gh release view` guard), so re-running on every push is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)