### PR TITLE
feat(skills): snowflake-dbt-pitfalls + tramite-mx-assistant

### DIFF
--- a/hooks.schema.json
+++ b/hooks.schema.json
@@ -20,7 +20,7 @@
               "properties": {
                 "type": { "const": "command" },
                 "command": { "type": "string", "minLength": 1 },
-                "timeout": { "type": "integer", "minimum": 1, "maximum": 5 },
+                "timeout": { "type": "integer", "minimum": 1, "maximum": 60 },
                 "statusMessage": { "type": "string" }
               },
               "required": ["type", "command"],

--- a/skills/snowflake-dbt-pitfalls/SKILL.md
+++ b/skills/snowflake-dbt-pitfalls/SKILL.md
@@ -7,33 +7,33 @@ description: Non-obvious Snowflake and dbt footguns that fail silently or destro
 
 Five non-obvious footguns distilled from real engineering sessions. Each is something the docs underplay and that a future task can trigger on. Generic only.
 
-## 1. `CREATE OR REPLACE TABLE` permanently destroys Time Travel (the worst one)
-`CREATE OR REPLACE TABLE` drops and recreates the object in one atomic step that **bypasses the recycle bin**:
-- `UNDROP` does NOT recover it (UNDROP only works after an explicit `DROP`).
-- Time Travel coverage restarts from zero at recreation; old snapshots are gone.
-- The old data is permanently, irrecoverably lost. No workaround after the fact.
+## 1. `CREATE OR REPLACE TABLE` resets the new object's Time Travel lineage
+`CREATE OR REPLACE TABLE` drops the old table and creates a **new object with fresh lineage**. What this breaks:
+- The new object's Time Travel window starts at creation. `SELECT ... AT/BEFORE` on the new table cannot reach the OLD table's history. Anything keyed to the old lineage (streams, downstream Time Travel queries) is severed.
+- The old data is NOT gone, though: the dropped version is retained in Time Travel for its retention window and is recoverable with `UNDROP TABLE`. The catch is `UNDROP` restores to the original name, so if the new same-named table already exists you must rename it out of the way first, then `UNDROP`, then reconcile.
 
-It is dangerous precisely because `CREATE OR REPLACE` is idiomatic for views/procs/stages, so engineers assume "replace" is recoverable. **Prevention: CLONE first.**
+So the real risk is silent lineage loss and a clumsy recovery, not permanent data loss. Engineers misread it because `CREATE OR REPLACE` is idiomatic for views/procs/stages. **Prevention: CLONE first** for a clean, immediately queryable backup with intact history:
 ```sql
 CREATE OR REPLACE TABLE my_table_backup CLONE my_table;
 CREATE OR REPLACE TABLE my_table AS SELECT ...;
 ```
 
 ## 2. Snowflake Dynamic Table (DT) constraints
-- **`CURRENT_TIMESTAMP()` (and other non-deterministic functions) are forbidden inside a DT query.** DTs use deterministic change-tracking for incremental refresh; non-determinism breaks it (create fails or results are wrong). Use `METADATA$ACTION_TIMESTAMP`, or pass the timestamp as a parameter via a Task.
-- **Default hard limit of 250 DTs per account** (raisable by support). Easy to hit when DTs are treated as cheap views.
-- If a table is **fully reloaded every cycle** anyway, a scheduled-Task `TRUNCATE + INSERT` is cheaper and simpler than a DT. The DT change-tracking overhead buys nothing when there is no incremental benefit.
+- **`CURRENT_TIMESTAMP` is allowed in filters but not in the SELECT list under incremental refresh.** Since the GA in May 2025, `CURRENT_TIMESTAMP`/`CURRENT_DATE`/`CURRENT_TIME` work in `WHERE`/`HAVING`/`QUALIFY` (the immutable-window pattern, e.g. `WHERE event_time < CURRENT_TIMESTAMP()`). Putting `CURRENT_TIMESTAMP()` in the SELECT list forces FULL refresh; use `METADATA$ROW_LAST_COMMIT_TIME` instead when you need a per-row refresh timestamp. Still restricted for incremental: session-context functions (`CURRENT_USER`/`CURRENT_ROLE`/`CURRENT_WAREHOUSE`) and sequences.
+- **Account limit is 50,000 DTs** (as of 2025; verify in your account limits, it has moved over releases). Not a small number, but design DT-heavy pipelines with it in mind.
+- If a table is **fully reloaded every cycle** anyway, a scheduled-Task `TRUNCATE + INSERT` can be cheaper and simpler than a DT. The DT change-tracking overhead buys little when there is no incremental benefit.
 
 ## 3. Snowflake `PIVOT` with dotted column values (two compounding bugs)
-- **Single-quoted values in `IN(...)` are string literals, not column refs.** `PIVOT(MAX(value) FOR tag IN ('c2.avg'))` makes the header AND cell the literal string, not aggregated data. Use **unquoted identifiers** in both `IN(...)` and the outer `SELECT`.
-- **Dots in identifiers** like `c2_tag.avg` parse as a two-part identifier `c2_tag.avg` and fail compilation. Normalize dots first.
+- **`IN(...)` takes quoted string literals that match the source column's VALUES**, and each becomes a generated column header. If a value contains a dot (e.g. `'c2_tag.avg'`), the auto-generated column header is an invalid/dotted identifier that fails downstream when you reference it unquoted in the outer `SELECT`. The fix is NOT to unquote the `IN` list (it must stay quoted), it is to **normalize the dots in the source values first** so the generated headers are clean identifiers.
 ```sql
 WITH normalized AS (
   SELECT REPLACE(tag_id, '.', '_') AS tag_id_clean, value FROM source_table
 )
-SELECT c2_tag_avg, c3_tag_sum
+SELECT *
 FROM normalized
-PIVOT(MAX(value) FOR tag_id_clean IN (c2_tag_avg, c3_tag_sum));
+PIVOT(MAX(value) FOR tag_id_clean IN ('c2_tag_avg', 'c3_tag_sum'));
+-- IN values stay quoted literals; headers come back as 'c2_tag_avg' etc.
+-- add  AS p (grp, c2_tag_avg, c3_tag_sum)  if you need bare SELECTable identifiers
 ```
 Symptom that points here: PIVOT returns the column-name strings or nulls instead of values.
 

--- a/skills/snowflake-dbt-pitfalls/SKILL.md
+++ b/skills/snowflake-dbt-pitfalls/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: snowflake-dbt-pitfalls
+description: Non-obvious Snowflake and dbt footguns that fail silently or destroy data. Load when writing or reviewing Snowflake DDL (CREATE OR REPLACE, Dynamic Tables, PIVOT) or dbt config (sources.yml freshness, versioned models). Each pitfall has a concrete prevention. Triggers - "CREATE OR REPLACE TABLE", Snowflake Time Travel / UNDROP, Dynamic Table refresh errors, PIVOT returning literals/nulls, dbt source freshness passing when it should not, dbt versioned-model YAML parse error that survives typo fixes.
+---
+
+# Snowflake and dbt pitfalls (silent / destructive)
+
+Five non-obvious footguns distilled from real engineering sessions. Each is something the docs underplay and that a future task can trigger on. Generic only.
+
+## 1. `CREATE OR REPLACE TABLE` permanently destroys Time Travel (the worst one)
+`CREATE OR REPLACE TABLE` drops and recreates the object in one atomic step that **bypasses the recycle bin**:
+- `UNDROP` does NOT recover it (UNDROP only works after an explicit `DROP`).
+- Time Travel coverage restarts from zero at recreation; old snapshots are gone.
+- The old data is permanently, irrecoverably lost. No workaround after the fact.
+
+It is dangerous precisely because `CREATE OR REPLACE` is idiomatic for views/procs/stages, so engineers assume "replace" is recoverable. **Prevention: CLONE first.**
+```sql
+CREATE OR REPLACE TABLE my_table_backup CLONE my_table;
+CREATE OR REPLACE TABLE my_table AS SELECT ...;
+```
+
+## 2. Snowflake Dynamic Table (DT) constraints
+- **`CURRENT_TIMESTAMP()` (and other non-deterministic functions) are forbidden inside a DT query.** DTs use deterministic change-tracking for incremental refresh; non-determinism breaks it (create fails or results are wrong). Use `METADATA$ACTION_TIMESTAMP`, or pass the timestamp as a parameter via a Task.
+- **Default hard limit of 250 DTs per account** (raisable by support). Easy to hit when DTs are treated as cheap views.
+- If a table is **fully reloaded every cycle** anyway, a scheduled-Task `TRUNCATE + INSERT` is cheaper and simpler than a DT. The DT change-tracking overhead buys nothing when there is no incremental benefit.
+
+## 3. Snowflake `PIVOT` with dotted column values (two compounding bugs)
+- **Single-quoted values in `IN(...)` are string literals, not column refs.** `PIVOT(MAX(value) FOR tag IN ('c2.avg'))` makes the header AND cell the literal string, not aggregated data. Use **unquoted identifiers** in both `IN(...)` and the outer `SELECT`.
+- **Dots in identifiers** like `c2_tag.avg` parse as a two-part identifier `c2_tag.avg` and fail compilation. Normalize dots first.
+```sql
+WITH normalized AS (
+  SELECT REPLACE(tag_id, '.', '_') AS tag_id_clean, value FROM source_table
+)
+SELECT c2_tag_avg, c3_tag_sum
+FROM normalized
+PIVOT(MAX(value) FOR tag_id_clean IN (c2_tag_avg, c3_tag_sum));
+```
+Symptom that points here: PIVOT returns the column-name strings or nulls instead of values.
+
+## 4. dbt `sources.yml` freshness has two underused keys
+- **`filter:`** accepts a WHERE expression evaluated before the freshness check. Without it, freshness checks `max(loaded_at)` across ALL rows including stale/rejected ones. Scope it, e.g. `filter: "status = 'LOADED'"`, so freshness reflects meaningful rows.
+- **`identifier:`** maps the logical source name to a different physical table name. Without it dbt assumes node name = table name; after a rename the freshness check silently hits the wrong table or errors. The fix is one `identifier:` key, not a schema change.
+Symptom: a freshness check passing when it should fail (or vice versa).
+
+## 5. dbt versioned-model `include/exclude` placement
+In versioned models (`versions:` in `schema.yml`), an `include: all` / `exclude: [col]` block nested **inside** the `columns:` list is structurally invalid and throws a YAML parse error that survives typo fixes (the error is structural, not textual). It belongs at the **version level**, a sibling of `defined_in:`/`config:`:
+```yaml
+versions:
+  - v: 1
+    include: all
+    exclude: [deprecated_col]
+    # NOT under columns:
+```
+Symptom: a dbt YAML parse error pointing at the wrong line that persists after every typo fix.
+
+## Provenance
+Distilled from real Snowflake/dbt debugging sessions, stripped of any project data. Complements `querymaster-snowflake` (query authoring) and the DDL-safety skills; this one is specifically the silent/destructive gotcha set.

--- a/skills/tramite-mx-assistant/SKILL.md
+++ b/skills/tramite-mx-assistant/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: tramite-mx-assistant
+description: Asistente de trámites gubernamentales/burocráticos guiado por agente. Reúne la identidad del operador desde los conectores (Gmail/WhatsApp/Drive/archivos locales), maneja un portal oficial con agent-browser (o Skyvern para formularios WRITE pesados), se DETIENE en los muros que por diseño son humanos (reCAPTCHA/Turnstile, OTP, pago con tarjeta, biométricos de primera vez), entrega al humano solo eso, y recoge el resultado (PDF) del correo. Úsalo para constancias de antecedentes penales, actas, apostillas, citas consulares, visados, SAT/IMSS y trámites análogos. NO intenta vencer captchas ni automatizar pagos.
+---
+
+# Trámite MX Assistant (asistente de trámites guiado)
+
+Patrón destilado de una corrida real (constancia de antecedentes penales federales para un visado de España). La meta NO es automatizar el 100%; es que el agente haga el 90% (reunir datos, llenar campos, recoger el PDF) y el humano solo toque lo irreducible.
+
+## Regla de oro (antes de construir nada)
+¿Ya existe en open source? Si sí y es gratis/OSS, **se adopta y se mejora**, no se reinventa. Para WRITE-tasks de formularios de gobierno el adoptado es **Skyvern** (`github.com/skyvern-ai/skyvern`, AGPL-3.0, self-host Docker, MCP-ready, "mejor en tareas WRITE: llenar forms, login, descargar"). agent-browser es el motor ligero por defecto; Skyvern es el upgrade para portales complejos o repetitivos.
+
+## Flujo (4D)
+1. **Censo de conectores (Delegate Q2).** `claude mcp list` + revisar Gmail/WhatsApp/Drive/archivos locales. Los datos de identidad (CURP, datos del acta, ID) casi siempre YA existen en el correo o en disco. No los pidas si puedes leerlos. Caso real: la CURP venía en un correo previo; el acta en PDF ya estaba en el repo.
+2. **Reúne los insumos.** Acta/ID en PDF legible <2MB (requisito típico gob.mx). Extrae datos con `pdftotext`/visión, nunca los inventes.
+3. **Maneja el portal.** agent-browser: `open` → `snapshot -i` → actúa sobre `@eN` → re-snapshot. Si el botón abre un modal Bootstrap (`data-toggle="modal"`), dispáralo por JS si el ref no aparece. Llena todo lo que NO sea secreto.
+4. **DETENTE en los muros humanos (no negociable):**
+   - **reCAPTCHA / Cloudflare Turnstile / captcha de imagen** → SIEMPRE humano. No se brinca, ni con Skyvern. (Mismo patrón que CF Dashboard Turnstile.)
+   - **OTP / 2FA / login con contraseña** (Llave MX, gob.mx) → el humano teclea; el agente nunca captura ni guarda la credencial.
+   - **Pago con tarjeta** (BBVA, línea de captura) → humano.
+   - **Biométricos de primera vez** (ej. carta no antecedentes Jalisco estatal: 1ª vez presencial) → humano.
+5. **Recoge el resultado.** El PDF suele llegar por correo (link válido N días). Búscalo con el Gmail MCP y descárgalo a la carpeta del trámite.
+6. **Encadena el siguiente paso.** Muchos trámites tienen un paso 2 (ej. apostilla en línea del documento federal en `apostillaylegalizacionmexico.segob.gob.mx`). Déjalo agendado/listo.
+
+## Avisar al humano cuando se necesita su mano
+Cuando el flujo topa un muro humano y el operador no está, AVÍSALE. Hoy: el Gmail MCP **sí** envía correo → usa eso. El WhatsApp MCP conectado suele ser **solo lectura** (sin `send_message`); para WhatsApp saliente hay que habilitar el bridge (`lharies/whatsapp-mcp`). Disclose el gap con 💡 Unlock-suggestion.
+
+## Anti-patrones
+- Pedirle al operador un dato que ya está en su correo/disco (haz el censo primero).
+- Intentar resolver un captcha (pérdida de tiempo + frágil + contra el diseño del sitio).
+- Capturar/loggear contraseñas o datos de tarjeta.
+- Apostillar/sacar con mucha anticipación documentos de vida corta (médico <3 meses, penales): hazlo cerca de la cita.
+
+## Provenance
+Cita cada requisito con su fuente oficial; los blogs/gestores valen como contexto pero si chocan con la fuente oficial, gana la oficial y el blog se marca "a verificar". Relacionado: agent-browser, harmonization-over-accretion, reflexes-over-discipline.


### PR DESCRIPTION
Two generic brain skills.

- **snowflake-dbt-pitfalls**: 5 silent/destructive Snowflake+dbt footguns with concrete preventions (CREATE OR REPLACE wipes Time Travel, Dynamic Table limits, PIVOT dotted identifiers, dbt source freshness filter/identifier, versioned-model YAML placement).
- **tramite-mx-assistant**: guided government-paperwork assistant pattern (connectors -> portal via agent-browser/Skyvern -> stop at human walls -> collect PDF).

Distilled from a ChatGPT-export migration. Zero client/personal data (leak-checked). Connectome will index on next master-side regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)