### PR TITLE
docs(memory): complete the bio-trio — immune system (learning) + ant stigmergy (coordination)

### DIFF
--- a/docs/architecture/memory-model.md
+++ b/docs/architecture/memory-model.md
@@ -39,7 +39,13 @@ The octopus says *where* memory lives. It doesn't say *how* an arm's lesson beco
 - **Memory cells** = the lesson becomes durable and body-wide. A generic skill or lesson is promoted to the central brain, available to every future arm, the way memory B and T cells make the whole body faster next time.
 - **Store the pattern, not the antigen.** Immune memory keeps the generalized receptor, never a copy of the pathogen. That is the distil-upward rule exactly: the *generic* lesson rises; the arm's *specific* data stays sealed and never travels. The seal and the upward path are the same invariant seen from two angles.
 
-Octopus = the spatial layer (1 + N sealed brains). Immune system = the learning layer (local to durable generic, pattern up, specifics sealed).
+## How machines stay in sync: ant stigmergy
+
+The octopus is one body, so it says nothing about many machines running one brain. That coordination has its own right model: **stigmergy**, how ants coordinate without talking. Each ant deposits a trace in a shared medium and senses what others left; the field coordinates, not direct contact.
+
+The machines never talk to each other. They read and write one shared medium, the git remote, which is the pheromone field. `ai-sync` is the stigmergic act: deposit (push) and sense (pull --rebase), then act. No central controller, no machine-to-machine messaging, so it scales to any number of machines. Convergence comes from repeated deposit-and-sense, the way pheromone accumulates onto one path. Honest limit: the field coordinates, it doesn't resolve. A same-line conflict is two crossing trails the medium won't adjudicate, so it stops for a human.
+
+Octopus = the spatial layer (1 + N sealed brains). Immune system = the learning layer (local to durable generic, pattern up, specifics sealed). Stigmergy = the coordination layer (many machines, one shared field, no central controller).
 
 ## The two tiers
 

--- a/docs/architecture/memory-model.md
+++ b/docs/architecture/memory-model.md
@@ -31,6 +31,16 @@ trying to cram the central brain into one tentacle. Anatomically impossible — 
 arm already has its own brain, the center has its own. A standalone brain-owned
 memory repo is the only morphologically correct shape.
 
+## How memory rises: the immune system
+
+The octopus says *where* memory lives. It doesn't say *how* an arm's lesson becomes a generic brain memory, and biologically it can't (octopus arms don't consolidate learning upward). That mechanism has a different right model: the **immune system**.
+
+- **Clonal selection** = a local encounter triggers learning. An arm hits a specific problem; solving it is the antigen encounter.
+- **Memory cells** = the lesson becomes durable and body-wide. A generic skill or lesson is promoted to the central brain, available to every future arm, the way memory B and T cells make the whole body faster next time.
+- **Store the pattern, not the antigen.** Immune memory keeps the generalized receptor, never a copy of the pathogen. That is the distil-upward rule exactly: the *generic* lesson rises; the arm's *specific* data stays sealed and never travels. The seal and the upward path are the same invariant seen from two angles.
+
+Octopus = the spatial layer (1 + N sealed brains). Immune system = the learning layer (local to durable generic, pattern up, specifics sealed).
+
 ## The two tiers
 
 | Tier | What it holds | Where it lives | Syncs to |

--- a/skills/octorato-symbolism/SKILL.md
+++ b/skills/octorato-symbolism/SKILL.md
@@ -50,7 +50,17 @@ The octopus explains *where* memory lives and *that* arms are autonomous. It doe
 - **Memory cells.** After the encounter the body keeps long-lived memory B and T cells, so the next encounter anywhere is handled fast. The lesson becomes a brain-level skill every arm can reach.
 - **It stores the pattern, not the pathogen.** Immune memory keeps the generalized receptor that recognizes a class of threat, never a copy of the antigen. That is the upward-distillation rule, biologically exact: the *generic* lesson rises to the central brain, while the arm's *specific* data stays sealed and never travels.
 
-Two anchors, one model: the **octopus** is the spatial layer (one brain, N sealed arms, autonomy, isolation); the **immune system** is the learning layer (local encounter to durable generic memory, pattern up, specifics sealed).
+### Ant stigmergy → cross-machine coordination
+
+One half is still missing: how many machines running one brain stay in sync, with no central controller and without talking to each other. The octopus is one body; it has nothing to say about many bodies. The right model here is **stigmergy**, the way ants coordinate.
+
+Ants don't message each other. Each one deposits a pheromone trace in a shared medium and senses the traces others left; coordination emerges from the field, not from direct contact. Octorato syncs the same way. The machines never talk to each other. They read and write one shared medium, the git remote, which is the pheromone field. `ai-sync` is the stigmergic act: deposit your work (push) and sense the field (pull --rebase), then act on what you find.
+
+- **No central controller, no direct messaging.** A machine never knows another exists; it only reads and writes the shared field. That's why it scales: 3 machines or 30, there's no machine-to-machine chatter, just the field.
+- **Convergence by reinforcement.** Ants converge on a path as pheromone accumulates; the brain converges to one consistent state as machines keep depositing and sensing (`ai-sync`'s rebase-and-retry).
+- **Honest limit.** A pheromone field coordinates, it doesn't *resolve*. Two ants can lay crossing trails and the ground won't pick a winner. Same here: git detects a same-line conflict but can't resolve it, so that one case stops for a human. The medium coordinates; it never adjudicates.
+
+Three anchors, one model: the **octopus** is the spatial layer (one brain, N sealed arms, autonomy, isolation), the **immune system** is the learning layer (local encounter to durable generic memory, pattern up, specifics sealed), and **stigmergy** is the coordination layer (many machines, one shared field, no central controller).
 
 ## The Tesseract → 4D
 

--- a/skills/octorato-symbolism/SKILL.md
+++ b/skills/octorato-symbolism/SKILL.md
@@ -42,6 +42,16 @@ arm-brain, sealed, and only distil *upward* once made generic. Most knowledge is
 arm-local (the 2/3), so the central brain — and the public framework that ships it —
 stays lean. Full model: `docs/architecture/memory-model.md`.
 
+### The immune system → upward learning
+
+The octopus explains *where* memory lives and *that* arms are autonomous. It does not explain *how* a lesson learned in one arm becomes a durable, generic memory for the whole brain, and biologically it can't: an octopus's arms don't share what they learn upward. So for the upward half of the model the right animal isn't the octopus, it's the **immune system**, which learns exactly the way Octorato is meant to.
+
+- **Clonal selection.** A cell meets a specific threat locally; the one that recognizes it is selected and proliferates. An arm hits a specific problem and solves it.
+- **Memory cells.** After the encounter the body keeps long-lived memory B and T cells, so the next encounter anywhere is handled fast. The lesson becomes a brain-level skill every arm can reach.
+- **It stores the pattern, not the pathogen.** Immune memory keeps the generalized receptor that recognizes a class of threat, never a copy of the antigen. That is the upward-distillation rule, biologically exact: the *generic* lesson rises to the central brain, while the arm's *specific* data stays sealed and never travels.
+
+Two anchors, one model: the **octopus** is the spatial layer (one brain, N sealed arms, autonomy, isolation); the **immune system** is the learning layer (local encounter to durable generic memory, pattern up, specifics sealed).
+
 ## The Tesseract → 4D
 
 The 4D Paradigm — **D**escribe → **D**elegate → **D**iligent → **D**isclose — is named *4D* deliberately. A tesseract is the 4-dimensional analog of a cube: a hypercube.


### PR DESCRIPTION
## Why
A multidisciplinary review (biology lens) found the memory/sync metaphor was carrying more than one organism should. The **octopus** is the right model for *where* memory lives and arm autonomy, but it can't explain two other things the framework actually does: how a local lesson becomes durable generic memory, and how many machines running one brain stay in sync. Octopus arms don't consolidate learning upward, and an octopus is one body. So this completes the model with the two organisms that fit those jobs.

## What — three anchors, one model
Adds two sections (in `skills/octorato-symbolism/SKILL.md` and `docs/architecture/memory-model.md`):

- **Immune system → the learning layer.** Clonal selection = a local encounter triggers learning. Memory cells = the lesson becomes durable and body-wide. It stores the *pattern, not the antigen*, which is the distill-upward rule biologically exact: the generic lesson rises, the arm's specific data stays sealed.
- **Ant stigmergy → the coordination layer.** Machines never talk to each other; they deposit and sense traces in one shared medium (the git remote = the pheromone field). `ai-sync` is the stigmergic act (deposit = push, sense = pull --rebase). No central controller, no machine-to-machine messaging, so it scales to any N. Honest limit kept: the field coordinates, it doesn't resolve, so a same-line conflict stops for a human.

| Anchor | Layer | Job |
|---|---|---|
| Octopus | spatial | where memory lives, arm autonomy, isolation (1 + N sealed brains) |
| Immune system | learning | local lesson to durable generic memory, pattern up, specifics sealed |
| Ant stigmergy | coordination | many machines, one shared field, no central controller |

The octopus claim is unchanged and still correct; this adds the two missing mechanisms, it doesn't replace anything.

## Scope / Impact Radius
Touches only the two depth docs where the memory model's rationale lives. The surfaces that mention the 1+N model (CLAUDE.md, README, Glossary) describe location/scope, unchanged, so they're a conscious skip.

## Verified
- 0 em-dash in the added lines (cadence canon); pre-existing em-dashes elsewhere in these files are out of scope.
- All sections render; diff limited to the two files (+36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)