### PR TITLE
docs: broaden "arm" to any sealed world + wire the first-user funnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 📄 **White paper:** [Octorato — An Organic, File-Native Model of Artificial Agency](WHITEPAPER.md) · 🌐 [Live: dataqbs.com/octorato](https://www.dataqbs.com/octorato) · 📣 [Launch article](https://www.linkedin.com/pulse/introducing-octorato-open-source-finops-brain-ai-agents-dataqbs-trbjc) · 🛠️ [Built with Octorato](SHOWCASE.md) · 📘 [dataqbs on Facebook](https://www.facebook.com/dataQBS/)
 
-> 🧑‍💻 **New here? [Start Here → contributing guide](https://github.com/CarlosCaPe/octorato/issues/34).** Grab a [good first issue](https://github.com/CarlosCaPe/octorato/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22), see where we're headed in the [ROADMAP](ROADMAP.md), or shape the architecture in the [RFCs](https://github.com/CarlosCaPe/octorato/discussions). Newcomers welcome — we credit every contributor. 🐙
+> 🧑‍💻 **New here? [Try it in 5 minutes](#try-it-in-5-minutes), then [help build it](https://github.com/CarlosCaPe/octorato/issues/34).** Grab a [good first issue](https://github.com/CarlosCaPe/octorato/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22), see where we're headed in the [ROADMAP](ROADMAP.md), or shape the architecture in the [RFCs](https://github.com/CarlosCaPe/octorato/discussions). Newcomers welcome, we credit every contributor. 🐙
 
 <!-- TODO(demo): add a terminal demo here — asciinema cast or GIF of "natural language → shipped product". Tracked as a maintainer follow-up. -->
 
@@ -287,7 +287,7 @@ Fork → branch off `test` → PR against `test`. Full guide: [CONTRIBUTING.md](
 
 ## Architecture — CLASS / OBJECT / ARM
 
-The framework uses an object-oriented inheritance model: **BRAIN = CLASS** (this public repo, the DNA) → **COMPANY BRAIN = OBJECT** (your private `~/.claude/company/`, gitignored) → **ARMS = PROPERTIES** (isolated per-client repos that never see each other).
+The framework uses an object-oriented inheritance model: **BRAIN = CLASS** (this public repo, the DNA) → **COMPANY BRAIN = OBJECT** (your private `~/.claude/company/`, gitignored) → **ARMS = PROPERTIES** (isolated, sealed worlds that never see each other: a client, a project, a topic, a course).
 
 The brain ships the engine — 4D Paradigm, connectome, agents, skills, enforcement scripts, templates. The company brain holds your identity and arm definitions. Each arm holds one client's context, sealed.
 
@@ -756,7 +756,7 @@ ai-pull --status
 ├── commands/                ← Slash command definitions
 ├── templates/
 │   ├── company/             ← Template for your private company brain
-│   ├── arm/                 ← Template for new client projects
+│   ├── arm/                 ← Template for new arms (any sealed world)
 │   └── skill/               ← Template for new skills
 └── company/                 ← YOUR private brain (gitignored, never committed)
     ├── COMPANY.md           ← Your identity, arms, connections

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -133,7 +133,7 @@ Four architectural layers, each with a fixed location on disk and a defined isol
 | **Brain** | `~/.claude/` | Shared across all arms — the generic CLASS. |
 | **Agents** | `~/.claude/agents/` (+ `REGISTRY.md`) | Generic personas, no client data. |
 | **Skills** | `~/.claude/skills/` | Generic techniques, no client data. |
-| **Arm** | `<CLIENT>/` (per-client repo, e.g. `~/Documents/github/<CLIENT>/`) | Per-client repo, fully sealed. |
+| **Arm** | `<WORLD>/` (one sealed repo per world, e.g. `~/Documents/github/<WORLD>/`) | Per-world repo, fully sealed: a client, a project, a topic, a course. |
 | **Arm instructions** | `<CLIENT>/.claude/CLAUDE.md` | Single source of truth for that arm. |
 
 Two properties to internalize:

--- a/docs/wiki/Glossary.md
+++ b/docs/wiki/Glossary.md
@@ -23,7 +23,7 @@ Sync script (in `~/.local/bin/`) that pulls the latest brain from the `octorato`
 Sync script that commits and pushes all `~/.claude/` changes to GitHub, regenerates the [[#Connectome (neural_map.json)]], and syncs every arm. It runs [[#check-generic]] first as a safety gate. The "broadcast" half of multi-machine sync. Usage: `ai-push "feat(brain): add new skill"`.
 
 ### Arm
-An **isolated client project** — one sealed repo per client, living outside the brain (e.g. `~/projects/<client>/`). Each arm carries its own `.claude/CLAUDE.md` as its single source of truth and its own sealed **[[#Arm memory]]** repo for client-specific knowledge. Arms are the *PROPERTIES* in the [[#CLASS / OBJECT / ARM]] model and the *WHERE* (FOR WHOM) in the [[#Activation stack]]. Named for the octopus's eight semi-autonomous arms, two-thirds of whose neurons live in the limb, not the central brain — most operational knowledge is arm-local.
+An **isolated, sealed world**, one sealed repo living outside the brain (e.g. `~/projects/<world>/`). A world is any context you keep separate: a client, a side project, a research topic, a course. Each arm carries its own `.claude/CLAUDE.md` as its single source of truth and its own sealed **[[#Arm memory]]** repo for that world's knowledge. Arms are the *PROPERTIES* in the [[#CLASS / OBJECT / ARM]] model and the *WHERE* (FOR WHOM) in the [[#Activation stack]]. Named for the octopus's eight semi-autonomous arms, two-thirds of whose neurons live in the limb, not the central brain, so most operational knowledge is arm-local.
 
 ### Arm isolation
 The framework's hardest invariant: **an arm never knows another arm exists.** No client data, names, or credentials ever flow arm→arm. The brain sees each arm's cost data but the arms never see each other. This is a *deliberate departure from the biology* — real octopus arms have some peripheral cross-talk; Octorato enforces total sideways isolation for client-data security. Marketed as "air-gapped arms" (software-level isolation between workspaces).
@@ -64,7 +64,7 @@ A per-arm spending ceiling defined in `budgets.yaml`. `budget-check.py` computes
 The object-oriented inheritance model of the framework:
 - **CLASS** = the [[#Brain]] (`~/.claude/`, open-source, the DNA — paradigms, agents, skills, scripts).
 - **OBJECT** = your [[#Company brain]] (`~/.claude/company/`, gitignored — your identity, your arm definitions).
-- **ARM** = the client projects themselves (isolated repos, each with its own `CLAUDE.md`).
+- **ARM** = the sealed worlds themselves (isolated repos, each with its own `CLAUDE.md`): a client, a project, a topic, a course.
 
 The CLASS *instantiates* into your OBJECT, which *manages* the ARMS. Generic knowledge inherits downward; nothing private leaks upward into the public CLASS.
 


### PR DESCRIPTION
## Why
The README-top reposition (#144) made an arm "any sealed world (client, project, topic, course)", but several surfaces still said "client project", and the "New here?" line still pointed only to the contributor guide, not the 5-minute quickstart (#143). This is the impact-radius follow-through.

## What
- **Wire the funnel**: `New here?` now leads with **[Try it in 5 minutes]** (the user path), then contributing.
- **Broaden "arm" → "sealed world"** in the surfaces that lagged: the CLASS/OBJECT/ARM line, the repo-structure template comment, the Architecture wiki Arm row, and the Glossary definition (a world = a client, a project, a topic, a course).
- Conscious skip: the Architecture.md ASCII-box line (fixed-width alignment, cosmetic) left as-is to avoid breaking the diagram.

## Verified
- 0 em-dash in the added lines (cadence canon).
- `#try-it-in-5-minutes` anchor exists on master (added by #143), so the new link resolves.
- Diff limited to README + 2 wiki docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)