### PR TITLE
chore(funding): enable GitHub Sponsors handle in FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: [CarlosCaPe]
 custom: ["https://dataqbs.com/donate"]


### PR DESCRIPTION
Adds `github: [CarlosCaPe]` to `.github/FUNDING.yml` alongside the existing custom donate URL, so the repo's Sponsor button lights the GitHub Sponsors option once the profile is published.

Note: the GitHub Sponsors button only renders after the Sponsors profile is live (Stripe Connect onboarding + identity/bank done at github.com/sponsors/CarlosCaPe). Merge anytime; it's inert until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)