### PR TITLE
feat(brain): Phase 2 — OO mechanism hierarchy + schema hardening

### DIFF
--- a/registry/rules.schema.json
+++ b/registry/rules.schema.json
@@ -73,6 +73,11 @@
           "if": { "properties": { "category": { "enum": ["SECURITY", "GENERIC", "ARCHITECTURE"] } } },
           "then": { "properties": { "strength": { "enum": ["GATE", "REFLEX", "DETECTOR"] } } },
           "description": "A SECURITY/GENERIC/ARCHITECTURE rule at PRESENCE is itself CORRUPT (understated strength)."
+        },
+        {
+          "if": { "properties": { "mechanism": { "contains": { "type": "object", "required": ["kind"], "properties": { "kind": { "const": "Presence" } } } } } },
+          "then": { "properties": { "category": { "not": { "enum": ["SECURITY", "GENERIC", "ARCHITECTURE"] } } } },
+          "description": "Closes the Presence-escape-hatch: a Presence (null-mechanism) entry on a SECURITY/GENERIC/ARCHITECTURE rule would falsely satisfy coverage with zero enforcement. Forbidden."
         }
       ]
     },

--- a/scripts/brain_doctor.py
+++ b/scripts/brain_doctor.py
@@ -581,6 +581,90 @@ def _claude_anchors() -> list:
     return anchors
 
 
+# --- OO mechanism hierarchy (Phase 2): strength == subclass, verify() is polymorphic ---
+
+class Mechanism:
+    """A backing mechanism for a rule. Subclass per enforcement strength."""
+    def __init__(self, d: dict):
+        self.kind = d.get("kind")
+        self.canonical_name = d.get("canonical_name")
+        self.firing_event = d.get("firing_event")
+        self.firing_matcher = d.get("firing_matcher") or "*"
+
+    def verify(self, hooks: set):
+        """Return a one-line failure string, or None if this mechanism is live."""
+        cn = self.canonical_name
+        if not cn:
+            return None  # a null-script mechanism is verified at the rule's anchor level
+        if not _resolve_script(cn).exists():
+            return f"{cn} MISSING on disk"
+        if self.firing_event in CC_EVENTS:
+            base = os.path.basename(cn)
+            fm = self.firing_matcher
+            hit = any(e == self.firing_event and b == base and (mm == fm or fm == "*" or mm == "*")
+                      for (e, mm, b) in hooks)
+            if not hit:
+                return f"{base} not in hooks.json at {self.firing_event}|{fm}"
+        return None
+
+
+class Gate(Mechanism):
+    pass
+
+
+class Reflex(Mechanism):
+    pass
+
+
+class Detector(Mechanism):
+    pass
+
+
+class Presence(Mechanism):
+    def verify(self, hooks: set):
+        return None  # presence rules are covered by the rule's ANCHOR_PRESENT check, not a script
+
+
+_MECH_BY_KIND = {"Gate": Gate, "Reflex": Reflex, "Detector": Detector, "Presence": Presence}
+
+
+def make_mechanism(d: dict) -> Mechanism:
+    return _MECH_BY_KIND.get(d.get("kind"), Mechanism)(d)
+
+
+class Rule:
+    def __init__(self, d: dict):
+        self.id = d.get("id", "?")
+        self.category = d.get("category", "?")
+        self.strength = d.get("strength", "?")
+        self.anchor = (d.get("source") or {}).get("anchor", "")
+        self.mechanisms = [make_mechanism(m) for m in d.get("mechanism", [])]
+
+    def anchor_failure(self, claude_text: str):
+        if self.anchor and self.anchor not in claude_text:
+            return f"{self.id}: anchor '{self.anchor}' absent"
+        return None
+
+    def wiring_failures(self, hooks: set) -> list:
+        out = []
+        for m in self.mechanisms:
+            f = m.verify(hooks)
+            if f:
+                out.append(f"{self.id}: {f}")
+        return out
+
+
+class Registry:
+    def __init__(self, raw):
+        rules = raw.get("rules", []) if isinstance(raw, dict) else []
+        self.rules = [Rule(r) for r in rules]
+
+    @classmethod
+    def load(cls, path: Path):
+        import yaml
+        return cls(yaml.safe_load(path.read_text(encoding="utf-8")))
+
+
 def check_registry(fix: bool) -> list:
     """RULE #1: every registry rule must be wired; unwired = CORRUPT (FAIL)."""
     if not REGISTRY_PATH.exists():
@@ -616,30 +700,16 @@ def check_registry(fix: bool) -> list:
     except Exception as e:
         out.append(Result("registry-schema", FAIL, f"schema check crashed: {e}", "pip install jsonschema"))
 
-    # D2 forward anchors + D3 per-rule wiring
+    # D2 forward anchors + D3 per-rule wiring (polymorphic via the Mechanism hierarchy)
+    registry = Registry(reg)
     hooks = _hooks_index()
     ctext = _rt(CLAUDE_MD)
     wiring_fail, anchor_fail = [], []
-    for r in rules:
-        rid = r.get("id", "?")
-        anchor = (r.get("source") or {}).get("anchor", "")
-        if anchor and anchor not in ctext:
-            anchor_fail.append(f"{rid}: anchor '{anchor}' absent")
-        for m in r.get("mechanism", []):
-            cn = m.get("canonical_name")
-            if not cn:
-                continue
-            if not _resolve_script(cn).exists():
-                wiring_fail.append(f"{rid}: {cn} MISSING on disk")
-                continue
-            fe = m.get("firing_event")
-            if fe in CC_EVENTS:
-                fm = m.get("firing_matcher") or "*"
-                base = os.path.basename(cn)
-                hit = any(e == fe and b == base and (mm == fm or fm == "*" or mm == "*")
-                          for (e, mm, b) in hooks)
-                if not hit:
-                    wiring_fail.append(f"{rid}: {base} not in hooks.json at {fe}|{fm}")
+    for rule in registry.rules:
+        af = rule.anchor_failure(ctext)
+        if af:
+            anchor_fail.append(af)
+        wiring_fail.extend(rule.wiring_failures(hooks))
     out.append(Result("registry-wiring", FAIL if wiring_fail else PASS,
                       f"all {len(rules)} rules wired (disk + hooks.json)"
                       if not wiring_fail else "; ".join(wiring_fail[:5]),

--- a/scripts/brain_doctor.py
+++ b/scripts/brain_doctor.py
@@ -608,6 +608,8 @@ class Mechanism:
         return None
 
 
+# Gate/Reflex/Detector share the base verify() today; the subclasses are intentional
+# extension points for per-strength liveness later (e.g. EXIT_CODE --selftest for Gates).
 class Gate(Mechanism):
     pass
 
@@ -800,7 +802,14 @@ def main() -> int:
                     help="run ONLY the RULE #1 registry checks (for .githooks/pre-push)")
     args = ap.parse_args()
 
-    results = check_registry(args.fix) if args.registry else run_all(args.fix)
+    if args.registry:
+        try:
+            results = check_registry(args.fix)
+        except Exception as e:
+            results = [Result("rule-1-registry", FAIL, f"registry check crashed: {e}",
+                              "fix registry/rules.yaml so it loads and validates")]
+    else:
+        results = run_all(args.fix)
     fails = sum(1 for r in results if r.status == FAIL)
 
     if args.json:


### PR DESCRIPTION
## Phase 2 — Wired or Corrupt: OO mechanism hierarchy + schema hardening

Modernizes the registry enforcement to an object-oriented model (operator directive) and closes the one integrity hole QA flagged in Phase 1. Builds on #165 + #166. Design: `docs/architecture/wired-or-corrupt.md`.

### What lands
- **registry/rules.schema.json**: closes the **Presence-escape-hatch**. A `Presence` (null-mechanism) entry on a SECURITY/GENERIC/ARCHITECTURE rule would have falsely satisfied coverage with zero enforcement; the schema now rejects it.
- **scripts/brain_doctor.py**: refactors the inline wiring logic into an **OO Mechanism hierarchy** (`Mechanism` base + `Gate`/`Reflex`/`Detector`/`Presence` with polymorphic `verify()`) + `Rule` + `Registry`. `check_registry` dispatches through them. Behavior-preserving. Plus a crash-wrap so a malformed registry yields a clean FAIL line (push still blocks), and a comment marking the subclasses as extension points for per-strength liveness.

### Verified
- **Behavior-preserving**: `--registry` output is byte-identical to the pre-refactor logic (5 PASS, coverage 100% 35/35, exit 0).
- **Teeth hold**: phantom mechanism → registry-wiring FAIL exit 1; orphan heading → registry-coverage FAIL exit 1 (both reverted clean).
- **Schema hole closed**: ARCH/SEC + Presence REJECTED; FLOW+Presence and ARCH+Gate ACCEPTED; the 42 live rules still validate (no false rejection).
- **Crash-safe**: malformed registry → clean FAIL, no traceback, exit 1.
- Independent QA (Code Reviewer agent): APPROVE, 0 blocking, 6/6 criteria PASS by live execution. Its 2 nits were applied in this PR.

### Deferred to a later phase (stated, not dropped)
Generating `hooks.json` from the manifest + the D5 drift gate. Both are entangled with the pre-existing `settings.json`↔`hooks.json` drift; inverting the source of truth carelessly would break every hook. That needs its own pass with a byte-equivalence proof before flipping.

### Merge gate
Fail-closed. Agent cannot self-approve. Operator: `python3 ~/.claude/scripts/octo-dim.py approve-merge <pr>`, then I merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
