### PR TITLE
docs: document Wired or Corrupt (RULE #1) across README, FAQ, wiki, whitepaper

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -34,6 +34,10 @@ Yes — MIT licensed, public on GitHub. You can read, fork, and self-host the en
 
 Every action follows four phases: **Describe** (state what and why), **Delegate** (search/verify before generating), **Diligent** (validate output with evidence), **Disclose** (state side effects and impact). It is the nervous system that makes each action describable, delegated, verified, and disclosed.
 
+## What stops a rule from being just ignored prose?
+
+**RULE #1: every rule must be wired, or the brain is corrupt.** A rule counts as real only when `registry/rules.yaml` maps it to a live mechanism (a hook, a gate, a detector). `brain_doctor` checks this in both directions: every rule in the constitution has a mechanism, and every live hook has a rule. If one is missing, the doctor declares the brain corrupt and the pre-push hook blocks the push. No force, no exception, no soft-fail. So a rule cannot quietly decay into advisory prose the model skips under load. Model-behavior rules (tone, no-hallucination, identity) are still registered, backed by a detector or a presence-assert. Full design: [`docs/architecture/wired-or-corrupt.md`](docs/architecture/wired-or-corrupt.md).
+
 ## Who maintains Octorato?
 
 Carlos Carrillo (Guadalajara, Mexico), through dataqbs. The productized "AI Agent OS" runs at [dataqbs.com](https://dataqbs.com), built and operated on this brain.

--- a/README.md
+++ b/README.md
@@ -309,6 +309,18 @@ Full protocol, gate formats, validation matrix, enforcement scripts, and the WHI
 
 ---
 
+## Wired or Corrupt: the brain enforces itself
+
+Most agent instructions are prose the model can skip under load. Octorato refuses that. **RULE #1 is the constitution's first rule: every rule must be wired.** A rule is wired only when `registry/rules.yaml` maps it to a live mechanism (a hook, a gate, a detector). A rule that exists as prose with no registered, live mechanism is not a rule. It is rot, and a brain that carries it is **CORRUPT**.
+
+`brain_doctor` is the mechanism of that rule. It loads the registry, asserts every rule is wired, and reconciles **both directions**: every CLAUDE.md rule has a mechanism, and every live hook has a rule. One miss and the doctor declares the brain corrupt, exits non-zero, and `.githooks/pre-push` **blocks the push**. No `--force`, no soft-fail. A documented-but-absent hook can no longer ship.
+
+"Wired" means covered, not mechanically forced. A model-behavior rule (tone, no-hallucination, identity) is backed by a registered detector or a presence-assert, never by bare prose. The Coverage Ledger prints the enforcement strength per rule, so 100% coverage is never misread as 100% force.
+
+Full architecture, the label ontology, and the migration history: [`docs/architecture/wired-or-corrupt.md`](docs/architecture/wired-or-corrupt.md).
+
+---
+
 ## 4D+S — Spec-Driven Development Integration
 
 For tasks above trivial complexity, the 4D integrates with a spec-driven workflow:

--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -93,6 +93,13 @@ is edited — so a change is neither under-applied (a stale reference) nor over-
 (an unintended edit). Feedback alone is tremor; feedforward plus involuntary feedback is
 a steady reach.
 
+The nervous system is itself held to account by RULE #1: every rule in the constitution
+must be wired to a live mechanism registered in `registry/rules.yaml`, or the brain is
+declared CORRUPT and the pre-push hook blocks the push. A `brain_doctor` check reconciles
+both directions (every rule has a mechanism, every live hook has a rule), so a principle
+cannot decay into advisory prose the model skips. Coverage is enforced; the irreducible
+model-behavior rules are still registered, backed by a detector or a presence-assert.
+
 ## 7. The Connectome
 
 The brain's skills and agents form a graph — a TF-IDF and co-activation map that routes

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -303,6 +303,16 @@ The intellectual lineage is math and biology, deliberately: **∞** from John Wa
 
 ---
 
+## 10. Wired or Corrupt: the self-enforcing constitution
+
+Rules used to be prose the model could skip under load. RULE #1 ends that: every rule in `CLAUDE.md` must be wired to a live mechanism, registered in `registry/rules.yaml`. A rule with no registered, live mechanism is not a rule. It is rot, and a brain carrying it is CORRUPT.
+
+`brain_doctor` is RULE #1's own mechanism. It reconciles the registry in **both directions**: every constitution rule has a mechanism, and every live hook has a rule (no orphans). One miss and the doctor exits non-zero, and `.githooks/pre-push` blocks the push. A documented-but-absent hook can no longer ship, which is how the original "phantom script" bug died.
+
+"Wired" means covered, not mechanically forced. Model-behavior rules (tone, no-hallucination, identity) are backed by a registered detector or a presence-assert, and the Coverage Ledger prints the enforcement strength per rule, so coverage is never confused with force. Full design: [`wired-or-corrupt.md`](../architecture/wired-or-corrupt.md).
+
+---
+
 ## See also
 
 - [[The-4D-Paradigm]] — the nervous-system protocol; the Change Gate, the three delegate questions, and the Impact Radius scan.

--- a/docs/wiki/Glossary.md
+++ b/docs/wiki/Glossary.md
@@ -160,6 +160,18 @@ The brain's **multi-engine database CLI** — `qm -e <engine> -c <conn> "<query>
 
 ---
 
+## R
+
+### RULE #1 (Wired or Corrupt)
+
+The constitution's first rule: every rule must be wired to a live mechanism, or the brain is CORRUPT. A rule with no registered, live mechanism in the [[#Rule registry]] is not a rule, it is rot. `brain_doctor` enforces it, reconciling both directions (every rule has a mechanism, every live hook has a rule); a miss exits non-zero and `.githooks/pre-push` blocks the push. "Wired" means covered (a gate, reflex, detector, or presence-assert), not 100% mechanically forced. See [`wired-or-corrupt.md`](../architecture/wired-or-corrupt.md).
+
+### Rule registry
+
+The single source of truth for [[#RULE #1 (Wired or Corrupt)]]: `registry/rules.yaml` maps every constitution rule to its backing mechanism(s), validated by `registry/rules.schema.json`. `brain_doctor` loads it to assert coverage in both directions and prints a Coverage Ledger.
+
+---
+
 ## S
 
 ### Self-growth loop


### PR DESCRIPTION
## docs: Wired or Corrupt (RULE #1) documented everywhere

The v4.0.0 architecture was shipped but undocumented on the public surfaces. This adds it where readers actually land. Doc-only, no code.

### What lands (5 files, 45 insertions)
- **README.md**: a new "Wired or Corrupt: the brain enforces itself" section after the 4D Paradigm.
- **FAQ.md**: a new Q&A, "What stops a rule from being just ignored prose?"
- **WHITEPAPER.md**: a paragraph in the 4D Nervous System section noting RULE #1 holds the nervous system to account.
- **docs/wiki/Architecture.md**: section 10, "Wired or Corrupt: the self-enforcing constitution."
- **docs/wiki/Glossary.md**: new R entries, "RULE #1 (Wired or Corrupt)" + "Rule registry."

All link to the canonical `docs/architecture/wired-or-corrupt.md`. Counts already in sync; wiki catalogs unchanged (Skills/Agents regen was a no-op).

### Verified
- 0 em-dashes in added lines (cadence). check-generic clean (no leak). All additions accurate to the shipped architecture.

### Merge gate
Fail-closed. Operator: `python3 ~/.claude/scripts/octo-dim.py approve-merge <pr>`, then I merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
