### PR TITLE
feat(brain): Phase 5 — close the create-to-register loop (RULE #1 coupling)

### DIFF
--- a/scripts/brain_doctor.py
+++ b/scripts/brain_doctor.py
@@ -778,8 +778,41 @@ def check_naming(fix: bool) -> list:
                    "new hook scripts must match the scheme in registry/naming-policy.yaml")]
 
 
+def _scaffold_orphan_stubs(orphans, idx) -> int:
+    """Append a TODO stub rule per orphan hook to rules.yaml. Idempotent: the caller passes only
+    hooks that are NOT a canonical_name in the registry, so a scaffolded stub (which registers the
+    name) drops out of the orphan set on the next run and is never re-appended. The stub keeps a
+    TODO anchor on purpose: it scaffolds the YAML skeleton but stays FAIL (registry-anchors) until
+    the operator fills the real anchor, so a gap is never silenced."""
+    blocks = []
+    for base in orphans:
+        ev, mt = next(((e, m) for (e, m, b) in idx if b == base), ("UserPromptSubmit", "*"))
+        slug = (base[:-3] if base.endswith(".py") else base).replace("_", "-").replace(".", "-")
+        blocks.append(
+            f"  - id: TODO.{slug}\n"
+            f"    title: \"TODO describe the rule this hook enforces\"\n"
+            f"    category: FLOW\n"
+            f"    source: {{ file: CLAUDE.md, anchor: \"TODO the heading this rule lives under\" }}\n"
+            f"    strength: REFLEX\n"
+            f"    firing_mode: [hook]\n"
+            f"    mechanism:\n"
+            f"      - {{ kind: Reflex, canonical_name: {base}, firing_event: {ev}, firing_matcher: \"{mt}\" }}\n"
+            f"    proof:\n"
+            f"      - {{ method: IN_HOOKS_JSON, locator: \"{ev}|{mt}|{base}\", expect: present }}\n"
+            f"      - {{ method: ANCHOR_PRESENT, locator: \"TODO the heading this rule lives under\", expect: present }}\n"
+            f"    liveness_required: FIRES\n"
+        )
+    if blocks:
+        with open(REGISTRY_PATH, "a", encoding="utf-8") as f:
+            f.write("\n  # --- brain_doctor --fix: TODO stubs for orphan hooks; fill id/title/category/anchor ---\n")
+            f.write("".join(blocks))
+    return len(blocks)
+
+
 def check_orphan_hooks(fix: bool) -> list:
-    """D4 (RULE #1 bidirectional): every live hook in hooks.json must be claimed by a registry rule."""
+    """D4 (RULE #1 bidirectional): every live hook in hooks.json must be claimed by a registry rule.
+    With --fix, scaffold a TODO stub per orphan so registering a new reflex is one edit, not hand-YAML.
+    The stub stays FAIL until its anchor is filled, so --fix helps but never silences a gap."""
     try:
         reg = Registry.load(REGISTRY_PATH)
     except Exception as e:
@@ -789,12 +822,18 @@ def check_orphan_hooks(fix: bool) -> list:
     # so the two checks together close the loop without double-reporting here.
     registered = {os.path.basename(m.canonical_name)
                   for r in reg.rules for m in r.mechanisms if m.canonical_name}
-    hooked = {base for (_ev, _mt, base) in _hooks_index()}
+    idx = _hooks_index()
+    hooked = {base for (_ev, _mt, base) in idx}
     orphans = sorted(hooked - registered)
+    if orphans and fix:
+        n = _scaffold_orphan_stubs(orphans, idx)
+        return [Result("registry-orphans", FAIL,
+                       f"scaffolded {n} TODO stub(s) in rules.yaml for: {', '.join(orphans)}",
+                       "fill each stub's title/category/anchor in rules.yaml, then re-run (stubs stay FAIL until filled)")]
     return [Result("registry-orphans", FAIL if orphans else PASS,
                    f"all {len(hooked)} live hooks claimed by a registry rule"
                    if not orphans else f"orphan hooks (fire but unregistered): {', '.join(orphans)}",
-                   "register every hooks.json script in registry/rules.yaml (RULE #1 is bidirectional)")]
+                   "register every hooks.json script in registry/rules.yaml, or run brain_doctor --fix to scaffold stubs")]
 
 
 CHECKS = [

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -366,3 +366,17 @@ After testing the skill, users may request improvements. Often this happens righ
 2. Notice struggles or inefficiencies
 3. Identify how SKILL.md or bundled resources should be updated
 4. Implement changes and test again
+
+### Step 7: Wire any reflex (RULE #1)
+
+Most skills are technique docs and ship no automation. But if your skill adds a **reflex** (a hook that fires on its own at a Claude Code event), that reflex MUST be registered, or the brain is corrupt and the push is blocked.
+
+The loop is mandatory and enforced:
+
+1. Add the hook to `hooks.json` (the event-to-script mapping).
+2. Register it in `registry/rules.yaml`: one rule mapping the reflex to the rule it enforces, with a `source.file` + `anchor` (a CLAUDE.md heading, or this skill's own heading).
+3. `brain_doctor --registry` (which the pre-push runs) checks both directions: every rule has a mechanism, and every live hook has a rule. An unregistered reflex is an orphan, the doctor declares the brain CORRUPT, and the push is blocked.
+
+Shortcut: run `python3 ~/.claude/scripts/brain_doctor.py --fix` to scaffold a TODO stub rule for your new hook, then fill its `title`, `category`, and `anchor`. The stub stays FAIL until you fill the anchor, so a gap is never silenced, only made one edit away.
+
+This is why a new reflex, the daily reflection that produces it, and `brain_doctor` form one loop: the brain grows by adding reflexes, and RULE #1 makes "a new reflex must be wired" a hard invariant, so creation and enforcement close into a cycle instead of drifting apart. See [`docs/architecture/wired-or-corrupt.md`](../../docs/architecture/wired-or-corrupt.md).


### PR DESCRIPTION
## Phase 5 — close the create-to-register loop (RULE #1)

Your insight: brain_doctor, the daily reflection, and new-skill reflexes should be coupled. They should, and this closes that loop. Until now a new reflex (a hook a new skill ships) was born an orphan: D4 blocked the push until someone hand-wrote its registry YAML. Now the loop is documented and the registration is one command.

### What lands (2 files)
- **scripts/brain_doctor.py**: `check_orphan_hooks --fix` scaffolds a TODO stub rule for each orphan hook (event/matcher derived from hooks.json), so registering a new reflex is one edit, not hand-YAML. The stub keeps a TODO anchor on purpose and stays FAIL until filled, so `--fix` helps but **never silences** a gap.
- **skills/skill-creator/SKILL.md**: "Step 7: Wire any reflex (RULE #1)" documents the mandatory loop (add hook -> register in rules.yaml -> brain_doctor enforces both directions) and the `--fix` shortcut.

### Why this matters
RULE #1 makes "a new reflex must be wired" a hard invariant. Without coupling, every time the brain learns something new (a reflex from the daily reflection) it breaks itself until a manual fix. Coupled, creation and enforcement form one cycle: the brain grows AND stays 100% wired.

### NOT done (on purpose)
Generating hooks.json from rules.yaml was measured and rejected: rules.yaml describes 29 of 32 placements, missing 7 (trace-hook at 5 events, plus --phase args). Inverting would break observability. rules.yaml is a validation layer, not a generation source.

### Verified
- `--registry` 7/7 PASS, exit 0. Scaffold proven: injected orphan -> TODO stub appended -> next run still RED (gap relocated to registry-anchors, not silenced) -> clean revert.
- Idempotent (2x --fix = 1 stub, via the orphan filter). Derivation correct (PostToolUse|Bash, not hardcoded). Append-only, no silencing path.
- Independent QA (Code Reviewer): APPROVE, 0 blocking, 6/6 PASS. Its nit (fragile substring guard) was fixed.

### Merge gate
Fail-closed. Operator: `python3 ~/.claude/scripts/octo-dim.py approve-merge <pr>`, then I merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
