### PR TITLE
feat(hooks): support Cursor — project hooks.json into ~/.cursor/hooks.json

### DIFF
--- a/commands/brain-doctor.md
+++ b/commands/brain-doctor.md
@@ -32,6 +32,7 @@ Ends with a summary line: `N passed, M warn, K fail`.
 ## Checks
 
 `repo-identity`, `sync-clean`, `interpreter`, `runners-tracked`, `hooks-runtime-sync`,
-`hooks-merge-fresh`, `leak-guard`, `connectome-fresh`, `arms-config`, `sync-targets`, `blocklist`.
+`hooks-merge-fresh`, `cursor-hooks-sync`, `leak-guard`, `connectome-fresh`, `arms-config`,
+`sync-targets`, `blocklist`.
 
 Each check is sandboxed — one failing check never crashes the run.

--- a/scripts/ai_sync.py
+++ b/scripts/ai_sync.py
@@ -265,6 +265,7 @@ def pull(args) -> int:
             info("✓ Already up to date")
 
     script_step("scripts/merge-hooks.py", label="=== Merging shared hooks ===")
+    script_step("scripts/merge-hooks-cursor.py", label="=== Projecting hooks → Cursor ===")
     ensure_hooks_path()
 
     if connectome_stale():  # F9: a pull-only machine otherwise never refreshes the graph

--- a/scripts/brain_doctor.py
+++ b/scripts/brain_doctor.py
@@ -311,6 +311,33 @@ def check_hooks_merge_fresh(fix: bool) -> Result:
     return Result(key, PASS, f"all {len(seen)} hooks.json command(s) reference existing files")
 
 
+def check_cursor_hooks_sync(fix: bool) -> Result:
+    """Octorato also supports Cursor: hooks.json is projected into ~/.cursor/hooks.json
+    by merge-hooks-cursor.py. WARN (never FAIL) — Cursor support is additive and the
+    target is a per-machine runtime artifact absent on CI runners / Claude-only machines."""
+    key = "cursor-hooks-sync"
+    projector = CLAUDE_DIR / "scripts" / "merge-hooks-cursor.py"
+    if not projector.exists():
+        return Result(key, WARN, "scripts/merge-hooks-cursor.py not found",
+                      "restore the Cursor hooks projector")
+    cursor_file = HOME / ".cursor" / "hooks.json"
+    if not cursor_file.exists():
+        if fix:
+            run([PYTHON or "python3", str(projector)], cwd=CLAUDE_DIR)
+            if cursor_file.exists():
+                return Result(key, PASS, "~/.cursor/hooks.json materialized from hooks.json")
+        return Result(key, WARN, "~/.cursor/hooks.json not materialized (Cursor reflexes off)",
+                      "run `python3 scripts/merge-hooks-cursor.py` (or ai-pull) inside Cursor's machine")
+    cp = run([PYTHON or "python3", str(projector), "--check"], cwd=CLAUDE_DIR)
+    if cp.returncode == 0:
+        return Result(key, PASS, "~/.cursor/hooks.json == hooks.json projection")
+    if fix:
+        run([PYTHON or "python3", str(projector)], cwd=CLAUDE_DIR)
+        return Result(key, PASS, "~/.cursor/hooks.json re-projected from hooks.json")
+    return Result(key, WARN, "~/.cursor/hooks.json drifted from hooks.json",
+                  "run `python3 scripts/merge-hooks-cursor.py` (or --fix)")
+
+
 def check_leak_guard(fix: bool) -> Result:
     key = "leak-guard"
     cp = git("config", "core.hooksPath")
@@ -847,6 +874,7 @@ CHECKS = [
     ("runners-tracked", check_runners_tracked),
     ("hooks-runtime-sync", check_hooks_runtime_sync),
     ("hooks-merge-fresh", check_hooks_merge_fresh),
+    ("cursor-hooks-sync", check_cursor_hooks_sync),
     ("leak-guard", check_leak_guard),
     ("connectome-fresh", check_connectome_fresh),
     ("arms-config", check_arms_config),

--- a/scripts/merge-hooks-cursor.py
+++ b/scripts/merge-hooks-cursor.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""merge-hooks-cursor.py — project hooks.json into Cursor's native ~/.cursor/hooks.json.
+
+Octorato's single source of truth for hooks is ~/.claude/hooks.json (Claude Code
+schema). merge-hooks.py projects it DOWN into the per-machine Claude settings.json.
+This sibling projects the SAME source into Cursor's native hook format so the brain's
+reflexes (trace, cadence, canon-heal, impact-radius, delegate/dimension gates, …) fire
+inside the Cursor IDE too — not just Claude Code.
+
+Why a separate projector and not Cursor's third-party Claude-hook loader? Cursor *can*
+read ~/.claude/settings.json directly (Settings → third-party hooks), but that path is a
+per-machine toggle and its matchers are Claude tool-names (Bash, Write|Edit, Skill, Agent)
+which do not line up with Cursor tool-names (Shell, Write, Task). This projector does the
+event + matcher translation so the hooks actually match Cursor's loop, and it is
+version-controlled (regenerated on every ai-pull / ai-sync, exactly like settings.json).
+
+Target: ~/.cursor/hooks.json — a per-machine RUNTIME artifact (gitignored by being outside
+the repo), owned the same way settings.json is. Foreign Cursor events the operator authored
+by hand are preserved; only the events Octorato emits are managed.
+
+Schema (Cursor native):
+  { "version": 1, "hooks": { "<event>": [ { "command", "timeout?", "matcher?" }, ... ] } }
+
+Event map (Claude Code -> Cursor):
+  PreToolUse        -> preToolUse        (matcher tool-names translated)
+  PostToolUse       -> postToolUse       (Shell) / afterFileEdit (Write|Edit)
+  Stop              -> stop
+  SessionStart      -> sessionStart
+  UserPromptSubmit  -> beforeSubmitPrompt
+
+Matcher tool map (Claude -> Cursor):  Bash->Shell, Write->Write, Edit->Write.
+Skill / Agent matchers have no Cursor equivalent and are DROPPED.
+
+Modes:
+  (default)  write ~/.cursor/hooks.json (merge: manage our events, keep foreign ones)
+  --check    compare only; exit 0 in-sync/absent, exit 1 drift; write nothing
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+if sys.platform == "win32":
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, OSError):
+            pass
+
+CLAUDE_DIR = Path(os.path.expanduser("~/.claude"))
+HOOKS_FILE = CLAUDE_DIR / "hooks.json"
+CURSOR_DIR = Path(os.path.expanduser("~/.cursor"))
+CURSOR_HOOKS_FILE = CURSOR_DIR / "hooks.json"
+
+MARKER = "_octorato_managed_events"
+
+# Claude tool-name -> Cursor tool-name (matcher tokens). None == drop the token.
+_TOOL_MAP = {"Bash": "Shell", "Write": "Write", "Edit": "Write",
+             "Skill": None, "Agent": None}
+
+
+def _atomic_write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".tmp-", suffix=".json", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+        os.replace(tmp, str(path))
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _script_exists(command: str) -> bool:
+    """Mirror merge-hooks.py: only project hooks whose target script is present."""
+    m = re.search(r"(?:python3?|bash|sh|node)\s+(~?/\S+)", command)
+    if not m:
+        return True  # not a recognizable script command — keep it
+    return os.path.isfile(os.path.expanduser(m.group(1)))
+
+
+def _map_matcher(matcher: str | None):
+    """(cursor_tokens, dropped_all) — translate Claude matcher tokens to Cursor tool-names."""
+    if not matcher:
+        return [], False
+    tokens = [t.strip() for t in matcher.split("|") if t.strip()]
+    mapped, seen = [], set()
+    for tok in tokens:
+        cur = _TOOL_MAP.get(tok, tok)  # unknown tokens pass through verbatim
+        if cur is None:
+            continue  # Skill / Agent — no Cursor equivalent
+        if cur not in seen:
+            seen.add(cur)
+            mapped.append(cur)
+    dropped_all = bool(tokens) and not mapped
+    return mapped, dropped_all
+
+
+def _target_event(claude_event: str, cursor_tokens: list[str]) -> tuple[str, str | None] | None:
+    """(cursor_event, cursor_matcher) for a Claude event + already-mapped matcher tokens."""
+    if claude_event == "Stop":
+        return "stop", None
+    if claude_event == "SessionStart":
+        return "sessionStart", None
+    if claude_event == "UserPromptSubmit":
+        return "beforeSubmitPrompt", None
+    if claude_event == "PreToolUse":
+        if not cursor_tokens:
+            return None
+        return "preToolUse", "|".join(cursor_tokens)
+    if claude_event == "PostToolUse":
+        if not cursor_tokens:
+            return None
+        # File-edit reflexes belong on Cursor's dedicated afterFileEdit event.
+        if cursor_tokens == ["Write"]:
+            return "afterFileEdit", "Write"
+        return "postToolUse", "|".join(cursor_tokens)
+    return None  # unknown Claude event — skip
+
+
+def build_projection(hooks_data: dict) -> dict:
+    """Claude hooks.json dict -> { cursor_event: [ {command, timeout?, matcher?}, ... ] }."""
+    projection: dict[str, list] = {}
+    for claude_event, entries in hooks_data.items():
+        if claude_event.startswith("$") or not isinstance(entries, list):
+            continue
+        for entry in entries:
+            matcher = entry.get("matcher")
+            cursor_tokens, dropped_all = _map_matcher(matcher)
+            if dropped_all:
+                continue  # e.g. Skill|Agent — nothing maps
+            target = _target_event(claude_event, cursor_tokens)
+            if target is None:
+                continue
+            cursor_event, cursor_matcher = target
+            for hook in entry.get("hooks", []):
+                cmd = hook.get("command", "")
+                if not cmd or not _script_exists(cmd):
+                    continue
+                definition: dict = {"command": cmd}
+                if "timeout" in hook:
+                    definition["timeout"] = hook["timeout"]
+                if cursor_matcher:
+                    definition["matcher"] = cursor_matcher
+                projection.setdefault(cursor_event, []).append(definition)
+    return projection
+
+
+def _load_json(path: Path) -> dict:
+    try:
+        with path.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _canonical(obj) -> str:
+    return json.dumps(obj, indent=2, sort_keys=True, ensure_ascii=False)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Project hooks.json -> ~/.cursor/hooks.json")
+    ap.add_argument("--check", action="store_true",
+                    help="compare only; exit 1 on drift, write nothing")
+    args = ap.parse_args()
+
+    if not HOOKS_FILE.exists():
+        print("  no hooks.json — nothing to project to Cursor")
+        return 0
+
+    hooks_data = _load_json(HOOKS_FILE)
+    projection = build_projection(hooks_data)
+
+    existing = _load_json(CURSOR_HOOKS_FILE)
+    live_hooks = existing.get("hooks", {}) if isinstance(existing.get("hooks"), dict) else {}
+    prev_managed = set(existing.get(MARKER, []))
+
+    # The subset of the live file that WE own (managed events only). Foreign events
+    # the operator authored by hand are intentionally excluded from the comparison.
+    live_managed = {ev: live_hooks[ev] for ev in (prev_managed | set(projection)) if ev in live_hooks}
+
+    in_sync = _canonical(live_managed) == _canonical(projection)
+
+    if args.check:
+        if not CURSOR_HOOKS_FILE.exists():
+            print("  absent — ~/.cursor/hooks.json not materialized (run ai-pull / merge-hooks-cursor.py)")
+            return 0
+        if in_sync:
+            print(f"  ✓ Cursor hooks in sync ({len(projection)} event(s) managed)")
+            return 0
+        print("  ✗ Cursor hooks drift — ~/.cursor/hooks.json differs from hooks.json projection")
+        return 1
+
+    if in_sync and CURSOR_HOOKS_FILE.exists():
+        print("  Cursor hooks already in sync")
+        return 0
+
+    # Merge: drop stale managed events, install the current projection, keep foreign events.
+    new_hooks = dict(live_hooks)
+    for stale in prev_managed - set(projection):
+        new_hooks.pop(stale, None)
+    new_hooks.update(projection)
+
+    out = dict(existing)
+    out["version"] = 1
+    out["hooks"] = new_hooks
+    out[MARKER] = sorted(projection)
+
+    _atomic_write_json(CURSOR_HOOKS_FILE, out)
+    total = sum(len(v) for v in projection.values())
+    print(f"  ✓ Cursor hooks projected -> {CURSOR_HOOKS_FILE} "
+          f"({total} hook(s) across {len(projection)} event(s): {', '.join(sorted(projection))})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
﻿## Summary
Make Octorato support **Cursor**, not just Claude Code. The brain's hooks (trace, cadence, canon-heal, impact-radius, delegate/dimension gates, etc.) now fire inside the Cursor IDE.

- `scripts/merge-hooks-cursor.py` projects the Claude-schema `hooks.json` (source of truth) into Cursor's native `~/.cursor/hooks.json` (per-machine runtime, same ownership model as `settings.json`).
- Event map: `PreToolUse/PostToolUse/Stop/SessionStart/UserPromptSubmit` -> `preToolUse/postToolUse`+`afterFileEdit`/`stop`/`sessionStart`/`beforeSubmitPrompt`.
- Matcher tool-name map: `Bash`->`Shell`, `Write|Edit`->`Write`; `Skill`/`Agent` matchers dropped (no Cursor equivalent).
- Preserves foreign Cursor events; manages only the events Octorato emits (`_octorato_managed_events` marker).
- Wired into `ai_sync.py` pull path beside `merge-hooks.py`.
- New `cursor-hooks-sync` check in `brain_doctor.py` (WARN-level, CI-safe).

## Test plan
- [x] `merge-hooks-cursor.py` generates valid `~/.cursor/hooks.json` (33 hooks / 6 events)
- [x] `--check` reports in-sync
- [x] `brain_doctor.py` -> `cursor-hooks-sync PASS`
- [x] `check-hooks-drift.py` clean (Claude path unaffected)
