### PR TITLE
fix(deps): declare jsonschema + propagate requirements.txt via ai-push

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@
 
 networkx>=3.0   # scripts/query_connectome.py — graph traversal for the connectome
 pyvis>=0.3      # scripts/query_connectome.py — HTML visualization of the connectome
+jsonschema>=4.0 # scripts/brain_doctor.py (registry-schema) + check-hooks-drift.py — JSON Schema validation

--- a/scripts/ai_sync.py
+++ b/scripts/ai_sync.py
@@ -62,7 +62,7 @@ POLICY = CLAUDE / ".githooks" / "push-policy.txt"
 BRAIN_PATHS = ["CLAUDE.md", "README.md", "FAQ.md", "CONTRIBUTING.md", "HEBBIAN_LEARNING.md",
                "CODE_OF_CONDUCT.md", "SECURITY.md", "SUPPORT.md", "CHANGELOG.md",
                "ROADMAP.md", "SHOWCASE.md", "WHITEPAPER.md", "LICENSE",
-               "budgets.yaml.example",
+               "budgets.yaml.example", "requirements.txt",
                "hooks.json", "hooks.schema.json", "skills/", "agents/",
                "scripts/", "hooks/", ".githooks/", "commands/", ".gitignore",
                "assets/", "templates/", ".github/", "connectome/", "docs/"]


### PR DESCRIPTION
﻿## Summary
Fix the `registry-schema` brain-doctor gap and a latent propagation gap.

- Declare `jsonschema>=4.0` in `requirements.txt`. `brain_doctor.py` (`registry-schema`) and `check-hooks-drift.py` import it, but it was undeclared, so a fresh machine / CI fails `registry-schema` with `No module named 'jsonschema'`.
- Add `requirements.txt` to `BRAIN_PATHS` in `ai_sync.py` so `ai-push` actually stages and propagates it. It was being silently dropped (same class as the governance-doc lesson already noted in that file), so dependency changes never reached other machines.

## Test plan
- [x] `brain_doctor.py` -> 23 passed, 0 warn, 0 fail (was 4 fail / 1 warn)
- [x] `python-deps` -> all importable (networkx, pyvis, jsonschema)
- [x] `registry-schema` PASS
