### PR TITLE
feat(observability): schedule daily brain digest via systemd timer (Phase 3b)

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -9,7 +9,7 @@
 | Skills | 231 |
 | Agents | 161 |
 | Divisions | 15 |
-| Scripts: wired | 77 |
+| Scripts: wired | 78 |
 | Scripts: orphan | 6 |
 | Rules | 50 |
 | Hook entries | 29 |
@@ -488,7 +488,7 @@
 | Tool Evaluator | Expert technology assessment specialist focused on evaluating, testing, and recommending tools, software, and platforms ... |
 | Workflow Optimizer | Expert process improvement specialist focused on analyzing, optimizing, and automating workflows across all business fun... |
 
-## Scripts (83)
+## Scripts (84)
 
 | Script | Purpose | Status |
 |---|---|---|
@@ -548,6 +548,7 @@
 | inbox-sweep-reflex.py | inbox-sweep-reflex.py - UserPromptSubmit hook. | wired |
 | incident-capture.py | incident-capture.py , Port 6 (Phase D) helper. Generates a structured incident markdown file from pa... | wired |
 | install-git-hooks.sh | install-git-hooks.sh , Install the brain-stays-generic git hooks into ~/.claude/.git/hooks/. | wired |
+| install-observability-timer.py | install-observability-timer.py - schedule the brain's daily observability digest. | wired |
 | install-runners.py | install-runners.py , make ~/.local/bin runners thin thunks into the tracked ai_sync.py. | wired |
 | lineage-doctor.py | lineage-doctor.py , fail-closed integrity check for the surface/derivation graph. | wired |
 | memory_sync.py | memory_sync , sync the brain's private memory store to a standalone remote. | wired |

--- a/scripts/install-observability-timer.py
+++ b/scripts/install-observability-timer.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""install-observability-timer.py - schedule the brain's daily observability digest.
+
+The digest (scripts/brain-digest.py, which chains slos/watchdog/finops) reads
+LOCAL session JSONL under ~/.claude/projects, so it must run on the operator's
+own machine, not in CI. This installer wires it as a systemd --user timer so it
+fires daily and, thanks to Persistent=true, recovers a run missed while the
+laptop was asleep (the multi-machine reality).
+
+Idempotent: safe to re-run. Run it once per machine.
+
+  python3 ~/.claude/scripts/install-observability-timer.py            # install + enable
+  python3 ~/.claude/scripts/install-observability-timer.py --status   # show timer state
+  python3 ~/.claude/scripts/install-observability-timer.py --uninstall # disable + remove
+
+If systemd --user is not available, it prints a cron fallback and exits 0
+(never fails the brain over a scheduling backend it cannot find).
+"""
+from __future__ import annotations
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+BRAIN = Path.home() / ".claude"
+TEMPLATES = BRAIN / "templates" / "systemd"
+USER_UNIT_DIR = Path.home() / ".config" / "systemd" / "user"
+UNITS = ["octorato-brain-digest.service", "octorato-brain-digest.timer"]
+TIMER = "octorato-brain-digest.timer"
+
+
+def _systemctl(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["systemctl", "--user", *args],
+                          capture_output=True, text=True)
+
+
+def systemd_user_available() -> bool:
+    if sys.platform != "linux" or not shutil.which("systemctl"):
+        return False
+    # is-system-running returns running/degraded (both usable) when the user
+    # manager is up; it errors with "Failed to connect to bus" when it is not.
+    probe = _systemctl("is-system-running")
+    return "Failed to connect" not in (probe.stderr or "")
+
+
+def _cron_fallback() -> int:
+    line = "0 7 * * *  /usr/bin/env python3 %s/scripts/brain-digest.py" % BRAIN
+    print("systemd --user is not available on this machine.")
+    print("Cron fallback: add this line with `crontab -e` (runs daily at 07:00):")
+    print("  " + line)
+    return 0
+
+
+def install() -> int:
+    if not systemd_user_available():
+        return _cron_fallback()
+    missing = [u for u in UNITS if not (TEMPLATES / u).is_file()]
+    if missing:
+        print("ERROR: missing unit template(s): %s" % ", ".join(missing))
+        return 1
+    USER_UNIT_DIR.mkdir(parents=True, exist_ok=True)
+    for u in UNITS:
+        shutil.copyfile(TEMPLATES / u, USER_UNIT_DIR / u)
+        print("installed: %s" % (USER_UNIT_DIR / u))
+    _systemctl("daemon-reload")
+    en = _systemctl("enable", "--now", TIMER)
+    if en.returncode != 0:
+        print("ERROR enabling timer: %s" % (en.stderr or en.stdout).strip())
+        return 1
+    print("enabled + started: %s" % TIMER)
+    return status()
+
+
+def status() -> int:
+    if not systemd_user_available():
+        return _cron_fallback()
+    lst = _systemctl("list-timers", "--all", TIMER)
+    out = (lst.stdout or "").strip()
+    print(out if out else "(timer not found; run without --status to install)")
+    return 0
+
+
+def uninstall() -> int:
+    if not systemd_user_available():
+        print("systemd --user not available; nothing to uninstall.")
+        return 0
+    _systemctl("disable", "--now", TIMER)
+    for u in UNITS:
+        target = USER_UNIT_DIR / u
+        if target.exists():
+            target.unlink()
+            print("removed: %s" % target)
+    _systemctl("daemon-reload")
+    print("uninstalled: %s" % TIMER)
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Install the brain observability digest timer.")
+    ap.add_argument("--status", action="store_true", help="show timer state and exit")
+    ap.add_argument("--uninstall", action="store_true", help="disable and remove the timer")
+    args = ap.parse_args()
+    if args.uninstall:
+        return uninstall()
+    if args.status:
+        return status()
+    return install()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/systemd/octorato-brain-digest.service
+++ b/templates/systemd/octorato-brain-digest.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Octorato brain daily observability digest
+Documentation=https://github.com/CarlosCaPe/octorato
+After=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/.claude
+ExecStart=/usr/bin/env python3 %h/.claude/scripts/brain-digest.py
+StandardOutput=journal
+StandardError=journal

--- a/templates/systemd/octorato-brain-digest.timer
+++ b/templates/systemd/octorato-brain-digest.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Octorato brain daily observability digest
+Documentation=https://github.com/CarlosCaPe/octorato
+PartOf=octorato-brain-digest.service
+
+[Timer]
+# Daily, early. Persistent catches a run missed while the laptop was asleep
+# (the multi-machine reality), and the randomized delay avoids a thundering herd.
+OnCalendar=*-*-* 07:00:00
+Persistent=true
+RandomizedDelaySec=900
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Follow-up to v5.0 (task #7). Wires the daily observability digest to run locally.

## Why local, not CI
`brain-digest.py` (the slos/watchdog/finops aggregator) reads LOCAL session JSONL under `~/.claude/projects`. A GitHub Actions runner is ephemeral and has none of that data, so a CI cron would be theatre. This schedules it where the data lives: the operator's machine.

## What
- `templates/systemd/octorato-brain-digest.{service,timer}` mirroring the machine's existing `dqbs-*` user-timer convention. Daily at 07:00 with jitter; `Persistent=true` recovers a run missed while the laptop slept (the multi-machine reality).
- `scripts/install-observability-timer.py`: idempotent installer (`--status`, `--uninstall`), detects systemd --user, prints a cron fallback if absent. Run once per machine.
- Manifest regenerated to include the new script (the v5.0 gate requires it).

## Verified
End-to-end under systemd: `Result=success`, journal `✓ Wrote digests/brain-2026-06-26.md`. Timer enabled, next run scheduled. brain_doctor 0 fail, manifest fresh.

Run on each machine after merge: `python3 ~/.claude/scripts/install-observability-timer.py`