### PR TITLE
feat(gate): flip manifest freshness to pre-push hard block (Phase 4b)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -225,4 +225,23 @@ if [ -f "$REPO_ROOT/scripts/brain_doctor.py" ] && [ -f "$REPO_ROOT/registry/rule
   fi
 fi
 
+# OCTORATO-MANIFEST-GATE: RULE #1 extended from rules to capabilities (v5.0).
+# capability_manifest.py --check asserts docs/CAPABILITIES.md reflects the live
+# capability set (skills/agents/scripts/rules/hooks). A skill/agent/script/rule
+# added without regenerating the manifest means the offering silently drifts, the
+# exact regression-by-replacement v5.0 exists to stop. ai-push regenerates the
+# manifest before staging, so this never fires on the canonical path; it catches a
+# direct `git push` with a stale manifest. Determinism verified before flipping to
+# fail-closed: byte-identical output, no env-specifics, gitignored cruft excluded.
+if [ -f "$REPO_ROOT/scripts/capability_manifest.py" ] && [ -n "$PYTHON" ]; then
+  if ! "$PYTHON" "$REPO_ROOT/scripts/capability_manifest.py" --check >/dev/null 2>&1; then
+    {
+      echo ""
+      echo "✗ pre-push: docs/CAPABILITIES.md is STALE (a capability changed without regen)."
+      echo "  Run: python3 scripts/capability_manifest.py  then commit it, and re-push."
+    } >&2
+    exit 1
+  fi
+fi
+
 exit 0


### PR DESCRIPTION
Closes the last v5.0 follow-up (task #8). The manifest freshness assertion goes from a brain_doctor WARN/ai-push-regen to a fail-closed pre-push block.

## What
`.githooks/pre-push` now runs `capability_manifest.py --check` and blocks any push whose `docs/CAPABILITIES.md` is stale, the same stance as the existing RULE #1 registry gate. From here, a skill/agent/script/rule cannot reach the remote without being represented in the offering manifest.

## Why it is safe to flip now (the deferral reason was determinism)
Verified before going fail-closed:
- Output byte-identical across 3 runs.
- No env-specifics: no home path, hostname, user, or date in the manifest.
- All output ordering is `sorted()`.
- Gitignored / per-machine cruft is excluded: `scan_skills` requires a `SKILL.md` (so the gitignored `skills/learned/` staging never leaks), and `scan_scripts` skips `__pycache__`/`lib`/`tests`/dotfiles.

So machine A and machine B with the same checkout produce the same manifest. The block cannot fire spuriously cross-machine.

## Tested
- stale manifest -> `--check` exit 1 (push blocked)
- fresh manifest -> `--check` exit 0 (push passes)
- bash syntax clean; this very push exercised the new hook end-to-end and passed.

ai-push regenerates the manifest before staging, so the block only ever bites a direct `git push` that forgot to regen.