### PR TITLE
docs: reflect v5 (capability manifest + gate) across README, wiki, FAQ, whitepaper

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -38,6 +38,8 @@ Every action follows four phases: **Describe** (state what and why), **Delegate*
 
 **RULE #1: every rule must be wired, or the brain is corrupt.** A rule counts as real only when `registry/rules.yaml` maps it to a live mechanism (a hook, a gate, a detector). `brain_doctor` checks this in both directions: every rule in the constitution has a mechanism, and every live hook has a rule. If one is missing, the doctor declares the brain corrupt and the pre-push hook blocks the push. No force, no exception, no soft-fail. So a rule cannot quietly decay into advisory prose the model skips under load. Model-behavior rules (tone, no-hallucination, identity) are still registered, backed by a detector or a presence-assert. Full design: [`docs/architecture/wired-or-corrupt.md`](docs/architecture/wired-or-corrupt.md).
 
+The same principle extends to the whole capability set. A generated manifest, [`docs/CAPABILITIES.md`](docs/CAPABILITIES.md), lists every skill, agent, script, rule, and hook the brain holds. It is produced by `scripts/capability_manifest.py` and regenerated on every push. The pre-push gate blocks a push whose manifest is stale, so a capability cannot be silently dropped from the offering by a later change. Architecture: [`docs/architecture/v5-capability-manifest.md`](docs/architecture/v5-capability-manifest.md).
+
 ## Who maintains Octorato?
 
 Carlos Carrillo (Guadalajara, Mexico), through dataqbs. The productized "AI Agent OS" runs at [dataqbs.com](https://dataqbs.com), built and operated on this brain.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ https://github.com/CarlosCaPe/octorato
 ## FinOps roadmap
 
 - [x] Trace capture per skill / agent / phase (`scripts/trace-hook.py` + 8 hook points)
-- [x] Daily brain digest with cost section (`scripts/brain-digest.py` via cron)
+- [x] Daily brain digest with cost section (`scripts/brain-digest.py`), scheduled per machine via a `systemd --user` timer (`scripts/install-observability-timer.py`)
 - [x] Skill-level cost profiler 30-day window (`scripts/skill-cost-profiler.py`)
 - [x] SLO + watchdog infrastructure (`success_rate` SLI)
 - [x] Per-event `arm` tagging (`trace-hook.py` reads cwd → client id)
@@ -316,6 +316,8 @@ Most agent instructions are prose the model can skip under load. Octorato refuse
 `brain_doctor` is the mechanism of that rule. It loads the registry, asserts every rule is wired, and reconciles **both directions**: every CLAUDE.md rule has a mechanism, and every live hook has a rule. One miss and the doctor declares the brain corrupt, exits non-zero, and `.githooks/pre-push` **blocks the push**. No `--force`, no soft-fail. A documented-but-absent hook can no longer ship.
 
 "Wired" means covered, not mechanically forced. A model-behavior rule (tone, no-hallucination, identity) is backed by a registered detector or a presence-assert, never by bare prose. The Coverage Ledger prints the enforcement strength per rule, so 100% coverage is never misread as 100% force.
+
+The same principle now covers the whole capability set, not only the rules. A generated manifest, [`docs/CAPABILITIES.md`](docs/CAPABILITIES.md), is the single source of the offering: every skill, agent, script, rule, and hook the brain holds, produced by `scripts/capability_manifest.py` and regenerated on every push. The pre-push gate that blocks an unwired rule also blocks a push whose manifest is stale, meaning a skill or agent or script was added without being represented. Regression-by-replacement, where a new change quietly drops a prior capability from the offering, becomes impossible at the push boundary. Architecture: [`docs/architecture/v5-capability-manifest.md`](docs/architecture/v5-capability-manifest.md).
 
 Full architecture, the label ontology, and the migration history: [`docs/architecture/wired-or-corrupt.md`](docs/architecture/wired-or-corrupt.md).
 
@@ -572,7 +574,9 @@ brain-trace.py top  --by name --window 7d               # top skills/agents
 brain-trace.py tail -n 20 -f                            # live tail
 ```
 
-Full schema, storage layout, and cron setup: [`docs/architecture/trace-storage.md`](docs/architecture/trace-storage.md).
+The daily digest is scheduled per machine by a `systemd --user` timer (`scripts/install-observability-timer.py`), not by CI: it reads local session data, and `Persistent=true` recovers a run missed while the laptop slept.
+
+Full schema, storage layout, and scheduling: [`docs/architecture/trace-storage.md`](docs/architecture/trace-storage.md).
 
 ---
 

--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -150,7 +150,8 @@ Unlike most white papers (a promise before code), every claim here maps to a fil
 | §6 Parallel dimensions (v3.1) | `scripts/octo-dim.py` · `connectome/sessions.json` (blackboard registry) · `skills/session-isolation/` |
 | §7 Connectome | `scripts/generate_neural_map.py` · `neural_map.json` |
 | §7 Reactive control architecture (v3.1) | `docs/architecture/hook-orchestration.md` — ECA atoms · Behavior-Tree priority · Statechart 4D · Spreading-Activation recall · Bandit tier-routing |
-| §4 Attribution corollary | `scripts/skill-cost-profiler.py` (`_arm_from_session_path`) · `scripts/budget-check.py` (exit 2 → PreToolUse halt) · `scripts/_pricing.py` |
+| §4 Attribution corollary | `scripts/skill-cost-profiler.py` (`_arm_from_session_path`) · `scripts/budget-check.py` (exit 2 → PreToolUse halt, registered as `FLOW.budget-halt`) · `scripts/_pricing.py` |
+| §6 Capability manifest (wired-or-corrupt extended) | `scripts/capability_manifest.py` → `docs/CAPABILITIES.md` (regenerated on every push; pre-push gate blocks a stale manifest); architecture: `docs/architecture/v5-capability-manifest.md` |
 
 *This document is the canonical source. The dataqbs.com manifesto page, the LinkedIn
 article, and the serialized blog posts all derive from it — one source, many views.*

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -311,6 +311,8 @@ Rules used to be prose the model could skip under load. RULE #1 ends that: every
 
 "Wired" means covered, not mechanically forced. Model-behavior rules (tone, no-hallucination, identity) are backed by a registered detector or a presence-assert, and the Coverage Ledger prints the enforcement strength per rule, so coverage is never confused with force. Full design: [`wired-or-corrupt.md`](../architecture/wired-or-corrupt.md).
 
+The same principle now covers the whole capability set. A generated manifest, [`docs/CAPABILITIES.md`](../CAPABILITIES.md), is the single source of the offering: every skill, agent, script, rule, and hook the brain holds, produced by `scripts/capability_manifest.py` and regenerated on every push. The pre-push gate that blocks an unwired rule also blocks a push whose manifest is stale, making regression-by-replacement impossible at the push boundary. Architecture: [`docs/architecture/v5-capability-manifest.md`](../architecture/v5-capability-manifest.md).
+
 ---
 
 ## See also

--- a/docs/wiki/FinOps.md
+++ b/docs/wiki/FinOps.md
@@ -271,6 +271,10 @@ default:                           # applies to any arm not listed
 
 `HARD_STOP` fires only when an arm's spend reaches `cap × grace_pct/100` **and** that arm's `action_on_breach == hard_stop`. The `halt_reason` string spells out the arithmetic, e.g. *"arm 'client-x' burned $221.40 (grace $220.00 = cap $200.00 × 110%) — refusing tool."*
 
+### Registration in the rule registry
+
+`budget-check.py` is wired as a `PreToolUse[Agent]` hook and registered as rule `FLOW.budget-halt` in `registry/rules.yaml`. This means `brain_doctor` asserts its presence on every `ai-push`; a push whose hook is missing or whose rule entry is absent is blocked by `.githooks/pre-push`. The budget halt is not advisory prose. It is a first-class registered mechanism, the same way RULE #1 itself is wired.
+
 ### Wiring the PreToolUse hook
 
 In `~/.claude/settings.json`, gate the expensive tools (`Agent`, subagent dispatch, browser automation) on the checker:
@@ -328,7 +332,7 @@ A delta over 20% is flagged — it almost always means a **stale `_pricing.py`**
 
 ## 8. The daily digest — where it all surfaces
 
-`scripts/brain-digest.py` is the cron'd morning report that assembles every FinOps surface into one place:
+`scripts/brain-digest.py` is the morning report that assembles every FinOps surface into one place. It runs on the operator's machine, not in CI: it reads local session data, so it must run where that data lives. Scheduling is handled by a `systemd --user` timer installed by `scripts/install-observability-timer.py`; the timer carries `Persistent=true`, which recovers a run missed while the machine was asleep.
 
 - **Cost by arm** (from the profiler) — the billable rollup.
 - **Budget burn this month** (from `budget-check.py`) — each configured arm's MTD spend vs cap with ✓ / ⚠ / 🛑 markers; a 🛑 means a hard-stop is active on at least one arm.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -11,7 +11,9 @@
 **Live:** <!--canon:skills.count-->230+<!--/canon--> skills · <!--canon:agents.count-->160+<!--/canon--> agent personas across
 13 divisions · hook-enforced gates · multi-machine sync · a neural
 connectome that learns over time · a FinOps pipeline that tags every trace event
-with the client who incurred it.
+with the client who incurred it · a generated capability manifest
+([`docs/CAPABILITIES.md`](../CAPABILITIES.md)) that the pre-push gate keeps
+fresh so no capability can be silently dropped.
 
 Repo: https://github.com/CarlosCaPe/octorato
 


### PR DESCRIPTION
Brings the brain's public docs into agreement with the shipped v5 reality (v5.0/5.1/5.2).

## Approach
Evergreen, not a changelog (per no-history-in-docs): the docs describe what the brain IS now. Version history stays in GitHub releases. Several v5 claims (the budget halt) were already written as shipped; v5.0 made them true, so this mostly makes the prose accurate and adds the genuinely new architecture (the manifest + gate).

## Changed (surgical, 6 files)
- README.md (Opus): Wired-or-Corrupt section now describes the capability manifest (docs/CAPABILITIES.md) and the pre-push block extending the principle from rules to all capabilities; FinOps + Observability note the systemd-timer digest schedule.
- docs/wiki/Architecture.md, FinOps.md, Home.md; FAQ.md; WHITEPAPER.md (Technical Writer agent, Opus-verified): same facts propagated to each surface.

## Verified
- No em-dash in any added line.
- No canon tokens or skill/agent counts touched.
- Relative links resolve (docs/CAPABILITIES.md, docs/architecture/v5-capability-manifest.md).
- Manifest fresh; pre-push gate passed on push.
- Every claim checked against the real wiring (FLOW.budget-halt registration, PreToolUse[Agent] hook, install-observability-timer.py).

Not touched: ROADMAP.md and Getting-Started.md (no v5 fact belongs there). The dataqbs.com product site lives in a separate sealed arm, handled separately.

Engine: Opus (README + verification) + Sonnet Technical Writer (wiki/FAQ/whitepaper propagation).