### PR TITLE
feat(release): changelog self-heal — sync entries from tags, doctor --fix wiring, v5.5.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ machine-generated growth ledger lives at
 
 ## [Unreleased]
 
+### Release self-heal
+- New `scripts/changelog-sync.py`: reconciles missing CHANGELOG entries from semver tags, promoting the curated `[Unreleased]` body into the newest missing version and pulling GitHub Release notes (commit-subject fallback) for the rest. Dry-run by default, `--check` for CI, `--apply` idempotent.
+- `brain_doctor --fix` repairs `release-drift` locally by running changelog-sync; the entry still lands through the normal PR flow.
+- `brain-version-bump` prepends a non-empty `[Unreleased]` body to the GitHub Release notes, so the curated summary reaches the Release even when the CHANGELOG commit lags behind the tag.
+
+## [2026-07-01]: v5.5.0
+
 ### Doctor teeth
 - Waiver expiry enforced: a gateable fail-open rule whose `waiver.expires` is missing, unparseable, or past now counts as UNWAIVED and fails the meta-gate.
 - `release-drift` is bidirectional: the newest semver tag ahead of the CHANGELOG top now WARNs (releases cut without entries), with tags sorted by semver.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -9,7 +9,7 @@
 | Skills | 231 |
 | Agents | 161 |
 | Divisions | 15 |
-| Scripts: wired | 78 |
+| Scripts: wired | 79 |
 | Scripts: orphan | 6 |
 | Rules | 50 |
 | Hook entries | 29 |
@@ -488,7 +488,7 @@
 | Tool Evaluator | Expert technology assessment specialist focused on evaluating, testing, and recommending tools, software, and platforms ... |
 | Workflow Optimizer | Expert process improvement specialist focused on analyzing, optimizing, and automating workflows across all business fun... |
 
-## Scripts (84)
+## Scripts (85)
 
 | Script | Purpose | Status |
 |---|---|---|
@@ -518,6 +518,7 @@
 | capability-census.py | capability-census.py - the live-source census heartbeat (UserPromptSubmit hook). | wired |
 | capability_inventory.py | capability_inventory.py , read-only capability census of skills + agents (issue #28). | wired |
 | capability_manifest.py | capability_manifest.py -- v5.0 Capability Manifest Generator for Octorato. Scans skills/, agents/, s... | wired |
+| changelog-sync.py | changelog-sync.py - heal CHANGELOG.md when releases were cut without entries. | wired |
 | check-generic.py | check-generic.py , Block commits that leak arm/client/person identifiers. The brain (~/.claude/) is ... | wired |
 | check-hooks-drift.py | check-hooks-drift.py , guard: settings.json.hooks must equal the projection of hooks.json. | wired |
 | check-readme-sync.sh | check-readme-sync.sh , Warn if skills/agents/scripts changed but README didn't. | orphan |

--- a/scripts/brain-version-bump.py
+++ b/scripts/brain-version-bump.py
@@ -163,11 +163,38 @@ def _news_draft(version, prev_tag, bump, notes):
     )
 
 
+def _unreleased_body(root):
+    """The `## [Unreleased]` body from CHANGELOG.md, or "" when absent/empty.
+    Tiny duplicate of the changelog-sync.py parser, kept inline so a missing
+    sibling script can never break the release path. Best-effort by contract."""
+    try:
+        text = (Path(root) / "CHANGELOG.md").read_text(encoding="utf-8")
+        body, inside = [], False
+        for line in text.split("\n"):
+            if re.match(r"^## \[Unreleased\]\s*$", line, re.I):
+                inside = True
+                continue
+            if inside and line.startswith("## "):
+                break
+            if inside:
+                body.append(line)
+        return "\n".join(body).strip("\n").strip()
+    except Exception:
+        return ""
+
+
 def emit_release(root, version, prev_tag, bump, commits):
     """Best-effort, AFTER the tag is pushed: a GitHub Release for every bump (that is
     the changelog), plus a queued news DRAFT for substantive bumps (minor/major).
     Never raises. A failure here must never break the caller (ai-push)."""
     notes = _release_notes(commits)
+    # Curated prose beats grouped commit subjects: when CHANGELOG.md carries a
+    # non-empty [Unreleased] section, promote it to the top of the Release body
+    # so the human-written summary reaches the Release even though branch
+    # protection keeps any bot from committing the CHANGELOG entry itself.
+    # The news draft below keeps the plain grouped list (the operator rewrites it).
+    unreleased = _unreleased_body(root)
+    release_body = f"{unreleased}\n\n---\n\n{notes}" if unreleased else notes
     # 1. GitHub Release = the changelog entry. Idempotent, needs gh, skips quietly.
     if which("gh"):
         seen = subprocess.run(["gh", "release", "view", version],
@@ -175,7 +202,7 @@ def emit_release(root, version, prev_tag, bump, commits):
         if not seen:
             r = subprocess.run(
                 ["gh", "release", "create", version, "--title", version,
-                 "--notes", notes, "--verify-tag"],
+                 "--notes", release_body, "--verify-tag"],
                 cwd=root, capture_output=True, text=True)
             if r.returncode == 0:
                 print(f"  released {version} (GitHub)")

--- a/scripts/brain_doctor.py
+++ b/scripts/brain_doctor.py
@@ -541,6 +541,24 @@ def check_release_drift(fix: bool) -> Result:
     if semver_tags:
         newest = max(semver_tags, key=_sv)
         if _sv(newest) > _sv(f"v{top_version}"):
+            if fix:
+                # Repair is local by design: branch protection means no bot can
+                # commit to master, so the sync writes CHANGELOG.md here and the
+                # entry rides the operator's normal PR flow.
+                sync = CLAUDE_DIR / "scripts" / "changelog-sync.py"
+                cp = run([PYTHON or "python3", str(sync), "--apply"], cwd=CLAUDE_DIR)
+                added = [ln for ln in cp.stdout.splitlines()
+                         if ln.strip().startswith("added ")]
+                if cp.returncode == 0 and added:
+                    return Result(key, PASS,
+                                  f"drift repaired locally: {len(added)} entr"
+                                  f"{'y' if len(added) == 1 else 'ies'} added by "
+                                  f"changelog-sync; commit via normal PR flow")
+                detail = (cp.stderr or cp.stdout or "").strip().splitlines()
+                return Result(key, WARN,
+                              f"changelog-sync --apply did not repair the drift "
+                              f"({detail[-1] if detail else 'no output'})",
+                              "run `python3 scripts/changelog-sync.py --apply` and inspect")
             return Result(key, WARN,
                           f"newest tag {newest} ahead of CHANGELOG top v{top_version} — "
                           f"releases were cut without CHANGELOG entries",

--- a/scripts/changelog-sync.py
+++ b/scripts/changelog-sync.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""changelog-sync.py - heal CHANGELOG.md when releases were cut without entries.
+
+Releases are cut server-side: version-bump.yml runs brain-version-bump.py on
+every push to master, which tags and creates a GitHub Release. CHANGELOG.md is
+manual, and master branch protection (required PRs, required checks,
+enforce_admins) means no bot can commit the matching entry. The result is a
+structural drift: tags run ahead of the CHANGELOG top and brain_doctor's
+release-drift check WARNs forever.
+
+This tool reconciles locally, so the repair rides the normal PR flow:
+
+    - missing versions = semver tags strictly greater than the CHANGELOG's top
+      released heading (`## [YYYY-MM-DD]: vX.Y.Z`)
+    - the NEWEST missing version takes the curated `## [Unreleased]` body
+      verbatim when that section is non-empty (that prose was written for it);
+      the [Unreleased] heading stays as the standing intake, its body empties
+    - every other missing version (or when [Unreleased] is empty) takes the
+      GitHub Release notes (`gh release view`), falling back to grouped commit
+      subjects from `git log <prev>..<tag>` when gh is missing or fails
+
+Modes:
+    (default)   print what would change. Writes nothing.
+    --check     exit 1 if entries are missing, 0 if reconciled. Writes nothing.
+    --apply     write CHANGELOG.md, one line per entry added. Idempotent: a
+                second --apply finds nothing missing and is a no-op.
+
+All git calls are pinned to the repo root via `-C`, so the result does not
+depend on the caller's working directory. Everything outside the touched
+section is preserved byte-for-byte.
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+from shutil import which
+
+TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+RELEASED_RE = re.compile(r"^## \[\d{4}-\d{2}-\d{2}\]: v(\d+\.\d+\.\d+)\s*$")
+UNRELEASED_RE = re.compile(r"^## \[Unreleased\]\s*$", re.I)
+
+
+def git(root, *args):
+    r = subprocess.run(["git", "-C", root, *args],
+                       capture_output=True, text=True)
+    return r.returncode, r.stdout.strip(), r.stderr.strip()
+
+
+def repo_root():
+    r = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        sys.stderr.write("changelog-sync: not a git repo\n")
+        sys.exit(2)
+    return r.stdout.strip()
+
+
+def semver_tuple(version):
+    return tuple(int(x) for x in version.lstrip("v").split("."))
+
+
+def list_tags(root):
+    """All vX.Y.Z tags, newest first by integer semver tuple."""
+    _, out, _ = git(root, "tag")
+    tags = [t.strip() for t in out.splitlines() if TAG_RE.match(t.strip())]
+    return sorted(tags, key=semver_tuple, reverse=True)
+
+
+def parse_changelog(text):
+    """Locate the top released version and the [Unreleased] section.
+
+    Returns (lines, top_version, unrel_idx, sect_end, body_lines):
+        lines      - text split on newline (rejoin with newline is lossless)
+        top_version- first `## [date]: vX.Y.Z` heading's version, or None
+        unrel_idx  - line index of `## [Unreleased]`, or None
+        sect_end   - index of the first `## ` line after [Unreleased] (or EOF);
+                     when there is no [Unreleased], the index of the first
+                     released heading (insert point after the title block)
+        body_lines - the [Unreleased] body, surrounding blank lines stripped
+    """
+    lines = text.split("\n")
+    top_version = None
+    unrel_idx = None
+    first_heading = len(lines)
+    for i, line in enumerate(lines):
+        if unrel_idx is None and UNRELEASED_RE.match(line):
+            unrel_idx = i
+            continue
+        m = RELEASED_RE.match(line)
+        if m:
+            if top_version is None:
+                top_version = m.group(1)
+            first_heading = min(first_heading, i)
+    if unrel_idx is not None:
+        sect_end = len(lines)
+        for i in range(unrel_idx + 1, len(lines)):
+            if lines[i].startswith("## "):
+                sect_end = i
+                break
+        body = lines[unrel_idx + 1:sect_end]
+    else:
+        sect_end = first_heading
+        body = []
+    while body and not body[0].strip():
+        body.pop(0)
+    while body and not body[-1].strip():
+        body.pop()
+    return lines, top_version, unrel_idx, sect_end, body
+
+
+def tag_date(root, tag):
+    code, out, _ = git(root, "for-each-ref",
+                       "--format=%(creatordate:short)", f"refs/tags/{tag}")
+    if code == 0 and out:
+        return out
+    code, out, _ = git(root, "log", "-1", "--format=%cs", tag)
+    return out if code == 0 and out else "unknown-date"
+
+
+def release_body(root, tag, prev):
+    """Release notes for a tag: GitHub Release body first, commit-subject
+    fallback second. Returns (lines, source_label)."""
+    if which("gh"):
+        r = subprocess.run(
+            ["gh", "release", "view", tag, "--json", "body", "-q", ".body"],
+            cwd=root, capture_output=True, text=True)
+        if r.returncode == 0 and r.stdout.strip():
+            return r.stdout.strip("\n").split("\n"), "GitHub Release notes"
+    rng = f"{prev}..{tag}" if prev else tag
+    code, out, _ = git(root, "log", rng, "--no-merges", "--format=- %s")
+    if code == 0 and out:
+        return out.split("\n"), "commit subjects"
+    return ["- (no release notes found for this tag)"], "empty fallback"
+
+
+def build_entries(root, missing, unreleased_body, tags):
+    """One (heading, body_lines, source) per missing version, newest first."""
+    entries = []
+    for i, tag in enumerate(missing):
+        date = tag_date(root, tag)
+        heading = f"## [{date}]: {tag}"
+        if i == 0 and unreleased_body:
+            body, source = list(unreleased_body), "[Unreleased] promotion"
+        else:
+            lower = [t for t in tags if semver_tuple(t) < semver_tuple(tag)]
+            prev = lower[0] if lower else None
+            body, source = release_body(root, tag, prev)
+        entries.append((heading, body, source))
+    return entries
+
+
+def main():
+    apply = "--apply" in sys.argv
+    check = "--check" in sys.argv
+
+    root = repo_root()
+    changelog = Path(root) / "CHANGELOG.md"
+    if not changelog.exists():
+        sys.stderr.write("changelog-sync: CHANGELOG.md not found at repo root\n")
+        return 2
+    text = changelog.read_text(encoding="utf-8")
+    lines, top_version, unrel_idx, sect_end, body = parse_changelog(text)
+
+    tags = list_tags(root)
+    if top_version:
+        top = semver_tuple(top_version)
+        missing = [t for t in tags if semver_tuple(t) > top]
+    else:
+        missing = list(tags)
+
+    top_label = f"v{top_version}" if top_version else "(none)"
+    newest_label = tags[0] if tags else "(none)"
+    print(f"changelog-sync: CHANGELOG top {top_label}, newest tag {newest_label}")
+
+    if not missing:
+        print("  reconciled, no entries missing")
+        return 0
+
+    entries = build_entries(root, missing, body, tags)
+    promoted = bool(body) and entries and entries[0][2] == "[Unreleased] promotion"
+
+    if check:
+        for heading, _, source in entries:
+            print(f"  missing {heading[3:]} (would fill from {source})")
+        return 1
+
+    if not apply:
+        for heading, _, source in entries:
+            print(f"  missing {heading[3:]} (would fill from {source})")
+        print("  dry-run, no writes; use --apply")
+        return 0
+
+    entry_lines = []
+    for heading, ebody, _ in entries:
+        entry_lines.extend([heading, *ebody, ""])
+    if unrel_idx is not None:
+        if promoted:
+            # Promote the curated body out; the heading stays as the intake.
+            new_lines = lines[:unrel_idx + 1] + [""] + entry_lines + lines[sect_end:]
+        else:
+            new_lines = lines[:sect_end] + entry_lines + lines[sect_end:]
+    else:
+        new_lines = lines[:sect_end] + entry_lines + lines[sect_end:]
+    changelog.write_text("\n".join(new_lines), encoding="utf-8")
+    for heading, _, source in entries:
+        print(f"  added {heading[3:]} (from {source})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Closes the last release-drift hole: releases are bot-cut on master push while CHANGELOG.md is manual and master's protection (required PRs + enforce_admins) forbids bot commits. This makes the drift self-healing through the normal PR flow instead of silent.

### changelog-sync self-heal (d9ef91a)
New `scripts/changelog-sync.py`: reconciles CHANGELOG.md against semver tags. Promotes the `[Unreleased]` body to the newest missing version's entry (keeping the heading as standing intake) and fills older missing entries from GitHub Release notes with a `git log` fallback. Modes: default dry, `--check` (exit 1 on drift), `--apply` (idempotent).

### Wiring (ff3e178)
- `brain_doctor.py check_release_drift --fix` runs the sync and reports "drift repaired locally, commit via normal PR flow". PASS only on returncode 0 plus actual added entries; anything else stays an honest WARN.
- `brain-version-bump.py`: the GitHub Release notes now prepend the `[Unreleased]` body above the grouped commit list, best-effort, tagging logic untouched.

### One-time reconciliation (ffd6d70)
CHANGELOG `[Unreleased]` promoted to `## [2026-07-01]: v5.5.0` (the bot cut that tag with exactly this content); a fresh `[Unreleased]` queues this branch's entry.

## Steady state
Bot cuts a tag with curated notes; the doctor WARNs one cycle; `--fix` repairs locally; the commit rides the next PR. Drift is visible for one beat, never silent, and no branch protection is weakened.

## Validation
Builder: py_compile clean; sync idempotent (double `--apply` byte-identical); doctor 31 passed, 3 warn, 0 fail with release-drift PASS; version-bump dry-run OK (v5.5.0 to v5.6.0 minor).
Independent QA: PASS, 0 blockers. Synthetic-repo probes: v5.10.x sorts above v5.9.0, gh-absent fallback works, top-ahead-of-tags no-ops, no-[Unreleased] and empty-[Unreleased] edges handled, injection-safe subprocess calls, 0 em-dash and 0 leak hits in added lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
