### PR TITLE
docs(skill): whatsapp bridge send-dial + liveness/verification gotchas

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -242,7 +242,7 @@
 | video-commercial-production | Video Commercial Production |
 | voice-and-cadence-consistency | Document Voice and Cadence Consistency |
 | web-perf | Analyzes web performance using Chrome DevTools MCP. Measures Core Web Vitals (LCP, INP, CLS) and supplementary metrics (... |
-| whatsapp-mcp-bridge-gotchas | Hard-won fixes for standing up the lharries/whatsapp-mcp bridge (whatsmeow + WhatsApp Web multidevice) read-only and enc... |
+| whatsapp-mcp-bridge-gotchas | Hard-won fixes for standing up the lharries/whatsapp-mcp bridge (whatsmeow + WhatsApp Web multidevice), encrypted, with ... |
 | windows-brain-script-portability | Two hard-won rules for any Python script in ~/.claude/scripts/ that must run on a Windows brain: (1) `python3` resolves ... |
 | winui-app | Bootstrap, develop, and design modern WinUI 3 desktop applications with C# and the Windows App SDK using official Micros... |
 | workers-best-practices | Reviews and authors Cloudflare Workers code against production best practices. Load when writing new Workers, reviewing ... |
@@ -312,8 +312,8 @@
 
 | Name | Description |
 |---|---|
-| nexus-spatial-discovery | Nexus Spatial: Full Agency Discovery Exercise |
 | README | Examples |
+| nexus-spatial-discovery | Nexus Spatial: Full Agency Discovery Exercise |
 | workflow-book-chapter | Workflow Example: Book Chapter Development |
 | workflow-landing-page | Multi-Agent Workflow: Landing Page Sprint |
 | workflow-startup-mvp | Multi-Agent Workflow: Startup MVP |
@@ -460,8 +460,8 @@
 | Name | Description |
 |---|---|
 | EXECUTIVE-BRIEF | 📑 NEXUS Executive Brief |
-| nexus-strategy | 🌐 NEXUS , Network of EXperts, Unified in Strategy |
 | QUICKSTART | ⚡ NEXUS Quick-Start Guide |
+| nexus-strategy | 🌐 NEXUS , Network of EXperts, Unified in Strategy |
 
 ### support (7)
 

--- a/skills/whatsapp-mcp-bridge-gotchas/SKILL.md
+++ b/skills/whatsapp-mcp-bridge-gotchas/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: whatsapp-mcp-bridge-gotchas
-description: "Hard-won fixes for standing up the lharries/whatsapp-mcp bridge (whatsmeow + WhatsApp Web multidevice) read-only and encrypted. Covers the 403 media-download root cause (direct path stripped of its CDN auth query), the 405 client-outdated fix (bump whatsmeow + add context.Context to changed APIs), QR-vs-phone-code pairing, encrypt-at-rest without sudo (gocryptfs static binary), and read-only enforcement. Load before installing or debugging a personal WhatsApp MCP."
+description: "Hard-won fixes for standing up the lharries/whatsapp-mcp bridge (whatsmeow + WhatsApp Web multidevice), encrypted, with send as a reversible dial. Covers the 403 media-download root cause (direct path stripped of its CDN auth query), the 405 client-outdated fix (bump whatsmeow + add context.Context to changed APIs), QR-vs-phone-code pairing, encrypt-at-rest without sudo (gocryptfs static binary), read-only vs send-enabled enforcement, and liveness/identity/verification gotchas (bridge freshness probe, @lid JID migration, outgoing REST sends absent from messages.db). Load before installing or debugging a personal WhatsApp MCP."
 metadata:
   type: reference
 ---
@@ -27,12 +27,19 @@ The terminal QR (qrterminal half-block) is often unscannable from a chat surface
 ## 4. Encrypt at rest without sudo
 `gocryptfs` built from source needs `libssl-dev` (sudo). Skip that: download the **prebuilt static binary** from the gocryptfs GitHub releases (`*_linux-static_amd64.tar.gz`), it has no deps and FUSE is usually present (`/dev/fuse` + `fusermount`). Init a cipher dir, mount it, and `ln -s <mount> whatsapp-bridge/store` so the bridge writes messages.db + the whatsmeow session encrypted. Passphrase via `-passfile` from a 600 file or, better, the SO keyring (`secret-tool`).
 
-## 5. Read-only enforcement (three layers)
-1. **Strip the send tools from the server source** (`main.py`): remove `send_message`, `send_file`, `send_audio_message` so they are absent from the MCP schema. Strongest layer.
-2. **Harness deny** in `settings.json` `permissions.deny`: `mcp__whatsapp__send_message`, `mcp__whatsapp__send_file`, `mcp__whatsapp__send_audio_message`.
-3. Open the messages DB read-only where the server reads it.
+## 5. Send enforcement is a dial, not a fact (read-only vs send-enabled)
+Read-only is a DEPLOYMENT DECISION with two layers, both reversible:
+1. **Tool registration in the server source** (`main.py`): the send functions (`send_message`, `send_file`, `send_audio_message`) live in `whatsapp.py` and the bridge exposes `/api/send` regardless. Removing their `@mcp.tool()` registration hides them from the MCP schema; re-adding it restores them. The capability never left the stack.
+2. **Harness deny** in `settings.json` `permissions.deny`: `mcp__whatsapp__send_*`. Note: an agent cannot remove its own deny rules (the auto-mode classifier blocks self-widening of permissions, and it also blocks tunneling the send through curl while the deny stands). Flipping this layer is an operator-only step, by design.
+
+Gotcha that costs a whole exchange: a skill doc that says "read-only by design" describes the decision AT WRITE TIME, not the current system. Before declaring "no se puede enviar", grep the live code (`grep "def send" whatsapp.py`, `grep "api/send" main.go`). If the operator asks for the capability, the answer is to flip the dial at the root (re-register tools + operator removes deny), never to build workarounds around your own lock.
 
 ## 6. Operational
 The Go bridge must stay alive (whatsmeow keeps the multidevice session); run it as a `systemd --user` service with `loginctl enable-linger`. The gocryptfs mount must be remounted on boot too. Both are prerequisites for the MCP server to read.
+
+## 7. Liveness, identity, and verification gotchas (post-mortem tested)
+1. **"The MCP answers" is NOT "the bridge is alive."** The python MCP server only reads the DB; the Go bridge is what syncs. The real liveness probe is data freshness: `SELECT MAX(timestamp) FROM messages` vs now. If it lags hours, the bridge is down even though every MCP query "works". On reconnect with a live session, WhatsApp re-delivers the queued backlog in minutes, no re-pairing needed (check `whatsapp.db` mtime to guess session health before assuming re-pair).
+2. **Contacts migrate to `@lid` JIDs.** A person's chat under `<phone>@s.whatsapp.net` can freeze in time while their new messages land under `<numeric>@lid`. Searching only the phone JID yields a false "no new messages". Sweep by content/media across all chats, or match the @lid chat by conversation context, before claiming silence.
+3. **Outgoing sends via `/api/send` are NOT persisted to `messages.db`** (only event-handler traffic is stored). A DB read-back after sending returns empty; that is a storage gap, not a delivery failure. The delivery evidence is the bridge log line `Message sent true ...` (whatsmeow ack). Verify sends against the log, and final-verify visually on a phone/WhatsApp Web.
 
 Related: [[mcp-stack-setup]], [[phi-aware-rag-ingestion]] (sensitive-data ingestion), [[sops-age-git-encryption]].

--- a/skills/whatsapp-mcp-bridge-gotchas/SKILL.md
+++ b/skills/whatsapp-mcp-bridge-gotchas/SKILL.md
@@ -42,4 +42,12 @@ The Go bridge must stay alive (whatsmeow keeps the multidevice session); run it 
 2. **Contacts migrate to `@lid` JIDs.** A person's chat under `<phone>@s.whatsapp.net` can freeze in time while their new messages land under `<numeric>@lid`. Searching only the phone JID yields a false "no new messages". Sweep by content/media across all chats, or match the @lid chat by conversation context, before claiming silence.
 3. **Outgoing sends via `/api/send` are NOT persisted to `messages.db`** (only event-handler traffic is stored). A DB read-back after sending returns empty; that is a storage gap, not a delivery failure. The delivery evidence is the bridge log line `Message sent true ...` (whatsmeow ack). Verify sends against the log, and final-verify visually on a phone/WhatsApp Web.
 
-Related: [[mcp-stack-setup]], [[phi-aware-rag-ingestion]] (sensitive-data ingestion), [[sops-age-git-encryption]].
+## 8. Sending documents: octet-stream without FileName arrives "damaged"
+The stock `sendWhatsAppMessage` routes any non-image/audio/video extension to `application/octet-stream` and builds the `DocumentMessage` with `Title` only. Receiving clients use `FileName` for the saved file's name and extension; without it they save an extension-less blob and report the document as damaged or undownloadable. Fix: map real mime types per extension (pdf, xml, doc/docx, xls/xlsx, zip, txt) and set BOTH `Title` and `FileName` on the `DocumentMessage`.
+
+Discipline that would have caught it before a third party did: the FIRST outward use of any newly enabled send path is a self-canary. Send the artifact to your own self-chat, download it back through the same stack, and verify it opens (bytes match), BEFORE pointing the path at a real recipient. A server ack ("Message sent true") proves acceptance, not artifact integrity at the receiver.
+
+## 9. Capture the undo handle: persist send IDs and expose revoke
+The stock `/api/send` handler discards `resp.ID` from `client.SendMessage`, outgoing REST sends are not stored (gotcha 7.3), and whatsmeow's revoke (`client.BuildRevoke(chatJID, types.EmptyJID, messageID)` = delete-for-everyone of your own message) REQUIRES that id. Net effect: anything sent wrong is unrecoverable from the bridge; the only cleanup is manual on a phone. Fix in three moves: return `message_id` + `chat_jid` in the send response, `StoreMessage(...)` the outgoing message so it is listable later, and add an `/api/revoke` endpoint. General rule: an outward action should record the handle needed to undo it at the moment it executes, not when you first need it.
+
+Related: [[mcp-stack-setup]], [[phi-aware-rag-ingestion]] (sensitive-data ingestion), [[sops-age-git-encryption]], [[canary-symbiont]] (live-test the path once).


### PR DESCRIPTION
Updates `whatsapp-mcp-bridge-gotchas` after a live incident chain (bridge down 20h, false 'no new messages', sends invisible in DB):

- Section 5 rewritten: send enforcement is a reversible two-layer dial (MCP tool registration + harness deny), not a fixed read-only fact. Includes the doc-as-snapshot warning: verify capability against live code before declaring 'can't', and flip the dial at the root instead of building workarounds around your own lock. Notes the agent cannot self-remove deny rules (operator-only, by design).
- New section 7: (1) bridge liveness = DB freshness probe, not MCP responsiveness; (2) contacts migrating to @lid JIDs make the phone-JID chat freeze (false silence); (3) outgoing /api/send messages are not persisted to messages.db, delivery evidence is the bridge log.
- Capability manifest regenerated (gate requirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeoALJCxPDJq4kwXyRFTeq