### PR TITLE
feat(client-doc-lint): fiscal-note (IVA) check + tax clause in cotizacion-legal-baseline

### DIFF
--- a/scripts/client-doc-lint.py
+++ b/scripts/client-doc-lint.py
@@ -45,6 +45,11 @@ for _s in (sys.stdout, sys.stderr):
         pass
 
 ACCENTED = "áéíóúüñÁÉÍÓÚÜÑ"
+# One source of truth for $-amounts: optional space after $ covers the common
+# Mexican "$ 85,000.00" typography and pdftotext extraction artifacts.
+AMOUNT_RE = re.compile(r"\$\s?[\d][\d,]*(?:\.\d{2})?")
+# Solid IVA word or fully dotted I.V.A. — never "IV.A" (roman-numeral sections).
+IVA_RE = re.compile(r"\bIVA\b|(?<![A-Za-z])I\.V\.A\.?(?![A-Za-z])", re.IGNORECASE)
 MONTHS = {
     "enero": 1, "febrero": 2, "marzo": 3, "abril": 4, "mayo": 5, "junio": 6,
     "julio": 7, "agosto": 8, "septiembre": 9, "setiembre": 9, "octubre": 10,
@@ -120,10 +125,10 @@ def check_stale(text: str, today: _dt.date) -> tuple[bool, str]:
 def check_iva(text: str, lang: str) -> tuple[bool, str]:
     if lang != "es":
         return True, "iva: omitido (lang != es)"
-    amounts = re.findall(r"\$[\d][\d,]*(?:\.\d{2})?", text)
+    amounts = AMOUNT_RE.findall(text)
     if not amounts:
         return True, "iva: OK — sin montos $, no aplica"
-    if re.search(r"\bI\.?V\.?A\.?\b", text):
+    if IVA_RE.search(text):
         return True, f"iva: OK — nota fiscal presente ({len(amounts)} monto(s) $)"
     return False, (f"iva: FAIL — {len(amounts)} monto(s) $ y cero menciones de 'IVA'. "
                    "Un doc con precios debe declarar 'más IVA' o 'IVA incluido'; "
@@ -131,7 +136,7 @@ def check_iva(text: str, lang: str) -> tuple[bool, str]:
 
 
 def figures(text: str) -> str:
-    found = sorted(set(re.findall(r"\$[\d][\d,]*(?:\.\d{2})?", text)))
+    found = sorted(set(AMOUNT_RE.findall(text)))
     return f"figures: {len(found)} montos distintos → " + ", ".join(found[:20]) + (
         " ..." if len(found) > 20 else "")
 

--- a/scripts/client-doc-lint.py
+++ b/scripts/client-doc-lint.py
@@ -15,7 +15,10 @@ Checks (Spanish client docs):
   2 em-dash   — any '—' in the rendered text (human-cadence rule 1). FAIL.
   3 stale     — a forward-looking line (kickoff/agendar/semana del ...) whose
                 date is already in the past relative to --today. FAIL.
-  4 figures   — informational inventory of every $ amount found, so a human
+  4 iva       — a Spanish doc that quotes $ amounts with ZERO mention of the
+                word IVA = fiscal ambiguity: the client can read the price as
+                tax-included and cut the PO for the gross. FAIL.
+  5 figures   — informational inventory of every $ amount found, so a human
                 can eyeball consistency across sections (no auto-verdict).
 
 Usage:
@@ -114,6 +117,19 @@ def check_stale(text: str, today: _dt.date) -> tuple[bool, str]:
     return True, f"stale-dates: OK (hoy {today.isoformat()})"
 
 
+def check_iva(text: str, lang: str) -> tuple[bool, str]:
+    if lang != "es":
+        return True, "iva: omitido (lang != es)"
+    amounts = re.findall(r"\$[\d][\d,]*(?:\.\d{2})?", text)
+    if not amounts:
+        return True, "iva: OK — sin montos $, no aplica"
+    if re.search(r"\bI\.?V\.?A\.?\b", text):
+        return True, f"iva: OK — nota fiscal presente ({len(amounts)} monto(s) $)"
+    return False, (f"iva: FAIL — {len(amounts)} monto(s) $ y cero menciones de 'IVA'. "
+                   "Un doc con precios debe declarar 'más IVA' o 'IVA incluido'; "
+                   "sin la nota, la orden de compra puede llegar por el monto como IVA incluido.")
+
+
 def figures(text: str) -> str:
     found = sorted(set(re.findall(r"\$[\d][\d,]*(?:\.\d{2})?", text)))
     return f"figures: {len(found)} montos distintos → " + ", ".join(found[:20]) + (
@@ -129,7 +145,8 @@ def main() -> int:
     today = (_dt.date.fromisoformat(a.today) if a.today else _dt.date.today())
 
     text = read_text(a.file)
-    results = [check_accents(text, a.lang), check_emdash(text), check_stale(text, today)]
+    results = [check_accents(text, a.lang), check_emdash(text), check_stale(text, today),
+               check_iva(text, a.lang)]
     print(f"── client-doc-lint: {a.file} ──")
     ok_all = True
     for ok, msg in results:

--- a/skills/client-doc-lint/SKILL.md
+++ b/skills/client-doc-lint/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: client-doc-lint
-description: Pre-send QA reflex for GENERATED client deliverables (cotización, propuesta, contrato PDF/DOCX). Lints the rendered artifact for stripped accents, em-dash, already-past forward dates (kickoff/vigencia), and inventories every $ amount for human eyeballing. Run it before declaring any client doc "listo para enviar". Complements cadence-lint.py (which lints prose SOURCE, not the rendered output).
+description: Pre-send QA reflex for GENERATED client deliverables (cotización, propuesta, contrato PDF/DOCX). Lints the rendered artifact for stripped accents, em-dash, already-past forward dates (kickoff/vigencia), missing fiscal note ($ amounts with zero IVA mention = FAIL), and inventories every $ amount for human eyeballing. Run it before declaring any client doc "listo para enviar". Complements cadence-lint.py (which lints prose SOURCE, not the rendered output).
 metadata:
   type: reference
 ---
@@ -28,7 +28,8 @@ Requiere `pdftotext` (poppler-utils) para PDF.
 1. **accents**: doc largo en español con ratio de acentos casi cero = acentos perdidos, FAIL. (Español sano ronda 3-6%; bandera por debajo de 0.5% en docs > 800 letras.)
 2. **em-dash**: cualquier guion largo (em-dash) en el texto renderizado (human-cadence regla 1), FAIL.
 3. **stale-dates**: una línea con intención futura (kickoff / agendar / semana del / antes del) cuya fecha ya pasó respecto a `--today`, FAIL. Ignora líneas de referencia (FIX/DOF/emisión) que legítimamente citan fechas pasadas.
-4. **figures**: inventario informativo de todos los montos `$` para que un humano verifique consistencia entre secciones (sin veredicto automático).
+4. **iva**: doc en español con montos `$` y cero menciones de "IVA", FAIL. Sin la nota fiscal el cliente puede leer el precio como IVA incluido y emitir la orden de compra por el bruto; el proveedor absorbe ~13.79% del monto. La cláusula canónica vive en [[cotizacion-legal-baseline]].
+5. **figures**: inventario informativo de todos los montos `$` para que un humano verifique consistencia entre secciones (sin veredicto automático).
 
 ## Cuándo (reflejo)
 Antes de decir "listo para enviar" sobre CUALQUIER entregable de cliente generado

--- a/skills/cotizacion-legal-baseline/SKILL.md
+++ b/skills/cotizacion-legal-baseline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cotizacion-legal-baseline
-description: Clausulado legal base (México B2B) que TODA cotización o propuesta de servicios debe incluir desde el borrador 1, no después de que un review lo cache. Cubre propiedad intelectual (obra por encargo), tratamiento de datos personales (LFPDPPP, encargado), confidencialidad/NDA, límite de responsabilidad, garantía y soporte post-entrega, y responsabilidad de licenciamiento. Texto genérico reutilizable, sin datos de cliente.
+description: Clausulado legal base (México B2B) que TODA cotización o propuesta de servicios debe incluir desde el borrador 1, no después de que un review lo cache. Cubre propiedad intelectual (obra por encargo), tratamiento de datos personales (LFPDPPP, encargado), confidencialidad/NDA, límite de responsabilidad, garantía y soporte post-entrega, responsabilidad de licenciamiento e impuestos (montos más IVA, desglose en CFDI). Texto genérico reutilizable, sin datos de cliente.
 metadata:
   type: reference
 ---
@@ -53,6 +53,15 @@ El licenciamiento de terceros (ej. Power Apps Premium, Dataverse) es
 responsabilidad y costo del cliente. El trabajo que dependa de esa licencia no
 inicia sin confirmación de su adquisición; el proveedor no asume retrasos por su
 no contratación oportuna.
+
+### Impuestos (IVA)
+Todos los montos de la propuesta se expresan **más IVA** (16%, tasa general de la
+Ley del IVA); el impuesto se desglosa en la factura CFDI. La nota va junto al monto
+principal Y en las condiciones de pago, nunca solo en una. Sin ella, el cliente
+puede leer el precio como IVA incluido y emitir la orden de compra por el bruto: el
+proveedor absorbe ~13.79% del monto (x/1.16). Si la aclaración llega después del
+envío, se corrige por escrito en el mismo hilo ANTES de que se emita la OC.
+`client-doc-lint` marca FAIL cualquier doc con montos $ y cero menciones de IVA.
 
 ### Pago y tipo de cambio (si aplica USD→MXN)
 Plazo claro: "N días naturales desde la factura del anticipo y, para el saldo,


### PR DESCRIPTION
A generated client doc that quotes $ amounts with zero mention of IVA is fiscally ambiguous: the client can read the price as tax-included and cut the purchase order for the gross, making the provider absorb ~13.79% of the amount (x/1.16). This shipped once and the client had to ask.

Changes:
- `scripts/client-doc-lint.py`: new check `iva` — Spanish doc with $ amounts and no \bIVA\b word = FAIL. Docs without amounts or non-es lang skip.
- `skills/client-doc-lint/SKILL.md`: check list updated (iva as #4, figures renumbered).
- `skills/cotizacion-legal-baseline/SKILL.md`: canonical Impuestos clause (amounts plus IVA 16%, CFDI breakdown, note near the amount AND in payment terms, correct-in-thread protocol before the PO is cut).

Verified: fixture without the note FAILs on iva only (other checks green); two current fixtures with the note PASS end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)