### PR TITLE
fix(multi-runtime): Grok cache_r + Cursor MCP census + Q2 parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,21 @@ machine-generated growth ledger lives at
 
 ## [Unreleased]
 
+### Fixed
+- fix(finops): Grok `cache_r` for 4.3 / 4.20-* / build is **$0.20**/1M (docs.x.ai), not = input;
+  Composer/GPT unknown engines report `$0` list instead of silent Sonnet fallback.
+- fix(census): `capability-census.collect_mcps()` reads Cursor `.cursor/mcp.json` (user +
+  workspace + parent walk) so Q2 is not Claude-file-only prose.
+- fix(4d-protocol): Q2 skill matches CLAUDE.md — MCP-first, runtime-aware census.
+- fix(routing): Cursor Task bindings prefer harness allow-list slugs; mark xAI API-only names.
+- docs(multi-runtime): Honest gaps (Skill/Agent matcher drop, pricing TBD, allow-list ≠ API);
+  Architecture wiki points at multi-runtime; tone "supported peer" not overclaim.
+- chore(quickstart): project Cursor hooks + accept Cursor as a valid runtime prerequisite.
+
 ### Features
 - feat(multi-runtime): Octorato is for **all models and all editors**. New canon
   `docs/architecture/multi-runtime.md` — brain vs runtime vs engine; growth rule
-  (new editor/model = binding row, not a fork); Claude Code + Cursor first-class;
+  (new editor/model = binding row, not a fork); Claude Code + Cursor supported peers;
   Q2 MCP census is runtime-aware; identity = engine, OS = Octorato.
 - feat(routing): model ladder is **tier-first, vendor-second** (mechanical · bulk ·
   build · judgment). Claude Code bindings unchanged (Haiku/Sonnet/Opus/Fable);

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -312,8 +312,8 @@
 
 | Name | Description |
 |---|---|
-| README | Examples |
 | nexus-spatial-discovery | Nexus Spatial: Full Agency Discovery Exercise |
+| README | Examples |
 | workflow-book-chapter | Workflow Example: Book Chapter Development |
 | workflow-landing-page | Multi-Agent Workflow: Landing Page Sprint |
 | workflow-startup-mvp | Multi-Agent Workflow: Startup MVP |
@@ -460,8 +460,8 @@
 | Name | Description |
 |---|---|
 | EXECUTIVE-BRIEF | 📑 NEXUS Executive Brief |
-| QUICKSTART | ⚡ NEXUS Quick-Start Guide |
 | nexus-strategy | 🌐 NEXUS , Network of EXperts, Unified in Strategy |
+| QUICKSTART | ⚡ NEXUS Quick-Start Guide |
 
 ### support (7)
 

--- a/docs/architecture/multi-runtime.md
+++ b/docs/architecture/multi-runtime.md
@@ -1,7 +1,7 @@
 # Multi-runtime — all editors, all engines
 
 > **Status:** live as of 2026-07-10.
-> **Thesis:** Octorato is a **file-native agent OS**. It is not "a Claude Code config" and not "an Anthropic product." The brain grows as new **runtimes** (editors/harnesses) and **engines** (models) become known. Claude was first; Cursor + Grok are first-class peers; the next editor or model gets a binding row, not a fork of the OS.
+> **Thesis:** Octorato is a **file-native agent OS**. It is not "a Claude Code config" and not "an Anthropic product." The brain grows as new **runtimes** (editors/harnesses) and **engines** (models) become known. Claude was first; Cursor + Grok are **supported peers with live bindings** (see Honest gaps — not every Claude-shaped hook maps 1:1 yet). The next editor or model gets a binding row, not a fork of the OS.
 
 ## The invariant
 
@@ -56,6 +56,15 @@ Same priority everywhere: **registered MCP → register official MCP if one exis
 | Cursor | Inspect MCP servers via `GetMcpTools` / Cursor Settings → MCP (no `claude` CLI required) |
 
 `"No MCP connected" ≠ "no MCP available"` holds on every runtime.
+
+## Honest gaps (Cursor peer — do not overclaim)
+
+These are known, intentional, or pending — not silent failures:
+
+1. **`merge-hooks-cursor.py` drops `Skill` / `Agent` matchers** — Cursor has no equivalent tool names; those Claude-only PreToolUse gates do not project. Shell/Write/Edit-class gates still fire.
+2. **Composer / bundled GPT list prices** — `_pricing.py` reports `$0` list (UNKNOWN) rather than inventing Anthropic Sonnet rates. Add rows when a public list exists or when reconciling invoices.
+3. **Cursor Task allow-list ≠ xAI API names** — prefer harness slugs (`composer-2.5-fast`, `grok-4.5-fast-xhigh`, `gpt-5.5-medium`, …). Treat `grok-4.3` / `grok-build-0.1` as API/FinOps unless the harness lists them.
+4. **MCP census** — `capability-census.py` reads Claude registries **and** `.cursor/mcp.json` (user + workspace). In-session truth is still `GetMcpTools`.
 
 ## What stays Claude-shaped on purpose
 

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -6,7 +6,7 @@ The deep architecture reference for Octorato — the open-source AI-agent operat
 
 If you want the philosophy in one sentence: **one human consciousness directs a shared brain of specialist agents across many sealed client workspaces, and the data never crosses sideways.** That single constraint — and the biology that solves it — produces everything below.
 
-> **Companion pages:** [[The-4D-Paradigm]] (the nervous-system protocol every signal obeys) · [[Skills-System]] (the *HOW* layer) · [[Agents-System]] (the *WHO* layer) · [[Arms-and-Sync]] (the *FOR WHOM* layer + multi-machine sync) · [[Self-Growth]] (how the brain extends itself).
+> **Companion pages:** [[The-4D-Paradigm]] (the nervous-system protocol every signal obeys) · [[Skills-System]] (the *HOW* layer) · [[Agents-System]] (the *WHO* layer) · [[Arms-and-Sync]] (the *FOR WHOM* layer + multi-machine sync) · [[Self-Growth]] (how the brain extends itself) · multi-runtime (`docs/architecture/multi-runtime.md` — Claude Code + Cursor + engine bindings).
 
 ---
 

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -14,7 +14,7 @@ If you only read one thing: **the brain (`~/.claude/`) is a public git repo.** E
 
 | Tool | Required? | Why | Check |
 |---|---|---|---|
-| A **runtime** — [Claude Code](https://docs.anthropic.com/en/docs/claude-code) **or** [Cursor](https://cursor.com) | **Yes (one)** | The harness that loads `~/.claude/` and *runs* Octorato. Claude Code was first; Cursor is first-class (hooks projected by `merge-hooks-cursor.py`). More editors get a binding as they are used — see [[Architecture]] / `docs/architecture/multi-runtime.md` | `claude --version` **or** Cursor Agent with `CURSOR_AGENT=1` |
+| A **runtime** — [Claude Code](https://docs.anthropic.com/en/docs/claude-code) **or** [Cursor](https://cursor.com) | **Yes (one)** | The harness that loads `~/.claude/` and *runs* Octorato. Claude Code was first; Cursor is a **supported peer** (hooks projected by `merge-hooks-cursor.py`; see Honest gaps in `docs/architecture/multi-runtime.md`). More editors get a binding as they are used — see [[Architecture]] / `docs/architecture/multi-runtime.md` | `claude --version` **or** Cursor Agent with `CURSOR_AGENT=1` |
 | An **engine** the runtime can select (Claude family, Grok, GPT, Composer, …) | **Yes** | The model that reasons. Octorato is engine-agnostic; the ladder binds tiers to whatever the runtime exposes | Session model picker |
 | `git` | **Yes** | The brain is a git repo; sync is git push/pull | `git --version` |
 | GitHub account | **Yes** | To clone the public brain and (optionally) push your fork | `gh auth status` |

--- a/scripts/_pricing.py
+++ b/scripts/_pricing.py
@@ -51,17 +51,22 @@ PRICING: dict[str, dict[str, float]] = {
     "claude-haiku-4":      {"in":  0.80, "out":  4.00, "cache_w":  1.00, "cache_r": 0.08},
     "claude-3-5-sonnet":   {"in":  3.00, "out": 15.00, "cache_w":  3.75, "cache_r": 0.30},
     "claude-3-5-haiku":    {"in":  0.80, "out":  4.00, "cache_w":  1.00, "cache_r": 0.08},
-    # --- xAI Grok (docs.x.ai/developers/pricing, 2026-07-10) ---
-    # cache_w unused by xAI list table; set = input. cache_r = cached input.
+    # --- xAI Grok (docs.x.ai/developers/models/*, verified 2026-07-10) ---
+    # cache_w unused by xAI list table; set = input. cache_r = cached input
+    # (NOT equal to input — see each model page's "Cached input" row).
     "grok-4.5":            {"in":  2.00, "out":  6.00, "cache_w":  2.00, "cache_r": 0.50},
     "grok-4.5-fast-xhigh": {"in":  2.00, "out":  6.00, "cache_w":  2.00, "cache_r": 0.50},
     "grok-4.5-latest":     {"in":  2.00, "out":  6.00, "cache_w":  2.00, "cache_r": 0.50},
-    "grok-4.3":            {"in":  1.25, "out":  2.50, "cache_w":  1.25, "cache_r": 1.25},
-    "grok-4.20-0309-reasoning":     {"in": 1.25, "out": 2.50, "cache_w": 1.25, "cache_r": 1.25},
-    "grok-4.20-0309-non-reasoning": {"in": 1.25, "out": 2.50, "cache_w": 1.25, "cache_r": 1.25},
-    "grok-4.20-multi-agent-0309":   {"in": 1.25, "out": 2.50, "cache_w": 1.25, "cache_r": 1.25},
-    "grok-build-0.1":      {"in":  1.00, "out":  2.00, "cache_w":  1.00, "cache_r": 1.00},
+    "grok-4.3":            {"in":  1.25, "out":  2.50, "cache_w":  1.25, "cache_r": 0.20},
+    "grok-4.20-0309-reasoning":     {"in": 1.25, "out": 2.50, "cache_w": 1.25, "cache_r": 0.20},
+    "grok-4.20-0309-non-reasoning": {"in": 1.25, "out": 2.50, "cache_w": 1.25, "cache_r": 0.20},
+    "grok-4.20-multi-agent-0309":   {"in": 1.25, "out": 2.50, "cache_w": 1.25, "cache_r": 0.20},
+    "grok-build-0.1":      {"in":  1.00, "out":  2.00, "cache_w":  1.00, "cache_r": 0.20},
 }
+
+# Honest zero row for engines without a published list price (Cursor Composer,
+# bundled GPT slugs, etc.). Prefer under-report over inventing Anthropic rates.
+UNKNOWN_LIST = {"in": 0.0, "out": 0.0, "cache_w": 0.0, "cache_r": 0.0}
 
 
 def _normalize_model_name(model: str) -> str:
@@ -98,8 +103,9 @@ def _price_per_model(model: str) -> dict[str, float]:
         return PRICING["claude-haiku-4-5"]
     if "sonnet" in base or "claude" in base:
         return PRICING["claude-sonnet-4-6"]
-    # Unknown vendor/engine — Sonnet-class placeholder so FinOps never NaNs.
-    return PRICING["claude-sonnet-4-6"]
+    # Composer / GPT / unknown — do NOT silently bill as Sonnet (invented USD).
+    # Cursor subscription engines have no public list price in this table yet.
+    return UNKNOWN_LIST
 
 
 def usage_to_usd(usage: dict, model: str = "claude-sonnet-4-6") -> float:

--- a/scripts/capability-census.py
+++ b/scripts/capability-census.py
@@ -44,11 +44,41 @@ def read_prompt() -> str:
         return ""
 
 
+def _mcp_candidates() -> list[Path]:
+    """Claude Code + Cursor registry paths (runtime-aware, no subprocess)."""
+    cwd = Path.cwd()
+    out: list[Path] = [
+        HOME / ".claude.json",
+        BRAIN / "settings.json",
+        HOME / ".cursor" / "mcp.json",  # Cursor user-scope
+        cwd / ".mcp.json",
+        cwd / ".cursor" / "mcp.json",  # Cursor workspace-scope (e.g. NFG)
+    ]
+    # Walk parents for workspace .cursor/mcp.json when CWD is an arm subfolder.
+    for parent in cwd.parents:
+        out.append(parent / ".cursor" / "mcp.json")
+        out.append(parent / ".mcp.json")
+        if parent == HOME or parent.name == "":
+            break
+        # Stop at common repo roots to keep the 2s budget.
+        if (parent / ".git").exists():
+            break
+    # Dedupe while preserving order.
+    seen: set[Path] = set()
+    uniq: list[Path] = []
+    for p in out:
+        rp = p.resolve() if p.exists() else p
+        if rp in seen:
+            continue
+        seen.add(rp)
+        uniq.append(p)
+    return uniq
+
+
 def collect_mcps() -> list[str]:
-    """Live MCP server names from the registry files (fast, no subprocess)."""
+    """Live MCP server names from Claude + Cursor registry files (fast)."""
     names: set[str] = set()
-    candidates = [HOME / ".claude.json", BRAIN / "settings.json", Path.cwd() / ".mcp.json"]
-    for p in candidates:
+    for p in _mcp_candidates():
         try:
             data = json.loads(p.read_text(encoding="utf-8"))
         except Exception:

--- a/scripts/quickstart.py
+++ b/scripts/quickstart.py
@@ -3,13 +3,14 @@
 
 A stranger clones the brain and runs this. No company brain, no sealed worlds, no
 config: it checks prerequisites, wires the bin runners, builds the connectome,
-runs the health check, and prints the first thing to TRY so the brain proves
-itself alive. The 5-minute "it works" moment.
+projects Cursor hooks when present, runs the health check, and prints the first
+thing to TRY so the brain proves itself alive. The 5-minute "it works" moment.
 
 Going further (your own brain + sealed worlds + multi-machine sync) is a separate,
 later step, documented in the README.
 
-Idempotent. Safe to re-run. No network, no writes outside ~/.claude.
+Idempotent. Safe to re-run. No network, no writes outside ~/.claude (and
+~/.cursor/hooks.json when Cursor is installed).
 """
 from __future__ import annotations
 
@@ -51,7 +52,7 @@ def run_script(rel: str, *args) -> bool:
 
 def main() -> int:
     print(_c("1;35", "\n🐙  Octorato quickstart. Let's bring your brain to life.\n"))
-    total = 4
+    total = 5
 
     # 1. Prerequisites
     step(1, total, "Checking prerequisites")
@@ -66,11 +67,21 @@ def main() -> int:
     else:
         err("  ✗ git not found. Install it first.")
         ok = False
-    if shutil.which("claude"):
+    has_claude = bool(shutil.which("claude"))
+    cursor_home = Path.home() / ".cursor"
+    has_cursor = cursor_home.is_dir()
+    if has_claude:
         info("  ✓ Claude Code CLI (`claude`)")
     else:
-        warn("  ! Claude Code CLI not on PATH. Octorato is its brain, so install it:")
-        warn("    https://docs.claude.com/claude-code")
+        warn("  ! Claude Code CLI not on PATH.")
+    if has_cursor:
+        info(f"  ✓ Cursor runtime detected ({cursor_home})")
+    else:
+        warn("  ! ~/.cursor not found (Cursor IDE not installed on this machine).")
+    if not has_claude and not has_cursor:
+        warn("  ! No runtime detected yet. Install Claude Code and/or Cursor:")
+        warn("    https://docs.claude.com/claude-code  |  https://cursor.com")
+        warn("    Continuing — brain files still wire; you need one runtime to run agents.")
     if not (CLAUDE / "CLAUDE.md").exists():
         err(f"  ✗ This doesn't look like a brain checkout ({CLAUDE}/CLAUDE.md missing).")
         err("    Clone first:  git clone https://github.com/CarlosCaPe/octorato.git ~/.claude")
@@ -88,8 +99,15 @@ def main() -> int:
     step(3, total, "Building the connectome (the skill/agent graph)")
     run_script("scripts/generate_neural_map.py")
 
-    # 4. Health check
-    step(4, total, "Running the brain health check")
+    # 4. Project hooks into Cursor when present
+    step(4, total, "Projecting fail-closed hooks → Cursor (no-op if Cursor absent)")
+    if has_cursor:
+        run_script("scripts/merge-hooks-cursor.py")
+    else:
+        warn("  (skipped: no ~/.cursor — run merge-hooks-cursor.py after installing Cursor)")
+
+    # 5. Health check
+    step(5, total, "Running the brain health check")
     healthy = run_script("scripts/brain_doctor.py")
 
     # First-value moment
@@ -102,7 +120,9 @@ def main() -> int:
     print("─" * 64)
     print("""
 TRY IT NOW (the 5-minute proof):
-  1. Open Claude Code in any folder:   claude
+  1. Open a runtime in any folder:
+       Claude Code:   claude
+       Cursor:        Agent chat (CURSOR_AGENT=1) with this brain loaded
   2. Ask it something real, e.g.:
        "summarize what this repo does and propose one improvement"
   3. Watch what a brain adds on top of a plain agent:
@@ -110,7 +130,7 @@ TRY IT NOW (the 5-minute proof):
        • the 2D delegate gate picking the right skill/agent for the task
        • skills loading themselves from this library
 
-WHY THIS, NOT PLAIN CLAUDE CODE:
+WHY THIS, NOT A STOCK EDITOR AGENT:
   Your AI agent forgets who you are and mixes your worlds. An octorato is its
   second brain: memory that lasts, every world sealed from the others, and a
   receipt on every action. One brain for clients, projects, courses, anything

--- a/skills/4d-paradigm-protocol/SKILL.md
+++ b/skills/4d-paradigm-protocol/SKILL.md
@@ -107,18 +107,26 @@ python3 ~/.claude/scripts/query_connectome.py query "<task description>"
 - Uses the IDF dictionary and top-200 TF-IDF vectors stored in `neural_map.json` (falls back to keyword matching if index is missing)
 - Complements Q3 — together they cover both deep semantic similarity AND rule-based triggers
 
-### Q2: ¿TIENE API? (API-First — Token Efficiency)
+### Q2: ¿TIENE MCP/API? (Token-efficient access — runtime-aware)
 
-Before any browser automation or scraping, check:
+Before any browser automation or scraping, run a **concrete MCP census** (not a mental check), then fall down the ladder:
 
 | Priority | Access method | Token cost | When to use |
 |---|---|---|---|
-| 1 | **REST API** | ~200 tokens/call | Always prefer. Structured JSON, cheapest |
-| 2 | **MCP server** | ~300 tokens/call | If integrated (GitHub, Gmail, Notion, etc.) |
-| 3 | **SDK / CLI** | ~500 tokens/call | Programmatic access, typed responses |
-| 4 | **Scraping** | ~5,000+ tokens/call | Last resort — snapshots are token-expensive |
+| 1 | **Registered MCP** | ~300 tokens/call | Already wired on this runtime — use it |
+| 2 | **Register official MCP** | one-time setup | Official server exists but not connected yet ("no MCP connected" ≠ "no MCP available") |
+| 3 | **REST API** | ~200 tokens/call | Structured JSON when no MCP path |
+| 4 | **SDK / CLI** | ~500 tokens/call | Programmatic access, typed responses |
+| 5 | **Scraping** | ~5,000+ tokens/call | Last resort — snapshots are token-expensive |
 
-**Check sequence:** search for `<target> API documentation`, check if an MCP server exists, check if a CLI/SDK is installed. Fall back to scraping only when all 3 are exhausted.
+**Runtime-aware census (pick the active harness):**
+
+| Runtime | Concrete check |
+|---|---|
+| Claude Code | `claude mcp list` (+ `claude mcp add …` to register) |
+| Cursor (`CURSOR_AGENT=1`) | `GetMcpTools` / Settings → MCP (no `claude` CLI). Heartbeat also reads `.cursor/mcp.json` via `capability-census.py` |
+
+**Check sequence:** census live MCPs → web-search `<service> MCP server` if none → REST docs → SDK/CLI → scrape only when exhausted. See `docs/architecture/multi-runtime.md`.
 
 **If the task does not involve external data access** (pure code edit, file manipulation, git operations), answer: `Q2 API-first: N/A (no external data access)`
 
@@ -146,7 +154,7 @@ After all 3, follow the COMBINED recommendation:
 ```
 2D Delegate: [domain classification]
   Q1 Ventosas:  [top agent] (score X) + [N skills via connectome]
-  Q2 API-first: [YES api.example.com / NO → scraping / N/A]
+  Q2 MCP/API:   [YES mcp-X / YES api.example.com / NO → scraping / N/A]
   Q3 Delegate:  ACTIVATE / LOAD / SELF — [reason]
 ```
 
@@ -352,7 +360,7 @@ grep -rn "$OBJECT" . --include="*.py" --include="*.md" --include="*.sh" \
 | `~/.claude/scripts/delegate-check "<task>"` | START of every task (2D Q3 — rule match) |
 | `~/.claude/scripts/gate-check` | BEFORE any file write (4D Gate). Flags: `--validate-session`, `--checklist`, `--audit-log` |
 
-Q2 (API-first) is a mental check, no script — evaluate before scraping.
+Q2 is a runtime-aware MCP census (Claude Code CLI or Cursor GetMcpTools / `.cursor/mcp.json`), not a mental check — evaluate before scraping.
 
 ## Lessons Learned
 

--- a/skills/model-routing-by-complexity/SKILL.md
+++ b/skills/model-routing-by-complexity/SKILL.md
@@ -58,16 +58,16 @@ Pass these via the Agent/Workflow `model` parameter (`haiku` \| `sonnet` \| `opu
 
 ### Cursor + xAI Grok (and other Cursor engines)
 
-Detect with `CURSOR_AGENT=1`. Use the **Cursor Task `model` slugs** the harness exposes (do not invent Anthropic aliases here — Cursor will reject or ignore them).
+Detect with `CURSOR_AGENT=1`. Use **only** Cursor Task `model` slugs the harness allow-lists (passing an unlisted slug fails or is ignored). API-only xAI names below are for FinOps / direct API — **not** for `Task` unless the harness lists them.
 
-| Tier | Preferred Cursor / xAI slug | Fallback if unavailable |
+| Tier | Preferred Cursor Task slug (allow-listed) | API-only / if unavailable |
 |---|---|---|
-| mechanical | `composer-2.5-fast` | `grok-build-0.1` (API) / smallest fast model the harness lists |
-| bulk | mid Grok (`grok-4.3` / `grok-4.20-*`) or `gpt-5.5-medium` | next mid-tier the harness lists |
+| mechanical | `composer-2.5-fast` | `grok-build-0.1` (xAI API) / smallest fast slug the harness lists |
+| bulk | `gpt-5.5-medium` (or mid GPT the harness lists) | mid Grok API (`grok-4.3` / `grok-4.20-*`) — only if Task allow-lists them |
 | build | `grok-4.5-fast-xhigh` (or session Grok 4.5) | inherit session model when already on build-tier Grok |
-| judgment | strongest **independent** engine ≥ builder | Prefer a *different vendor* when Cursor offers one (e.g. Claude Opus / GPT high for a Grok builder). If only Grok is available, spawn a **fresh** Task on the same Grok tier (independent context). Never drop below the builder. |
+| judgment | strongest **independent** engine ≥ builder (e.g. `claude-opus-4-8-thinking-high` for a Grok builder) | Prefer a *different vendor* when Cursor offers one. If only Grok is available, spawn a **fresh** Task on the same Grok tier (independent context). Never drop below the builder. |
 
-List prices for FinOps live in `scripts/_pricing.py` (Anthropic + xAI). Cursor subscription billing may differ from list — treat USD as value-extracted unless reconciling a real invoice.
+List prices for FinOps live in `scripts/_pricing.py` (Anthropic + xAI). Composer / bundled GPT have **no list row yet** — FinOps reports `$0` list rather than inventing Sonnet rates. Cursor subscription billing may differ from list — treat USD as value-extracted unless reconciling a real invoice.
 
 ## How to apply in Octorato tooling
 


### PR DESCRIPTION
## Summary
- Fix Grok `cache_r` to $0.20 for 4.3 / 4.20-* / build (docs.x.ai)
- `capability-census` reads Cursor `.cursor/mcp.json` (user + workspace)
- Align `4d-paradigm-protocol` Q2 with CLAUDE.md (MCP-first, runtime-aware)
- Prefer Cursor Task allow-list slugs; honest gaps instead of first-class overclaim
- `quickstart` projects Cursor hooks

## Test plan
- [x] `collect_mcps()` from `clients/adh` returns `mcp-github-adh`, `mcp-teams-adh`
- [x] `tokens_to_usd_simple(1e6,0,cache_read=1e6, model=grok-4.3)` == 1.45
- [ ] CI / required checks green
- [ ] Merge closes review gaps from PR #197 follow-up

Made with [Cursor](https://cursor.com)