### PR TITLE
feat: graphify deep-learn — code-graph skill + connectome shrink-guard

### DIFF
--- a/connectome/lineage.yaml
+++ b/connectome/lineage.yaml
@@ -399,3 +399,19 @@ edges:
       land there). Change the canonical query or the triage method and reconcile
       the reflex script + the skill doc + the hooks.json registration together.
       Edge added 2026-06-18 after the seek fell back to grep (unlit neuron).
+
+  - id: connectome-shrink-guard
+    concept: "shrink-guard: refuse to regenerate a smaller graph / graphify code-graph skill"
+    appears_in:
+      - scripts/generate_neural_map.py
+      - skills/graphify-code-graph/SKILL.md
+    kind: appears_in
+    single_source: "scripts/generate_neural_map.py (SHRINK_TOLERANCE + shrink_guard(), --allow-shrink override)"
+    note: >-
+      A partial skills/agents checkout must not silently shrink neural_map.json
+      and propagate via ai-push as if regeneration succeeded; the guard exits
+      non-zero past a 10% node drop. The invariant was adopted from the graphify
+      deep-learn (their export safety check); the skill documents both the tool
+      and the cross-reference. Change the tolerance or the flag and reconcile
+      the script + the skill Gotchas together. Edge added 2026-07-16 at skill
+      creation so the neuron is born lit.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -6,7 +6,7 @@
 
 | Metric | Count |
 |---|---|
-| Skills | 231 |
+| Skills | 232 |
 | Agents | 161 |
 | Divisions | 15 |
 | Scripts: wired | 84 |
@@ -14,7 +14,7 @@
 | Rules | 58 |
 | Hook entries | 31 |
 
-## Skills (231)
+## Skills (232)
 
 | Name | Description |
 |---|---|
@@ -96,6 +96,7 @@
 | gh-address-comments | Help address review/issue comments on the open GitHub PR for the current branch using gh CLI; verify gh auth first and p... |
 | gh-fix-ci | Use when a user asks to debug or fix failing GitHub PR checks that run in GitHub Actions; use `gh` to inspect checks and... |
 | github-trending-curation | Daily brain discovery loop. Pulls top trending from GitHub + HN + Product Hunt, runs heuristic + LLM filter against exis... |
+| graphify-code-graph | Build a deterministic, queryable knowledge graph over any codebase with graphify (tree-sitter AST over 25+ languages, Le... |
 | gsap-core | Official GSAP skill for the core API , gsap.to(), from(), fromTo(), easing, duration, stagger, defaults, gsap.matchMedia... |
 | gsap-frameworks | Official GSAP skill for Vue, Svelte, and other non-React frameworks , lifecycle, scoping selectors, cleanup on unmount. ... |
 | gsap-performance | Official GSAP skill for performance , prefer transforms, avoid layout thrashing, will-change, batching. Use when optimiz... |
@@ -312,8 +313,8 @@
 
 | Name | Description |
 |---|---|
-| nexus-spatial-discovery | Nexus Spatial: Full Agency Discovery Exercise |
 | README | Examples |
+| nexus-spatial-discovery | Nexus Spatial: Full Agency Discovery Exercise |
 | workflow-book-chapter | Workflow Example: Book Chapter Development |
 | workflow-landing-page | Multi-Agent Workflow: Landing Page Sprint |
 | workflow-startup-mvp | Multi-Agent Workflow: Startup MVP |
@@ -460,8 +461,8 @@
 | Name | Description |
 |---|---|
 | EXECUTIVE-BRIEF | 📑 NEXUS Executive Brief |
-| nexus-strategy | 🌐 NEXUS , Network of EXperts, Unified in Strategy |
 | QUICKSTART | ⚡ NEXUS Quick-Start Guide |
+| nexus-strategy | 🌐 NEXUS , Network of EXperts, Unified in Strategy |
 
 ### support (7)
 

--- a/scripts/brain_doctor.py
+++ b/scripts/brain_doctor.py
@@ -404,8 +404,9 @@ def check_connectome_fresh(fix: bool) -> Result:
             cp = run([PYTHON or "python3", str(gen)], cwd=CLAUDE_DIR)
             if cp.returncode == 0:
                 return Result(key, PASS, "neural_map.json regenerated")
-            return Result(key, FAIL, f"regeneration failed: {cp.stderr.strip()[:80]}",
-                          "run generate_neural_map.py manually")
+            return Result(key, FAIL, f"regeneration failed: {cp.stderr.strip()[:240]}",
+                          "run generate_neural_map.py manually; if it reports "
+                          "SHRINK-GUARD, re-run with --allow-shrink once verified")
     return Result(key, WARN, f"neural_map.json stale — {rel} is newer",
                   "run `python3 scripts/generate_neural_map.py` (or --fix)")
 

--- a/scripts/generate_neural_map.py
+++ b/scripts/generate_neural_map.py
@@ -990,10 +990,45 @@ def print_summary(connectome):
     print(f"\nGeneration time: {meta['generation_time_sec']}s")
 
 
+# Refuse to silently replace the connectome with a much smaller one: a partial
+# skills/agents checkout (broken glob, interrupted sync) would otherwise shrink
+# the graph that THIS machine's heartbeat and query_connectome.py read, looking
+# like a successful regeneration. neural_map.json is gitignored, so the damage
+# is local-only, but silent. Only D1/D2 are guarded: D3 arm counts come from
+# the gitignored company config and legitimately differ per machine. Deliberate
+# prunes stay under the tolerance; bigger cuts need --allow-shrink.
+SHRINK_TOLERANCE = 0.10
+
+
+def shrink_guard(connectome, allow_shrink=False):
+    """Exit non-zero if the new graph lost >SHRINK_TOLERANCE of nodes."""
+    if allow_shrink or not OUTPUT_FILE.exists():
+        return
+    try:
+        prev = json.loads(OUTPUT_FILE.read_text(encoding="utf-8"))
+        prev_counts = {
+            dim: prev["dimensions"][dim]["count"] for dim in ("D1_WHO", "D2_HOW")
+        }
+    except (OSError, ValueError, KeyError, TypeError):
+        return  # previous map unreadable: nothing trustworthy to compare against
+    for dim, prev_count in prev_counts.items():
+        new_count = connectome["dimensions"][dim]["count"]
+        floor = int(prev_count * (1 - SHRINK_TOLERANCE))
+        if new_count < floor:
+            label = connectome["dimensions"][dim]["label"]
+            sys.exit(
+                f"SHRINK-GUARD: {label} would drop {prev_count} -> {new_count} "
+                f"(floor {floor}, tolerance {SHRINK_TOLERANCE:.0%}). Refusing to "
+                f"overwrite {OUTPUT_FILE.name}. If the shrink is deliberate, "
+                f"re-run with --allow-shrink."
+            )
+
+
 def main():
     connectome = generate_connectome()
     print_summary(connectome)
 
+    shrink_guard(connectome, allow_shrink="--allow-shrink" in sys.argv[1:])
     OUTPUT_FILE.write_text(
         json.dumps(connectome, indent=2, ensure_ascii=False),
         encoding="utf-8",

--- a/skills/graphify-code-graph/SKILL.md
+++ b/skills/graphify-code-graph/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: graphify-code-graph
+description: Build a deterministic, queryable knowledge graph over any codebase with graphify (tree-sitter AST over 25+ languages, Leiden clustering, flat graph.json, zero LLM cost for code-only corpora) and query it via CLI or MCP. Use inside a client repo for code-level impact analysis (graphify affected), symbol path tracing, and architecture questions that grep answers poorly. Complements the brain's connectome/lineage graphs: graphify maps CODE SYMBOLS, the connectome maps CONCEPTS and governance. auto-promoted 2026-07-16 from repo-deep-learn (https://github.com/Graphify-Labs/graphify).
+metadata:
+  type: tool-skill
+  source: https://github.com/Graphify-Labs/graphify (MIT)
+  deep-learn: knowledge/repo-deep-learn/graphify/2026-07-16.md
+---
+
+# Graphify: deterministic code knowledge graph
+
+## When to use
+
+- A code question spans many files ("what breaks if I change X?", "how does A reach B?") and grep gives partial, noisy answers.
+- Onboarding into a large or unfamiliar codebase (client repo, OSS dependency).
+- Repeated architecture questions in one repo: build the graph once, query it every session at near-zero token cost.
+
+Not for concept/governance recall. Which skill knows this, where does a rule live, what derives from a doc: that is the brain's connectome (`query_connectome.py`) and lineage (`impact-radius.py`). Graphify maps code symbols; those map concepts. Two layers, keep both.
+
+## Install (one time per machine)
+
+```bash
+uv tool install graphifyy      # or: pipx install graphifyy
+graphify install               # registers the /graphify skill with the AI assistant
+```
+
+The PyPI package is `graphifyy` (double y); the CLI is `graphify`.
+
+## Build the graph (inside the target repo)
+
+```bash
+graphify .          # writes graphify-out/graph.json + GRAPH_REPORT.md + graph.html
+graphify update .   # incremental re-extract of changed paths only, AST-only, no API cost
+graphify watch      # keep it fresh on file changes
+```
+
+The code pass is fully deterministic: tree-sitter AST, no LLM, no API key, $0. Only the optional semantic pass (docs, PDFs, images, video, community labels) calls an LLM; without a key it is skipped entirely. Add `graphify-out/` to the repo's `.gitignore` unless the team wants the artifact versioned.
+
+## Query it
+
+```bash
+graphify query "how does auth reach the billing module"
+graphify affected src/auth/session.py    # code-level impact radius
+graphify path NodeA NodeB                # shortest path between symbols
+graphify explain "PaymentProcessor"      # natural-language node explanation
+graphify diagnose                        # graph health
+```
+
+Matching is case-folded substring + IDF over the flat `graph.json` (NetworkX node-link format). No server, no embeddings. For assistant integration without shell calls there is an MCP server: `graphify-mcp` (stdio/HTTP).
+
+## Arm usage pattern
+
+Run it inside ONE arm's repo; the graph lives in that repo's `graphify-out/` and never leaves the arm (arm isolation applies to the artifact like to any other client data). Start every code-impact question with `graphify affected <file>` and fall back to grep only for symbols the graph does not know, same seek-before-scan discipline as the brain's graphs.
+
+## Gotchas
+
+- Edges carry `confidence` (EXTRACTED / INFERRED / AMBIGUOUS, 0.55-0.95 rubric): trust EXTRACTED, verify INFERRED before acting on it.
+- The exporter refuses to silently shrink an existing graph (their issue #479). The brain adopted the same invariant in `scripts/generate_neural_map.py` (SHRINK-GUARD).
+- Exports available when a human wants to browse: Obsidian vault, GraphML (Gephi/yEd), SVG, Cypher (Neo4j/FalkorDB).
+
+## See also
+
+- [[repomix]]: flat single-file codebase packing, the non-graph alternative for one-shot context stuffing.
+- [[4d-paradigm-protocol]]: `graphify affected` is the code-level twin of the concept-level Impact Radius scan.


### PR DESCRIPTION
Deep-learn of Graphify-Labs/graphify (88.5k stars, MIT). Two changes:

1. **skills/graphify-code-graph/SKILL.md**: tool-skill for building a deterministic code knowledge graph (tree-sitter AST over 25+ languages, Leiden clustering, flat graph.json, query via CLI or MCP, zero LLM cost for code-only corpora). Positioned as the code-symbol layer complementing the concept-level connectome/lineage graphs, never replacing them. Lineage edge added at creation.

2. **scripts/generate_neural_map.py + brain_doctor.py**: shrink-guard invariant adopted from graphify's export safety check. Regeneration now refuses to overwrite neural_map.json when agent or skill counts drop >10% vs the existing map (a partial checkout would otherwise silently shrink the graph the heartbeat reads); `--allow-shrink` overrides deliberate prunes. brain_doctor --fix surfaces the remedy instead of truncating it.

QA (independent Code Reviewer, judgment tier): initial verdict NEEDS WORK, 3 required findings, all fixed: guard comment no longer overclaims push propagation (neural_map.json is gitignored, damage is local-only), brain_doctor truncation widened 80→240 chars + actionable hint, skill claims `graphify update` and the exporters list verified against upstream source (cli.py:1435; export.py:334,404,735,913,976). Shrink-guard fixture test 6/6 PASS (no-prev, within-tolerance, block, override, corrupt-prev, growth). lineage-doctor: 25 edges, sound.

Safety note from QA: the guard cannot brick ai-push (both callers tolerate non-zero exit; old graph survives, push proceeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeoALJCxPDJq4kwXyRFTeq