### PR TITLE
feat(brain): link /ai-sync and daily-reflection as one ritual

### DIFF
--- a/commands/ai-sync.md
+++ b/commands/ai-sync.md
@@ -2,7 +2,11 @@ Reconcile the AI brain (~/.claude) with its remote in ONE race-safe command: int
 
 ## Steps: execute in order using Bash tool
 
-### 1. Run the sync runner
+### 1. Daily reflection (linked ritual)
+
+/ai-sync and the `daily-reflection` skill are two halves of one ritual: the sync publishes the day's work, the reflection distils its lesson. If this session did substantive work and no reflection has run yet, run the `daily-reflection` skill FIRST (mistakes-first retro, distil the sharpest lesson to brain memory, then `python3 ~/.claude/scripts/memory_sync.py push`) so the lesson persists in the same beat that publishes the work. Skip only when the session was trivial (pure Q&A, nothing shipped) and say so in the report.
+
+### 2. Run the sync runner
 
 `$ARGUMENTS` is an optional commit message for any local changes the runner commits.
 
@@ -18,10 +22,10 @@ python3 ~/.claude/scripts/ai_sync.py cycle "$ARGUMENTS"
 
 The runner handles everything internally: rebase-pull, generic-content gate, secret scan, commit, push with retry on non-fast-forward, connectome regen, arm sync, and a closing brain_doctor pass. Do NOT wrap it with your own git pull/push.
 
-### 2. Dimension safety (multi-session machines)
+### 3. Dimension safety (multi-session machines)
 
 If another live session shares the ~/.claude working tree, broad staging is gated by the dimension hook. When the runner reports a staging denial, do not force it: commit your session's files by explicit pathspec from your own dimension worktree and re-run the sync. Never `git add -A` on the shared tree.
 
-### 3. Report
+### 4. Report
 
-Show: what was pulled (commits behind before/after), what was committed and pushed (or "nothing to commit"), arms synced, and the brain_doctor verdict. If the push was rejected by branch protection (GH006), follow the auto-PR fallback documented in /ai-push step 3b and report the PR URL instead.
+Show: what was pulled (commits behind before/after), what was committed and pushed (or "nothing to commit"), arms synced, the brain_doctor verdict, and whether the daily reflection ran (name the memory it wrote) or why it was skipped. If the push was rejected by branch protection (GH006), follow the auto-PR fallback documented in /ai-push step 3b and report the PR URL instead.

--- a/connectome/lineage.yaml
+++ b/connectome/lineage.yaml
@@ -415,3 +415,16 @@ edges:
       and the cross-reference. Change the tolerance or the flag and reconcile
       the script + the skill Gotchas together. Edge added 2026-07-16 at skill
       creation so the neuron is born lit.
+
+  - id: sync-reflection-ritual
+    concept: "linked ritual: /ai-sync runs daily-reflection first; the reflection closes with /ai-sync"
+    appears_in:
+      - commands/ai-sync.md
+      - skills/daily-reflection/SKILL.md
+    kind: appears_in
+    note: >-
+      The sync and the reflection are two halves of one ritual: publish the
+      day's work and distil its lesson in the same beat. The linkage text lives
+      on both sides; change the trigger condition, the skip rule, or the
+      co-tenancy stance on one side and reconcile the other in the same commit.
+      Edge added 2026-07-20 at linkage creation so the neuron is born lit.

--- a/skills/daily-reflection/SKILL.md
+++ b/skills/daily-reflection/SKILL.md
@@ -59,6 +59,12 @@ This is what separates this skill from "a nice answer":
 3. `python3 ~/.claude/scripts/memory_sync.py push` so it persists cross-machine.
 4. Before writing, check for an existing memory that already covers it. Update
    that file rather than duplicating.
+5. Close the ritual with the canonical sync: run `/ai-sync` (the
+   `~/.local/bin/ai-sync` runner) so any public brain changes from the session
+   reconcile with the remote in the same beat. The link is two-way: `/ai-sync`
+   runs this reflection before syncing, and this reflection ends by syncing.
+   If the co-tenancy guard aborts (another live session on the brain tree),
+   report that and leave the sync to the surviving session; never override it.
 
 A reflection without this step is half-done. The operator will catch it.
 
@@ -77,5 +83,8 @@ A reflection without this step is half-done. The operator will catch it.
 - **`daily-reflection`** (this): session → BEHAVIOR/discipline retro → memory.
   Use for the "how should I act better" question. They compose: a session can
   produce both a draft skill and a discipline memory.
+- **`/ai-sync`**: the other half of this ritual. The sync command runs this
+  reflection first when the session did substantive work; this skill closes by
+  running the sync. Publish and learn travel together.
 - See also `feedback_verify_visually_before_claiming`, `reflexes-over-discipline`,
   `transcend-the-marionette` for the reflex-over-willpower stance.


### PR DESCRIPTION
The sync publishes the day's work; the reflection distils its lesson. Now they travel together:

- `commands/ai-sync.md`: new step 1 runs the `daily-reflection` retro first when the session did substantive work (skippable on trivial sessions, stated in the report); report line added.
- `skills/daily-reflection/SKILL.md`: new closing step runs the canonical `/ai-sync` cycle, co-tenancy guard respected (report the abort, never override).
- `connectome/lineage.yaml`: edge `sync-reflection-ritual` (appears_in, both files) so the linkage stays reconciled; born lit.

Verified: cadence-lint clean on both prose files, lineage-doctor sound (26 edges), brain_doctor 25 pass / 6 warn (worktree-environmental) / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8sYhDqDwe21ezmi8jut6q