### PR TITLE
feat(brain): inject today's weekday as data in the 4D reminder

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -11,7 +11,7 @@
 | Divisions | 15 |
 | Scripts: wired | 85 |
 | Scripts: orphan | 6 |
-| Rules | 59 |
+| Rules | 60 |
 | Hook entries | 32 |
 
 ## Skills (232)
@@ -585,7 +585,7 @@
 | validate-skill-manifest.py | validate-skill-manifest.py , validate a skill.json against the M5 manifest schema (issue #31). | wired |
 | watchdog.py | watchdog.py , observability surface 4 anomaly detector. Reads the JSONL trace files written by trace... | wired |
 
-## Rules (59)
+## Rules (60)
 
 ### ARCHITECTURE
 
@@ -629,6 +629,7 @@
 - FLOW.4d-paradigm
 - FLOW.4d-spec-enhancement
 - FLOW.budget-halt
+- FLOW.calendar-facts-as-data
 - FLOW.canon-heal
 - FLOW.delegate-gate
 - FLOW.enforcement-scripts

--- a/registry/rules.yaml
+++ b/registry/rules.yaml
@@ -1448,3 +1448,25 @@ rules:
     locator: scripts/g__pretool-mcp__chat-context.py --selftest registry/fixtures/COMMS.chat-context-before-send
     expect: 0
   liveness_required: FIRES
+- id: FLOW.calendar-facts-as-data
+  title: Calendar facts are injected data, never mental derivation (weekday class)
+  category: FLOW
+  source:
+    file: CLAUDE.md
+    anchor: Never invent data
+  strength: REFLEX
+  firing_mode:
+  - hook
+  mechanism:
+  - kind: Reflex
+    canonical_name: 4d-reminder.py
+    firing_event: UserPromptSubmit
+    firing_matcher: null
+  proof:
+  - method: IN_HOOKS_JSON
+    locator: UserPromptSubmit|*|4d-reminder.py
+    expect: present
+  - method: ANCHOR_PRESENT
+    locator: Never invent data
+    expect: present
+  liveness_required: FIRES

--- a/scripts/4d-reminder.py
+++ b/scripts/4d-reminder.py
@@ -9,6 +9,7 @@ Emits JSON on stdout per the UserPromptSubmit hook contract:
   { "hookSpecificOutput": { "hookEventName": "UserPromptSubmit",
                             "additionalContext": "<reminder>" } }
 """
+import datetime
 import json
 import sys
 # Force UTF-8 on stdout/stderr so the ✓ / ✗ / em-dash glyphs in reports
@@ -34,7 +35,16 @@ except Exception:
 # RENDER (1D / 2D verdict / 3D) sits LAST in this string, closest to
 # generation; the verbose footer spec sits earlier and compressed (full spec
 # lives in skills/4d-paradigm-protocol). No em-dashes (brain cadence rule 1).
+# Calendar facts are DATA, never derivation. A model computing a weekday in
+# its head is modular arithmetic in one forward pass: it fails silently and
+# fluently (the weekday-hallucination class). Injecting today's weekday kills
+# the whole class; anything beyond it (days-between, deadlines) must come from
+# a tool receipt (`date`, python), never mental math.
+_TODAY = datetime.date.today()
 REMINDER = (
+    f"TODAY IS: {_TODAY.strftime('%A')} {_TODAY.isoformat()} (injected as data; "
+    "for any other date arithmetic run `date`/python and cite the receipt, "
+    "never derive it mentally).\n"
     "4d: Apply the 4D paradigm to this turn. Do not skip it.\n"
     "4D Disclose: state side effects + Impact Radius. 4D Gate: present a Change "
     "Manifest before the first file write and wait for confirmation.\n"


### PR DESCRIPTION
## Why
A model deriving a weekday is one-pass modular arithmetic: it fails silently and fluently (the weekday-hallucination class). The date was injected as text but the weekday was not, so the model filled the gap with the most fluent guess.

## What
- `scripts/4d-reminder.py` (UserPromptSubmit): injects `TODAY IS: <weekday> <ISO date>` as the first line of the 4D reminder, plus the instruction that any other date arithmetic must come from a `date`/python receipt, never mental derivation.
- `registry/rules.yaml`: new rule `FLOW.calendar-facts-as-data` (REFLEX, mechanism = 4d-reminder.py, anchor: Never invent data).
- `docs/CAPABILITIES.md`: regenerated (rules 59 -> 60).

## Evidence
- Hook run: `TODAY IS: Thursday 2026-07-23 (...)` first line verified.
- `brain_doctor`: 23 passed; only local-env FAIL is `neural_map.json missing` (gitignored artifact of a fresh worktree, regenerated by ai-push; unrelated to this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gjN4vww1Fvwj7fVCr518m