### PR TITLE
fix(connectome): name cross-layer gaps for what they measure

### DIFF
--- a/scripts/generate_neural_map.py
+++ b/scripts/generate_neural_map.py
@@ -21,7 +21,7 @@ Biological principles implemented:
   2. Multi-layer synapses  — agent↔skill, agent↔agent, skill↔skill
   3. Hebbian learning      — "neurons that fire together wire together"
   4. Zero broken synapses  — every connection validated at build time
-  5. Gap detection         — isolated neurons, orphan synapses, blind spots
+  5. Gap detection         — agents with no skill link, skills with no agent link
   6. Team Assembly Engine  — given a task, find the optimal squad
   7. Arm-distributed intel — each region has its own neural profile
 
@@ -697,8 +697,12 @@ def generate_connectome():
         agent_neighbors[b][a] = w
 
     # Diagnostics
-    isolated_neurons = [n["id"] for n in neurons if not n.get("_skill_connections")]
-    orphan_synapses = [s_id for s_id, conns in skill_to_agents.items() if not conns]
+    # NOTE: these two are CROSS-LAYER coverage gaps, not dead cells. An entry here
+    # still has skill<->skill (or agent<->agent) edges and is reachable by recall;
+    # it merely has no link across the agent/skill boundary above the threshold.
+    # Prune candidates are degree-0/degree-1 nodes: see `query_connectome.py dead`.
+    agents_without_skills = [n["id"] for n in neurons if not n.get("_skill_connections")]
+    skills_without_agents = [s_id for s_id, conns in skill_to_agents.items() if not conns]
 
     busiest_neurons = sorted(neurons, key=lambda n: len(n.get("_skill_connections", {})), reverse=True)[:15]
     most_connected_agents = sorted(neurons, key=lambda n: len(agent_neighbors.get(n["id"], {})), reverse=True)[:15]
@@ -892,8 +896,8 @@ def generate_connectome():
             ),
         },
         "diagnostics": {
-            "isolated_neurons": isolated_neurons,
-            "orphan_synapses": orphan_synapses,
+            "agents_without_skills": agents_without_skills,
+            "skills_without_agents": skills_without_agents,
             "busiest_neurons": [
                 {"id": n["id"], "skill_connections": len(n.get("_skill_connections", {})),
                  "agent_connections": len(agent_neighbors.get(n["id"], {})),
@@ -950,8 +954,8 @@ def print_summary(connectome):
     print(f"   Formula: {cap['formula']}")
 
     print(f"\nDiagnostics:")
-    print(f"   Isolated neurons (no skills):   {len(diag['isolated_neurons'])}")
-    print(f"   Orphan synapses (no agents):    {len(diag['orphan_synapses'])}")
+    print(f"   Agents with no skill link:      {len(diag['agents_without_skills'])}")
+    print(f"   Skills with no agent link:      {len(diag['skills_without_agents'])}")
 
     print(f"\nBusiest Neurons (total connections):")
     for item in diag["busiest_neurons"][:8]:
@@ -973,19 +977,24 @@ def print_summary(connectome):
         avg_r = stats["total_arm_conns"] / max(c, 1)
         print(f"   {div:.<28} {c:>3} neurons | avg skills:{avg_s:>5.1f} agents:{avg_a:>5.1f} arms:{avg_r:>4.1f}")
 
-    if diag["isolated_neurons"]:
-        print(f"\nIsolated Neurons ({len(diag['isolated_neurons'])} total):")
-        for n in diag["isolated_neurons"][:5]:
-            print(f"   - {n}")
-        if len(diag["isolated_neurons"]) > 5:
-            print(f"   ... and {len(diag['isolated_neurons']) - 5} more")
+    if diag["agents_without_skills"] or diag["skills_without_agents"]:
+        print("\nCross-layer coverage gaps (NOT prune candidates):")
+        print("   These nodes keep their same-layer edges and stay reachable by recall.")
+        print("   For real dead cells (degree 0 or 1) run: query_connectome.py dead")
 
-    if diag["orphan_synapses"]:
-        print(f"\nOrphan Synapses ({len(diag['orphan_synapses'])} total):")
-        for s in diag["orphan_synapses"][:5]:
+    if diag["agents_without_skills"]:
+        print(f"\nAgents With No Skill Link ({len(diag['agents_without_skills'])} total):")
+        for n in diag["agents_without_skills"][:5]:
+            print(f"   - {n}")
+        if len(diag["agents_without_skills"]) > 5:
+            print(f"   ... and {len(diag['agents_without_skills']) - 5} more")
+
+    if diag["skills_without_agents"]:
+        print(f"\nSkills With No Agent Link ({len(diag['skills_without_agents'])} total):")
+        for s in diag["skills_without_agents"][:5]:
             print(f"   - {s}")
-        if len(diag["orphan_synapses"]) > 5:
-            print(f"   ... and {len(diag['orphan_synapses']) - 5} more")
+        if len(diag["skills_without_agents"]) > 5:
+            print(f"   ... and {len(diag['skills_without_agents']) - 5} more")
 
     print(f"\nGeneration time: {meta['generation_time_sec']}s")
 


### PR DESCRIPTION
## Problem

`generate_neural_map.py` printed two diagnostics under the labels **Isolated Neurons** and **Orphan Synapses**. What they actually count is cross-layer coverage:

- agents with no skill link above `AGENT_SKILL_THRESHOLD` (0.03)
- skills with no agent link above the same threshold

Both labels read as "dead node". That is a different concept, owned by `query_connectome.py dead` (degree 0 or 1).

The confusion already produced a wrong call: `octorato-isomorphism` was reported as an orphan and proposed for pruning, while it held 14 skill-to-skill edges and the dead-scan reported `dead=0 dying=0 clean`. It is an `identity` skill about the framework itself, so having no specialist-agent neighbour is correct, not a defect.

## Change

Single file, `scripts/generate_neural_map.py`:

| Surface | Before | After |
|---|---|---|
| docstring | `isolated neurons, orphan synapses` | states what is measured |
| variables | `isolated_neurons` / `orphan_synapses` | `agents_without_skills` / `skills_without_agents` |
| `diagnostics` JSON keys | same old names | same new names |
| printed summary + sections | `Isolated Neurons` / `Orphan Synapses` | `Agents With No Skill Link` / `Skills With No Agent Link` |

Adds a header before the detail sections stating these are **not** prune candidates, and pointing at `query_connectome.py dead` for the scan that does find them. A code comment fixes the same distinction for whoever reads the source instead of the output.

Both halves of the pair are renamed. Fixing one and leaving its twin would leave the same trap set.

## Why renaming the JSON keys is safe

Verified before touching them:

- `neural_map.json` has no schema (`schemas/` holds only `skill-manifest` and `trace-event`)
- CI asserts only that the script runs and the JSON parses (`brain-pr-checks.yml:90-92`)
- neither `brain_doctor.py` nor `query_connectome.py` reads the `diagnostics` block

`neural_map.json` is gitignored, so no generated artifact ships in this diff.

## Verification

- `py_compile` OK, zero leftover old identifiers
- generator runs: new labels print, `skills_without_agents: 1`, old keys absent from the JSON
- `brain_doctor.py` 30 passed / 3 warn / 0 fail, `connectome-fresh` PASS
- `query_connectome.py dead` unchanged: `dead=0 dying=0 clean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)