### PR TITLE
fix(memoria): el indice compacto ya no silencia entradas ni acredita al archivo equivocado

### DIFF
--- a/scripts/brain-memory-recall.py
+++ b/scripts/brain-memory-recall.py
@@ -42,6 +42,10 @@ TAIL_BYTES = 20_000
 MAX_HITS = 5
 MIN_SCORE = 2           # need at least this much token overlap to surface a line
 INDEX_RE = re.compile(r"^- \[(?P<title>[^\]]+)\]\((?P<file>[^)]+)\)\s*[:\-]\s*(?P<hook>.*)$")
+# Una linea del indice puede compactar VARIAS entradas separadas por " · ".
+# Leer solo la primera (INDEX_RE.match) dejaba muda a toda entrada en segunda
+# posicion: mitad del canon sin recall y el doctor contandola como no-indexada.
+ENTRY_RE = re.compile(r"\[(?P<title>[^\]]+)\]\((?P<file>[^)]+)\)\s*[:\-]\s*(?P<hook>[^·]*)")
 TOKEN_RE = re.compile(r"[a-z0-9áéíóúñü]{3,}")
 
 STOP = {
@@ -105,17 +109,22 @@ def score_lines(md: Path, ptoks: set[str]):
     except Exception:
         return out
     for ln in lines:
-        m = INDEX_RE.match(ln.strip())
-        if not m:
+        ln = ln.strip()
+        if not ln.startswith("- ") or not INDEX_RE.match(ln):
             continue
-        title, fname, hook = m.group("title"), m.group("file"), m.group("hook")
-        ltoks = tokenize(title + " " + fname + " " + hook)
-        overlap = ptoks & ltoks
-        score = len(overlap)
-        if score >= MIN_SCORE:
-            out.append((score, title, fname))
+        for m in ENTRY_RE.finditer(ln):
+            _score_entry(out, m, ptoks)
     out.sort(key=lambda x: (-x[0], x[1]))
     return out[:MAX_HITS]
+
+
+def _score_entry(out, m, ptoks):
+    title, fname, hook = m.group("title"), m.group("file"), m.group("hook")
+    ltoks = tokenize(title + " " + fname + " " + hook)
+    overlap = ptoks & ltoks
+    score = len(overlap)
+    if score >= MIN_SCORE:
+        out.append((score, title, fname))
 
 
 def main() -> int:

--- a/scripts/brain_doctor.py
+++ b/scripts/brain_doctor.py
@@ -948,6 +948,10 @@ def check_corpus_coverage(fix: bool) -> Result:
     # never fires and stays uncovered. The memory layer is private and gitignored,
     # so absence on this machine is a soft skip.
     index_re = re.compile(r"^- \[(?P<title>[^\]]+)\]\((?P<file>[^)]+)\)\s*[:\-]\s*(?P<hook>.*)$")
+    # Una linea del indice compacta VARIAS entradas separadas por " · "; hay que
+    # leerlas todas o toda entrada en segunda posicion cuenta como no-indexada
+    # (mismo parser que brain-memory-recall.py, que es quien inyecta el recall).
+    entry_re = re.compile(r"\[(?P<title>[^\]]+)\]\((?P<file>[^)]+)\)\s*[:\-]")
     home_slug = "-" + str(Path.home()).strip("/").replace("/", "-")
     brain_mem_dir = CLAUDE_DIR / "projects" / home_slug / "memory"
     class_row = next((r for r in rules if r.get("id") == "MEMORY.feedback-directive-corpus"), None)
@@ -981,8 +985,10 @@ def check_corpus_coverage(fix: bool) -> Result:
             mm = d / "MEMORY.md"
             if mm.exists():
                 for ln in _rt(mm).splitlines():
-                    m = index_re.match(ln.strip())
-                    if m:
+                    ln = ln.strip()
+                    if not index_re.match(ln):
+                        continue
+                    for m in entry_re.finditer(ln):
                         idx.add(os.path.basename(m.group("file")))
             indexed_by_dir[d] = idx
         for mf in mem_files:


### PR DESCRIPTION
MEMORY.md compacta dos entradas por linea separadas por ' · '. El parser de una-captura-por-linea hacia dos danos: el recall acreditaba los tokens de la linea entera a la PRIMERA entrada (recomendaba el archivo equivocado) y toda entrada en segunda posicion quedaba muda; el doctor la contaba como no-indexada (54/110 uncovered en corpus-coverage).

Fix: ambos lectores (brain-memory-recall.py y brain_doctor.py) iteran las entradas de la linea con el mismo criterio.

Prueba contra el indice real, tokens de una entrada en segunda posicion:
- viejo: hit en 'Paste-ready=raw' (archivo equivocado, score 7)
- nuevo: hit en 'Ausencia query' (correcto, score 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNTBaawUaGF3GbhvkBVad6