### PR TITLE
feat(gate): commit-msg English-only gate for the public octorato repo

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# commit-msg — OCTORATO-COMMIT-MSG-LANG-GATE
+#
+# The public octorato repo is English-only (see CLAUDE.md, "The Brain Stays
+# Generic"). This blocks non-English (Spanish) commit messages before they enter
+# the world-visible history. Only guards THIS repo: it lives in octorato's
+# .githooks, so per-client arm repos are untouched.
+#
+# Override (intentional): put `lang-ok` on a line of the message, or
+# `git commit --no-verify`.
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+[ -z "$REPO_ROOT" ] && exit 0
+GATE="$REPO_ROOT/scripts/commit_msg_language_gate.py"
+[ -f "$GATE" ] || exit 0
+exec python3 "$GATE" "$1"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ The brain is published as **open-source**; git history is publicly visible on Gi
 - Commit messages must be **purely about the framework change** — never about who triggered it or where the lesson came from.
   - ✅ `"feat(brain): add ado-refactor-performance-gate skill"`
   - ❌ `"feat(brain): add ado-refactor-performance-gate skill from <ARM_CODE> arm"`
+- **English-only in the public repo.** Commit messages, code, comments, and docs in `octorato` ship in English; the repo is world-visible and English is its lingua franca. Spanish (the operator's language) belongs in arm repos and in chat, never in octorato's permanent history. Translatable content lives as EN/ES/DE i18n assets, not as Spanish commit prose. Wired by a `commit-msg` gate (`scripts/commit_msg_language_gate.py` via `.githooks/commit-msg`) that blocks non-English commit subjects; deliberate exception with `lang-ok` on a line or `git commit --no-verify`.
 
 **Enforcement (two layers):**
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -9,9 +9,9 @@
 | Skills | 233 |
 | Agents | 161 |
 | Divisions | 15 |
-| Scripts: wired | 98 |
+| Scripts: wired | 99 |
 | Scripts: orphan | 7 |
-| Rules | 66 |
+| Rules | 67 |
 | Hook entries | 39 |
 
 ## Skills (233)
@@ -490,7 +490,7 @@
 | Tool Evaluator | Expert technology assessment specialist focused on evaluating, testing, and recommending tools, software, and platforms ... |
 | Workflow Optimizer | Expert process improvement specialist focused on analyzing, optimizing, and automating workflows across all business fun... |
 
-## Scripts (105)
+## Scripts (106)
 
 | Script | Purpose | Status |
 |---|---|---|
@@ -530,6 +530,7 @@
 | claim_vocab.py | claim_vocab.py: vocabulario compartido de CLAIMS DE CIERRE. | wired |
 | client-doc-lint-hook.py | client-doc-lint-hook.py , PostToolUse(Bash) reflex wrapper for client-doc-lint. | wired |
 | client-doc-lint.py | client-doc-lint.py , pre-send QA reflex for generated CLIENT deliverables. | wired |
+| commit_msg_language_gate.py | commit-msg language gate , the public octorato repo is English-only. | wired |
 | config-ship-verify.py | config-ship-verify.py , PreToolUse:Bash hook: ask before shipping generated configs. | wired |
 | connectome-heartbeat.py | connectome-heartbeat.py , the Delegate-phase heartbeat (UserPromptSubmit hook). | wired |
 | cost-vs-change.py | cost-vs-change.py , "is the new thing making me cheaper or more expensive?" Correlates the daily Cla... | wired |
@@ -600,7 +601,7 @@
 | wa-soporte.sh | Envia un WhatsApp por el canal de SOPORTE, no por el numero personal del operador. | orphan |
 | watchdog.py | watchdog.py , observability surface 4 anomaly detector. Reads the JSONL trace files written by trace... | wired |
 
-## Rules (66)
+## Rules (67)
 
 ### ARCHITECTURE
 
@@ -666,6 +667,7 @@
 ### GENERIC
 
 - GENERIC.brain-stays-generic
+- GENERIC.commit-msg-english-only
 
 ### GIT
 

--- a/registry/fixtures/GENERIC.commit-msg-english-only/benign.txt
+++ b/registry/fixtures/GENERIC.commit-msg-english-only/benign.txt
@@ -1,0 +1,7 @@
+feat(vigia): add whatsapp alert sink to the silence watcher
+
+Third alert channel alongside gmail and canario. The destination comes from the
+private config, never hardcoded, because the script is public. Selftest covers
+the payload, the message body, and the missing-destination case.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

--- a/registry/fixtures/GENERIC.commit-msg-english-only/violation.txt
+++ b/registry/fixtures/GENERIC.commit-msg-english-only/violation.txt
@@ -1,0 +1,4 @@
+brain: indice residente mas chico, vigia de silencio, y tres gates nuevos
+
+El cambio corrige el aviso cuando un cliente queda sin respuesta: ahora el
+vigia manda con cada entrada, sin perder ninguna por el formato de la linea.

--- a/registry/rules.yaml
+++ b/registry/rules.yaml
@@ -1635,3 +1635,33 @@ rules:
     locator: The 4D runs in a WHILE
     expect: present
   liveness_required: FIRES
+- id: GENERIC.commit-msg-english-only
+  title: commit messages in the public octorato repo must be English
+  category: GENERIC
+  source:
+    file: CLAUDE.md
+    anchor: English-only in the public repo
+  strength: GATE
+  gateable: true
+  enforcement: fail-closed
+  firing_mode:
+  - git-hook
+  mechanism:
+  - kind: Gate
+    canonical_name: .githooks/commit-msg
+    firing_event: null
+    firing_matcher: null
+  proof:
+  - method: FILE_EXISTS
+    locator: .githooks/commit-msg
+    expect: present
+  - method: EXIT_CODE
+    locator: grep -q OCTORATO-COMMIT-MSG-LANG-GATE .githooks/commit-msg
+    expect: 0
+  - method: EXIT_CODE
+    locator: scripts/commit_msg_language_gate.py --selftest registry/fixtures/GENERIC.commit-msg-english-only
+    expect: 0
+  - method: ANCHOR_PRESENT
+    locator: English-only in the public repo
+    expect: present
+  liveness_required: PRESENT

--- a/scripts/commit_msg_language_gate.py
+++ b/scripts/commit_msg_language_gate.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""commit-msg language gate — the public octorato repo is English-only.
+
+WHY. The brain (~/.claude == the octorato repo) is published open-source; its
+git history is world-visible forever, and commit messages are part of it. The
+operator's rule is that the public repo ships in English (i18n lives as EN/ES/DE
+assets, never as Spanish commit prose). Spanish subjects drifted in because the
+operator writes in Spanish and the model followed; a prose rule loses to that
+pull under load, so this fires on its own as a git-hook.
+
+WHAT. Invoked by `.githooks/commit-msg` with the path to COMMIT_EDITMSG. It reads
+the human-written part of the message (git's diff comment and the trailer block
+stripped) and BLOCKS the commit (exit 1) when it reads as Spanish, printing why.
+English passes (exit 0). Escape hatch: put `lang-ok` on a line, or commit with
+`git commit --no-verify`.
+
+SCOPE. The hook lives in octorato's .githooks, so it only guards octorato
+commits. Arm repos (private, per-client, often Spanish) are untouched.
+
+SELFTEST. `commit_msg_language_gate.py --selftest <fixture-dir>` runs the
+detector against <dir>/violation.txt (must block) and <dir>/benign.txt (must
+allow), exiting 0 only if both are correct. That is the fixture-driven liveness
+proof brain_doctor runs on every fail-closed gate.
+"""
+import re
+import sys
+import unicodedata
+from pathlib import Path
+
+# Signals English never uses. Any one of these is enough on its own.
+STRONG = ("¿", "¡", "ñ", "Ñ")  # ¿ ¡ ñ Ñ
+
+# Function/content words that are Spanish and NOT common in English commit prose
+# or code identifiers. Stored ACCENT-STRIPPED and matched against accent-stripped
+# tokens, because real Spanish commit subjects are often typed without accents
+# ("mas", "vigia", "indice"): matching only the accented form misses them. A
+# message needs >=2 DISTINCT hits to trip, so a lone loanword never blocks
+# English. Overlaps with English/code ("no", "base", "final", "solo", "sale",
+# "config", "canario") are deliberately excluded.
+SPANISH_WORDS = {
+    "que", "para", "con", "sin", "por", "una", "unos", "unas", "del", "los",
+    "las", "este", "esta", "estos", "estas", "porque", "cuando", "desde",
+    "hace", "segun", "tambien", "mas", "asi", "aviso", "correo", "cambio",
+    "archivo", "entrada", "entradas", "puente", "silencio", "cliente", "cada",
+    "nuevo", "nueva", "nuevos", "nuevas", "propio", "propia", "leer", "todas",
+    "todos", "manda", "queda", "quedan", "cierra", "revisa", "numero",
+    "indice", "linea", "chico", "chica", "tres", "avisa", "avisar", "envio",
+    "pantalla", "campo", "regla", "reglas", "vigia", "vigilancia", "respuesta",
+}
+
+
+def _strip_accents(w: str) -> str:
+    return "".join(c for c in unicodedata.normalize("NFD", w)
+                   if unicodedata.category(c) != "Mn")
+
+# A real git trailer key is hyphenated multi-word (Co-Authored-By, Signed-off-by,
+# Claude-Session). Requiring the hyphen means a conventional-commit subject like
+# "brain: ..." or a Spanish body line "El cambio: ..." is NOT mistaken for a
+# trailer and stripped.
+TRAILER_RE = re.compile(r"^[A-Za-z]+(-[A-Za-z]+)+:\s")
+
+
+def human_text(raw: str) -> str:
+    """The part a person wrote: drop git's diff comment lines (#...) and the
+    trailing trailer block. The subject (first line) is ALWAYS kept: it is the
+    most load-bearing line and must never be swallowed as a trailer."""
+    lines = [ln for ln in raw.splitlines() if not ln.startswith("#")]
+    if not lines:
+        return ""
+    subject, body = lines[0], lines[1:]
+    while body and (not body[-1].strip() or TRAILER_RE.match(body[-1].strip())):
+        body.pop()
+    return "\n".join([subject] + body)
+
+
+def looks_spanish(raw: str):
+    """(is_spanish, reasons). Conservative: one STRONG char, or >=2 distinct
+    unambiguous Spanish function words. `lang-ok` anywhere is an explicit pass."""
+    text = human_text(raw)
+    if "lang-ok" in text:
+        return (False, ["lang-ok override present"])
+    reasons = []
+    for ch in STRONG:
+        if ch in text:
+            reasons.append(f"Spanish character {ch!r}")
+    tokens = re.findall(r"[a-záéíóúñü]+", text.lower())
+    hits = sorted({_strip_accents(t) for t in tokens
+                   if _strip_accents(t) in SPANISH_WORDS})
+    if len(hits) >= 2:
+        reasons.append("Spanish words: " + ", ".join(hits))
+    return (bool(reasons), reasons)
+
+
+def check_message_file(path: str) -> int:
+    raw = Path(path).read_text(encoding="utf-8", errors="replace")
+    is_es, reasons = looks_spanish(raw)
+    if is_es:
+        sys.stderr.write(
+            "commit-msg gate: this reads as a non-English (Spanish) commit "
+            "message, and octorato is an English-only public repo.\n  "
+            + "\n  ".join(reasons) + "\n"
+            "Rewrite it in English. Intentional exception: add 'lang-ok' on a "
+            "line, or commit with --no-verify.\n")
+        return 1
+    return 0
+
+
+def selftest(fixture_dir: str) -> int:
+    d = Path(fixture_dir)
+    vio, ben = d / "violation.txt", d / "benign.txt"
+    if not vio.exists() or not ben.exists():
+        sys.stderr.write(f"selftest: missing violation.txt/benign.txt in {d}\n")
+        return 1
+    fails = []
+    if not looks_spanish(vio.read_text(encoding="utf-8"))[0]:
+        fails.append("violation.txt did NOT block (detector missed Spanish)")
+    if looks_spanish(ben.read_text(encoding="utf-8"))[0]:
+        fails.append("benign.txt was BLOCKED (false positive on English)")
+    if fails:
+        sys.stderr.write("selftest FAIL:\n  " + "\n  ".join(fails) + "\n")
+        return 1
+    print("commit-msg language gate selftest OK (violation blocks, benign allows)")
+    return 0
+
+
+def main(argv):
+    if len(argv) >= 2 and argv[1] == "--selftest":
+        return selftest(argv[2] if len(argv) > 2
+                        else "registry/fixtures/GENERIC.commit-msg-english-only")
+    if len(argv) < 2:
+        sys.stderr.write("usage: commit_msg_language_gate.py <commit-msg-file>\n")
+        return 2
+    return check_message_file(argv[1])
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Wires the operator's rule that the **public octorato repo is English-only** into a fail-closed `commit-msg` git-hook, so Spanish subjects stop drifting into world-visible history.

## Mechanism
- `.githooks/commit-msg` -> `scripts/commit_msg_language_gate.py`. Blocks (exit 1) when the message reads as Spanish; English passes.
- Detector strips accents (real Spanish commits are often typed without them), matches Spanish function/content words (>=2 distinct, or a strong char like the tilde / inverted marks), keeps the conventional-commit subject, and strips only hyphenated trailers so `brain: ...` subjects are analysed, not swallowed.
- Override: `lang-ok` on a line, or `git commit --no-verify`. Scope: octorato only; per-client arm repos untouched.

## Wired per RULE #1
- `GENERIC.commit-msg-english-only` in registry/rules.yaml, anchored to a new CLAUDE.md line under 'The Brain Stays Generic'.
- Fixture-driven `--selftest` (violation blocks + benign allows). brain_doctor: registry-schema valid, registry-wiring 66/66, gate-liveness 24/24, coverage 37/37 anchors.

## Tested
- Detector battery: 4 English subjects pass (incl. accented names Jose/Malaga), 4 Spanish subjects block, lang-ok override passes.
- Live end-to-end: a real git commit with a Spanish message is rejected by the hook (no commit created); English commits succeed.
- Broke it on purpose and fixed two bugs: unaccented Spanish slipping through, and the subject mistaken for a trailer.

## Follow-up (not this PR)
- The registry schema `firing_event` enum has no commit-msg event, so it is set to null (git-hook wiring is proven by FILE_EXISTS + marker grep, same shape as pre-push). Adding a CommitMsg/PreCommit enum value would let it be explicit.
- The Spanish code comments inside wa-sin-respuesta.py and past Spanish commit messages are separate cleanups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)