### PR TITLE
feat(skill): cross-link AstrBot sandbox and MCP client patterns

### DIFF
--- a/skills/mcp-stack-setup/SKILL.md
+++ b/skills/mcp-stack-setup/SKILL.md
@@ -203,3 +203,7 @@ The actual list lives in your private `company/COMPANY.md`. Generic example:
 - **2024-04**: `.mcp.json` should use env var references (`${VAR}`) not hardcoded values — enables arm isolation without `.gitignore` dependency on the file itself
 - **2024-04**: Cloud MCP OAuth tokens are scoped to the Claude account, not to the workspace directory — they safely appear in all arms without leaking client data
 - **2024-04**: Prefix all DB env vars with the client code (`CLIENT_E_MSSQL_SERVER` not `MSSQL_SERVER`) to prevent collisions when two arms share the same shell session
+
+## See also
+
+- AstrBot (https://github.com/AstrBotDevs/AstrBot, `astrbot/core/agent/mcp_client.py`): reference implementation of an MCP client embedded inside an IM-bot runtime, with tools fanning into the agent loop.

--- a/skills/sandbox-sdk/SKILL.md
+++ b/skills/sandbox-sdk/SKILL.md
@@ -175,3 +175,7 @@ See `examples/openai-agents` for complete integration pattern.
 
 - **[references/api-quick-ref.md](references/api-quick-ref.md)** - Full API with options and return types
 - **[references/examples.md](references/examples.md)** - Example index with use cases
+
+## See also
+
+- AstrBot agent sandbox (https://github.com/AstrBotDevs/AstrBot, `astrbot/core/skills/`): closest OSS peer of the session-reuse sandbox pattern. aiodocker-isolated code/shell exec with session-level resource reuse, and skill files synced into the container at `/workspace/skills`.


### PR DESCRIPTION
Two See-also cross-links learned from a repo-deep-learn pass over https://github.com/AstrBotDevs/AstrBot:

- `skills/sandbox-sdk/SKILL.md`: AstrBot agent sandbox as the closest OSS peer of the session-reuse sandbox pattern (aiodocker isolation, skills synced into the container at /workspace/skills).
- `skills/mcp-stack-setup/SKILL.md`: AstrBot as a reference implementation of an MCP client embedded in an IM-bot runtime.

Report: knowledge/repo-deep-learn/AstrBot/2026-08-21.md (local knowledge cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PryBWMWPckgP6BGph9sXfz