### PR TITLE
fix(memory): parse hookless compacted index entries (recall + corpus-coverage)

### DIFF
--- a/scripts/brain-memory-recall.py
+++ b/scripts/brain-memory-recall.py
@@ -41,11 +41,13 @@ TIMEOUT_S = 3
 TAIL_BYTES = 20_000
 MAX_HITS = 5
 MIN_SCORE = 2           # need at least this much token overlap to surface a line
-INDEX_RE = re.compile(r"^- \[(?P<title>[^\]]+)\]\((?P<file>[^)]+)\)\s*[:\-]\s*(?P<hook>.*)$")
 # Una linea del indice puede compactar VARIAS entradas separadas por " · ".
-# Leer solo la primera (INDEX_RE.match) dejaba muda a toda entrada en segunda
-# posicion: mitad del canon sin recall y el doctor contandola como no-indexada.
-ENTRY_RE = re.compile(r"\[(?P<title>[^\]]+)\]\((?P<file>[^)]+)\)\s*[:\-]\s*(?P<hook>[^·]*)")
+# Leerlas todas (finditer) o toda entrada en segunda posicion queda muda: mitad
+# del canon sin recall y el doctor contandola como no-indexada. El gancho
+# ': hook' es OPCIONAL: el indice compactado escribe entradas sin gancho
+# (`[Titulo](archivo.md) · [Otra](otra.md)`); exigirlo dejaba fuera 120 de 122
+# ficheros. La entrada se puntua por titulo+archivo aunque no traiga hook.
+ENTRY_RE = re.compile(r"\[(?P<title>[^\]]+)\]\((?P<file>[^)]+)\)(?:\s*[:\-]\s*(?P<hook>[^·]*))?")
 TOKEN_RE = re.compile(r"[a-z0-9áéíóúñü]{3,}")
 
 STOP = {
@@ -110,7 +112,7 @@ def score_lines(md: Path, ptoks: set[str]):
         return out
     for ln in lines:
         ln = ln.strip()
-        if not ln.startswith("- ") or not INDEX_RE.match(ln):
+        if not ln.startswith("- ["):
             continue
         for m in ENTRY_RE.finditer(ln):
             _score_entry(out, m, ptoks)
@@ -119,7 +121,7 @@ def score_lines(md: Path, ptoks: set[str]):
 
 
 def _score_entry(out, m, ptoks):
-    title, fname, hook = m.group("title"), m.group("file"), m.group("hook")
+    title, fname, hook = m.group("title"), m.group("file"), (m.group("hook") or "")
     ltoks = tokenize(title + " " + fname + " " + hook)
     overlap = ptoks & ltoks
     score = len(overlap)

--- a/scripts/brain_doctor.py
+++ b/scripts/brain_doctor.py
@@ -964,11 +964,12 @@ def check_corpus_coverage(fix: bool) -> Result:
     # context each session and what the recall hook scores, so an unindexed file
     # never fires and stays uncovered. The memory layer is private and gitignored,
     # so absence on this machine is a soft skip.
-    index_re = re.compile(r"^- \[(?P<title>[^\]]+)\]\((?P<file>[^)]+)\)\s*[:\-]\s*(?P<hook>.*)$")
     # Una linea del indice compacta VARIAS entradas separadas por " · "; hay que
     # leerlas todas o toda entrada en segunda posicion cuenta como no-indexada
     # (mismo parser que brain-memory-recall.py, que es quien inyecta el recall).
-    entry_re = re.compile(r"\[(?P<title>[^\]]+)\]\((?P<file>[^)]+)\)\s*[:\-]")
+    # El gancho ': hook' es OPCIONAL: el indice compactado escribe entradas sin
+    # gancho, y exigirlo dejaba 120/122 ficheros como no-indexados (FAIL falso).
+    entry_re = re.compile(r"\[(?P<title>[^\]]+)\]\((?P<file>[^)]+)\)")
     home_slug = "-" + str(Path.home()).strip("/").replace("/", "-")
     brain_mem_dir = CLAUDE_DIR / "projects" / home_slug / "memory"
     class_row = next((r for r in rules if r.get("id") == "MEMORY.feedback-directive-corpus"), None)
@@ -1003,7 +1004,7 @@ def check_corpus_coverage(fix: bool) -> Result:
             if mm.exists():
                 for ln in _rt(mm).splitlines():
                     ln = ln.strip()
-                    if not index_re.match(ln):
+                    if not ln.startswith("- ["):
                         continue
                     for m in entry_re.finditer(ln):
                         idx.add(os.path.basename(m.group("file")))


### PR DESCRIPTION
## Problem

corpus-coverage FAILs and the memory recall reflex is silent for most directives. The index parser in `brain-memory-recall.py` and `brain_doctor.py` requires a `: hook` after each `](file.md)` and gates the whole line on the first entry having it. `MEMORY.md` was compacted to hookless entries separated by ` · `, so the parser covers **2 of 122** feedback files.

The existing `fix/memory-index-multi-entry` branch (its `finditer` step is already in master) kept the mandatory suffix, so it does not fix the current format. This supersedes it.

## Fix

Relax both parsers in lockstep: gate the line on `- [`, and make the `: hook` suffix optional per entry. A hookless entry still scores on title+file.

## Verified against the real MEMORY.md

- Parser coverage: **2/122 → 122/122** (0 uncovered).
- Recall run against real memory surfaces a second-position compacted entry (`feedback_absence_claims_need_a_query_that_proves_absence`) correctly.
- Both scripts compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)