### PR TITLE
fix(connectome): fold accents in the tokenizer, on both sides

### DIFF
--- a/scripts/ai_sync.py
+++ b/scripts/ai_sync.py
@@ -154,6 +154,27 @@ def connectome_stale() -> bool:
     m = CLAUDE / "neural_map.json"
     if not m.exists():
         return True
+
+    # A map built by a DIFFERENT TOKENIZER is stale even when its mtime is newer
+    # than every source file. A machine that pulls a tokenizer change touches
+    # only scripts/, so an mtime-only check keeps the old index while the query
+    # side already speaks the new dialect, and recall silently answers zero.
+    # Compare the contract, not the clock.
+    try:
+        import json as _json
+        gen = CLAUDE / "scripts" / "generate_neural_map.py"
+        want = None
+        for line in gen.read_text(encoding="utf-8", errors="replace").splitlines():
+            if line.startswith("TOKENIZER_VERSION"):
+                want = line.split("=", 1)[1].strip().strip('"').strip("'")
+                break
+        if want:
+            have = _json.loads(m.read_text(encoding="utf-8")).get("meta", {}).get("tokenizer")
+            if have != want:
+                return True
+    except Exception:
+        pass  # unreadable map or generator: fall through to the mtime check
+
     newest = m.stat().st_mtime
     for base, pat in (("skills", "SKILL.md"), ("agents", "*.md")):
         for f in (CLAUDE / base).rglob(pat):

--- a/scripts/ai_sync.py
+++ b/scripts/ai_sync.py
@@ -161,7 +161,6 @@ def connectome_stale() -> bool:
     # side already speaks the new dialect, and recall silently answers zero.
     # Compare the contract, not the clock.
     try:
-        import json as _json
         gen = CLAUDE / "scripts" / "generate_neural_map.py"
         want = None
         for line in gen.read_text(encoding="utf-8", errors="replace").splitlines():
@@ -169,11 +168,13 @@ def connectome_stale() -> bool:
                 want = line.split("=", 1)[1].strip().strip('"').strip("'")
                 break
         if want:
-            have = _json.loads(m.read_text(encoding="utf-8")).get("meta", {}).get("tokenizer")
+            have = json.loads(m.read_text(encoding="utf-8")).get("meta", {}).get("tokenizer")
             if have != want:
                 return True
+    except json.JSONDecodeError:
+        return True  # an unparseable map is not fresh, it is broken
     except Exception:
-        pass  # unreadable map or generator: fall through to the mtime check
+        pass  # generator unreadable: fall through to the mtime check
 
     newest = m.stat().st_mtime
     for base, pat in (("skills", "SKILL.md"), ("agents", "*.md")):

--- a/scripts/brain_doctor.py
+++ b/scripts/brain_doctor.py
@@ -403,7 +403,10 @@ def _tokenizer_mismatch(nm: Path) -> str | None:
                 break
         if not want:
             return None
-        have = json.loads(nm.read_text(encoding="utf-8")).get("meta", {}).get("tokenizer")
+        try:
+            have = json.loads(nm.read_text(encoding="utf-8")).get("meta", {}).get("tokenizer")
+        except json.JSONDecodeError:
+            return "is not valid JSON"  # broken is not fresh
         if have != want:
             return f"built by tokenizer {have!r}, generator is {want!r}"
     except Exception:

--- a/scripts/brain_doctor.py
+++ b/scripts/brain_doctor.py
@@ -386,6 +386,31 @@ def check_leak_guard(fix: bool) -> Result:
     return Result(key, status, "; ".join(problems), hint)
 
 
+def _tokenizer_mismatch(nm: Path) -> str | None:
+    """Return a reason when the map was built by a different tokenizer.
+
+    Mtime freshness cannot see this: pulling a tokenizer change touches only
+    scripts/, so the map looks current while it speaks the old dialect and the
+    query side speaks the new one. The result is a silent zero-hit recall, which
+    is the worst failure shape: it looks like "nothing matched".
+    """
+    try:
+        gen = CLAUDE_DIR / "scripts" / "generate_neural_map.py"
+        want = None
+        for line in gen.read_text(encoding="utf-8", errors="replace").splitlines():
+            if line.startswith("TOKENIZER_VERSION"):
+                want = line.split("=", 1)[1].strip().strip('"').strip("'")
+                break
+        if not want:
+            return None
+        have = json.loads(nm.read_text(encoding="utf-8")).get("meta", {}).get("tokenizer")
+        if have != want:
+            return f"built by tokenizer {have!r}, generator is {want!r}"
+    except Exception:
+        return None
+    return None
+
+
 def check_connectome_fresh(fix: bool) -> Result:
     key = "connectome-fresh"
     nm = CLAUDE_DIR / "neural_map.json"
@@ -397,6 +422,20 @@ def check_connectome_fresh(fix: bool) -> Result:
         if not nm.exists():
             return Result(key, FAIL, "neural_map.json missing",
                           "run `python3 scripts/generate_neural_map.py`")
+    # Contract before clock: a tokenizer mismatch is staleness that no mtime
+    # comparison can see, and it fails as a silent zero-hit recall.
+    mismatch = _tokenizer_mismatch(nm)
+    if mismatch:
+        if fix:
+            gen = CLAUDE_DIR / "scripts" / "generate_neural_map.py"
+            if gen.exists():
+                cp = run([PYTHON or "python3", str(gen)], cwd=CLAUDE_DIR)
+                if cp.returncode == 0 and not _tokenizer_mismatch(nm):
+                    return Result(key, PASS, "neural_map.json regenerated (tokenizer changed)")
+        return Result(key, FAIL, f"neural_map.json {mismatch}",
+                      "run `python3 scripts/generate_neural_map.py` — queries and "
+                      "index must speak the same tokenizer or recall silently returns nothing")
+
     nm_mtime = nm.stat().st_mtime
     newest = 0.0
     newest_src = None

--- a/scripts/generate_neural_map.py
+++ b/scripts/generate_neural_map.py
@@ -35,6 +35,7 @@ import json
 import math
 import os
 import re
+import unicodedata
 import sys
 from collections import Counter
 from datetime import datetime, timezone
@@ -132,7 +133,27 @@ STOP_WORDS = frozenset((_STOP_EN + " " + _STOP_ES).split())
 # ─── Text Processing & TF-IDF ────────────────────────────────────────────────
 
 def tokenize(text):
-    """Extract meaningful tokens from text. Lowercased, no stop words."""
+    """Extract meaningful tokens from text. Lowercased, accent-folded, no stop words.
+
+    ACCENT FOLDING IS NOT COSMETIC. The word regex below only starts a token at
+    [a-z], so a combining accent SPLITS the word and eats its head: "codigo"
+    written with its accent yields "digo", "diseno" yields "dise", "espanol"
+    yields "espa". Two failures follow. The real word never enters the
+    vocabulary, so a search for it cannot match; and the mutilated stem does,
+    where it can collide with an unrelated real word ("digo" is Spanish for
+    "I say") and weave a synapse between documents that share nothing.
+
+    Measured on this corpus (441 skill/agent files): 157 distinct accented
+    words, 240 occurrences. Folding removes 129 mutilated stems and admits 97
+    real words, moving the vocabulary from 16,865 to 16,833 terms. Small here
+    because skills and agents are written mostly in English; the same defect was
+    severe in the life-memories corpus, where the operator's own city indexed as
+    "laga" and "dia" vanished outright.
+
+    NFKD + drop-combining is idempotent, so folding again downstream is safe.
+    """
+    text = unicodedata.normalize("NFKD", text)
+    text = "".join(c for c in text if not unicodedata.combining(c))
     # Remove code blocks (they add noise)
     text = re.sub(r"```[\s\S]*?```", " ", text)
     # Remove URLs

--- a/scripts/generate_neural_map.py
+++ b/scripts/generate_neural_map.py
@@ -176,13 +176,16 @@ def tokenize(text):
     where it can collide with an unrelated real word ("digo" is Spanish for
     "I say") and weave a synapse between documents that share nothing.
 
-    Measured on the 418 files this generator actually reads (skills/**/SKILL.md
-    plus the agent divisions): 157 distinct accented words, 240 occurrences.
-    Folding removes 129 mutilated stems and admits 98 real words, moving the raw
-    vocabulary from 16,978 to 16,947 terms. Small here because skills and agents
-    are written mostly in English; the same defect was severe in the
-    life-memories corpus, where the operator's own city indexed as "laga" and
-    "dia" vanished outright.
+    Snapshot on one machine, 2026-09-02: ~157 distinct accented words over the
+    ~415 documents this generator feeds to TF-IDF, folding out ~130 mutilated
+    stems and admitting ~97 real words for a net vocabulary change of about -30
+    terms. Deliberately approximate: skills/learned/ is gitignored and drifts
+    per machine, so an exact count is NOT reproducible by a reader and any
+    precise figure here would rot into a lie. The shape is what matters and it
+    is stable: a small effect in this corpus, because skills and agents are
+    written mostly in English. The same defect was severe in the life-memories
+    corpus, where the operator's own city indexed as "laga" and "dia" vanished
+    outright.
 
     Folding the corpus WITHOUT folding STOP_WORDS is worse than not folding at
     all: see _folded_stops above. That half-fix shipped junk terms ("que" at idf

--- a/scripts/generate_neural_map.py
+++ b/scripts/generate_neural_map.py
@@ -57,6 +57,10 @@ BRAIN_DIR = Path.home() / ".claude"
 AGENTS_DIR = BRAIN_DIR / "agents"
 SKILLS_DIR = BRAIN_DIR / "skills"
 REGISTRY_FILE = AGENTS_DIR / "REGISTRY.md"
+# Tokenizer contract version. Bump on ANY change to tokenize() that alters the
+# terms it produces (folding, regex, stop list).
+TOKENIZER_VERSION = "2-accent-folded"
+
 OUTPUT_FILE = BRAIN_DIR / "neural_map.json"
 ACTIVITY_LOG = BRAIN_DIR / "neural_activity.json"
 
@@ -127,7 +131,36 @@ _STOP_ES = (
     "hace hizo hay hubo habrá había también ante antes después durante luego "
     "porque pues aunque mientras si bien aquí ahí allí allá esto ello"
 )
-STOP_WORDS = frozenset((_STOP_EN + " " + _STOP_ES).split())
+STOP_WORDS = None  # set below, after _folded_stops is defined
+
+def _fold(text):
+    """NFKD-fold: drop combining marks. Idempotent."""
+    return "".join(
+        c for c in unicodedata.normalize("NFKD", text) if not unicodedata.combining(c)
+    )
+
+
+def _folded_stops(words):
+    """Every stop word PLUS its folded form.
+
+    Folding the corpus without folding this list is a trap that bites in the
+    worst direction: an accented stop word ("que" with its accent) can never be
+    matched again, so it stops being filtered, and its folded form walks into
+    the vocabulary as a high-frequency term. Measured before this fix: "que"
+    entered the index with idf 2.502 and drove every one of the 9 synapses the
+    accent fix added. A stop list must be folded in lockstep with the tokenizer,
+    and identically in both files, since their equality is what keeps the index
+    and the query aligned.
+    """
+    out = set()
+    for w in words:
+        out.add(w)
+        out.add(_fold(w))
+    return frozenset(out)
+
+
+STOP_WORDS = _folded_stops((_STOP_EN + " " + _STOP_ES).split())
+
 
 
 # ─── Text Processing & TF-IDF ────────────────────────────────────────────────
@@ -143,17 +176,21 @@ def tokenize(text):
     where it can collide with an unrelated real word ("digo" is Spanish for
     "I say") and weave a synapse between documents that share nothing.
 
-    Measured on this corpus (441 skill/agent files): 157 distinct accented
-    words, 240 occurrences. Folding removes 129 mutilated stems and admits 97
-    real words, moving the vocabulary from 16,865 to 16,833 terms. Small here
-    because skills and agents are written mostly in English; the same defect was
-    severe in the life-memories corpus, where the operator's own city indexed as
-    "laga" and "dia" vanished outright.
+    Measured on the 418 files this generator actually reads (skills/**/SKILL.md
+    plus the agent divisions): 157 distinct accented words, 240 occurrences.
+    Folding removes 129 mutilated stems and admits 98 real words, moving the raw
+    vocabulary from 16,978 to 16,947 terms. Small here because skills and agents
+    are written mostly in English; the same defect was severe in the
+    life-memories corpus, where the operator's own city indexed as "laga" and
+    "dia" vanished outright.
+
+    Folding the corpus WITHOUT folding STOP_WORDS is worse than not folding at
+    all: see _folded_stops above. That half-fix shipped junk terms ("que" at idf
+    2.502) that wove 6 false skill-skill edges before it was caught.
 
     NFKD + drop-combining is idempotent, so folding again downstream is safe.
     """
-    text = unicodedata.normalize("NFKD", text)
-    text = "".join(c for c in text if not unicodedata.combining(c))
+    text = _fold(text)
     # Remove code blocks (they add noise)
     text = re.sub(r"```[\s\S]*?```", " ", text)
     # Remove URLs
@@ -799,6 +836,12 @@ def generate_connectome():
         "meta": {
             "generated": t0.isoformat(),
             "version": "2.0",
+            # Bumped whenever tokenization changes. A map built by a different
+            # tokenizer than the one asking the question is STALE even when its
+            # mtime is newer than every source file: a sibling machine that
+            # pulls new scripts keeps an old-tokenizer index and silently
+            # answers zero. Freshness checks compare this, not just mtimes.
+            "tokenizer": TOKENIZER_VERSION,
             "generator": "generate_neural_map.py",
             "model": "Octopus Deep Connectome",
             "generation_time_sec": round(elapsed, 2),

--- a/scripts/query_connectome.py
+++ b/scripts/query_connectome.py
@@ -38,6 +38,7 @@ import math
 import os
 import re
 import sys
+import unicodedata
 import tempfile
 from collections import Counter
 from contextlib import contextmanager
@@ -392,7 +393,20 @@ def build_graph(data, use_hebbian=True):
 # ─── Tokenizer (lightweight, matches generator) ──────────────────────────────
 
 def tokenize_query(text):
-    """Tokenize a query string for matching against node content."""
+    """Tokenize a query string for matching against node content.
+
+    MUST fold accents exactly like the generator. Both sides tokenize
+    independently, and a query that produces "sesi" can never match an index
+    that stores "sesion". Measured while fixing the generator: folding the build
+    side ALONE turned a working Spanish query into zero hits, because the two
+    sides stopped agreeing. Consistently wrong beat inconsistently right.
+
+    Three copies of this tokenizer now exist (here, generate_neural_map.py,
+    brain-memory-recall.py). They must agree on folding; the duplication itself
+    is the standing hazard and wants a shared module.
+    """
+    text = unicodedata.normalize("NFKD", text)
+    text = "".join(c for c in text if not unicodedata.combining(c))
     text = re.sub(r"[#*\`\[\](){}|>_~=\-]", " ", text.lower())
     words = re.findall(r"[a-z][a-z0-9]{2,}(?:-[a-z0-9]+)*", text)
     return [w for w in words if w not in STOP_WORDS and len(w) >= 3]

--- a/scripts/query_connectome.py
+++ b/scripts/query_connectome.py
@@ -146,7 +146,36 @@ _STOP_ES = (
     "hace hizo hay hubo habrá había también ante antes después durante luego "
     "porque pues aunque mientras si bien aquí ahí allí allá esto ello"
 )
-STOP_WORDS = frozenset((_STOP_EN + " " + _STOP_ES).split())
+STOP_WORDS = None  # set below, after _folded_stops is defined
+
+def _fold(text):
+    """NFKD-fold: drop combining marks. Idempotent."""
+    return "".join(
+        c for c in unicodedata.normalize("NFKD", text) if not unicodedata.combining(c)
+    )
+
+
+def _folded_stops(words):
+    """Every stop word PLUS its folded form.
+
+    Folding the corpus without folding this list is a trap that bites in the
+    worst direction: an accented stop word ("que" with its accent) can never be
+    matched again, so it stops being filtered, and its folded form walks into
+    the vocabulary as a high-frequency term. Measured before this fix: "que"
+    entered the index with idf 2.502 and drove every one of the 9 synapses the
+    accent fix added. A stop list must be folded in lockstep with the tokenizer,
+    and identically in both files, since their equality is what keeps the index
+    and the query aligned.
+    """
+    out = set()
+    for w in words:
+        out.add(w)
+        out.add(_fold(w))
+    return frozenset(out)
+
+
+STOP_WORDS = _folded_stops((_STOP_EN + " " + _STOP_ES).split())
+
 
 
 # ─── Graph Builder ────────────────────────────────────────────────────────────
@@ -401,12 +430,19 @@ def tokenize_query(text):
     side ALONE turned a working Spanish query into zero hits, because the two
     sides stopped agreeing. Consistently wrong beat inconsistently right.
 
-    Three copies of this tokenizer now exist (here, generate_neural_map.py,
-    brain-memory-recall.py). They must agree on folding; the duplication itself
-    is the standing hazard and wants a shared module.
+    TWO tokenizers must agree, and only two: this one and
+    generate_neural_map.tokenize. They are the pair that writes and reads
+    neural_map.json, so a divergence between them is a silent zero-hit recall.
+    connectome-heartbeat.py imports this function, so it folds transitively.
+
+    Other tokenizers in the brain (delegate-check, brain-memory-recall.py,
+    gap-capture.py, goal-anchor.py) tokenize their own text on BOTH sides and
+    never read neural_map.json, so they cannot desynchronize from it.
+    brain-memory-recall.py in particular does not mutilate: its regex already
+    admits accented characters. The duplication is still a standing hazard and
+    wants a shared module; that is a separate change.
     """
-    text = unicodedata.normalize("NFKD", text)
-    text = "".join(c for c in text if not unicodedata.combining(c))
+    text = _fold(text)
     text = re.sub(r"[#*\`\[\](){}|>_~=\-]", " ", text.lower())
     words = re.findall(r"[a-z][a-z0-9]{2,}(?:-[a-z0-9]+)*", text)
     return [w for w in words if w not in STOP_WORDS and len(w) >= 3]
@@ -659,7 +695,11 @@ def cmd_query(G, data, query_text, top_n=10):
                 " ".join(attrs.get("triggers", [])),
                 attrs.get("description", ""),
                 node_id.replace("-", " "),
-            ]).lower()
+            ])
+            # Fold the HAYSTACK too. The tokens were folded, so a raw haystack
+            # loses every accented match: folded "canonico" does not appear in
+            # a description that spells it with the accent.
+            node_text = _fold(node_text).lower()
 
             for token in tokens:
                 if token in node_text:
@@ -836,7 +876,8 @@ def cmd_4d(G, data, task_text):
             " ".join(attrs.get("triggers", [])),
             attrs.get("description", ""),
             node_id.replace("-", " "),
-        ]).lower()
+        ])
+        node_text = _fold(node_text).lower()  # folded tokens need a folded haystack
         score = sum(1 for t in tokens if t in node_text)
         if score > 0:
             scores[node_id] = score


### PR DESCRIPTION
Follow-up to #248, which found this defect but deliberately left it alone because fixing it here rewrites similarity scores brain-wide.

## The defect

The word regex only starts a token at `[a-z]`, so a combining accent **splits the word and eats its head**.

| written | tokenized as |
|---|---|
| `código` | `digo` |
| `diseño` | `dise` |
| `español` | `espa` |
| `sesión` | `sesi` |
| `día` | *(gone — too short after the cut)* |

Two failures follow. The real word never enters the vocabulary, so a search for it cannot match. And the mutilated stem *does* enter, where it can collide with an unrelated real word (`digo` is a real Spanish verb) and weave a synapse between documents that share nothing.

## Measured, not assumed

Corpus: 441 skill and agent files.

| | before | after | delta |
|---|---|---|---|
| distinct accented words | 157 (240 occurrences) | — | — |
| mutilated stems in vocabulary | 129 | 0 | −129 |
| real words admitted | — | 97 | +97 |
| vocabulary (idf) | 24,342 | 24,347 | +5 |
| neurons | 167 | 167 | 0 |
| synapses | 248 | 248 | 0 |
| vectors | 415 | 415 | 0 |

Structure is untouched. The change is entirely in *which terms* carry weight.

The impact here is modest because skills and agents are written mostly in English. The same defect was severe in the life-memories corpus of #248, where the operator's own city indexed as `laga`.

## Both sides, and that is the point

**Folding the generator alone turned a working Spanish query into ZERO hits.** `query_connectome.py` tokenizes independently, so it kept producing `sesi` against an index that now stored `sesion`. Consistently wrong beat inconsistently right.

Caught by an A/B against the pre-fix map, not by reading the diff. Both tokenizers fold now.

## A/B, 6 queries, old map + old query vs new map + new query

- **3 English queries**: identical results, no degradation
- **Spanish, chat-guard sessions**: old returned two unrelated skills (`client-doc-lint`, `Clausulado de cotización`); new returns `Guardia de chat` and `Session / Instance Isolation`, both correct. Clear win
- **Spanish, quoting with tax**: identical. It already worked, because both sides mutilated *consistently*
- **Spanish, code review before merge**: mild third-place reshuffle, `Book Co-Author` displaces `AI Data Remediation Engineer`. Noise, reported rather than tuned away

## Hazard left standing

Three copies of this tokenizer now exist: `generate_neural_map.py`, `query_connectome.py`, `brain-memory-recall.py`. They must agree on folding, and nothing enforces that. **The duplication is the standing risk and this PR does not fix it** — a shared module is the real answer and deserves its own change.

`brain-memory-recall.py` does not mutilate (its regex already admits accented characters), so it is left to #248, which already touches that file.

## Verification

- `check-generic` clean
- `ast.parse` clean on both files
- Unit control: an accented Spanish sentence now tokenizes to `sesion, revision, malaga, decision, correccion, codigo, diseno, dia`
- Live map regenerated and restored; hash-verified that the working map matches the fixed build

## Merge gate

Not self-approved. Touches the brain's recall path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NS39VxQBhVyxKkbiQKGQNd