### PR TITLE
fix(security): resolve the leak blocklist from the main checkout, not the worktree

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -15,7 +15,19 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
 [ -z "$REPO_ROOT" ] && { echo "pre-push: not in a git repo" >&2; exit 0; }
 
 POLICY="$REPO_ROOT/.githooks/push-policy.txt"
+
+# The blocklist is gitignored, so it exists ONLY in the main checkout: a git
+# worktree gets tracked files and nothing else. Resolving it from $REPO_ROOT
+# meant every push from a worktree ran with an EMPTY blocklist and silently
+# allowed what it exists to stop. That is not hypothetical: a client's company
+# name reached a public branch that way, from a worktree the session-isolation
+# hook had created automatically. --git-common-dir points at the main .git even
+# from a linked worktree, so its parent is where the private data lives.
+MAIN_ROOT="$(dirname "$(git rev-parse --git-common-dir 2>/dev/null)")"
 BLOCKLIST="$REPO_ROOT/company/brain-blocklist.txt"
+if [ ! -f "$BLOCKLIST" ] && [ -f "$MAIN_ROOT/company/brain-blocklist.txt" ]; then
+  BLOCKLIST="$MAIN_ROOT/company/brain-blocklist.txt"
+fi
 ZERO="0000000000000000000000000000000000000000"
 
 # ── Load policy ────────────────────────────────────────────────────────────
@@ -50,6 +62,14 @@ if [ -f "$BLOCKLIST" ]; then
 fi
 
 BLOCKLIST_RE=""
+if [ ${#BLOCKLIST_TOKENS[@]} -eq 0 ]; then
+  # A guard that disables itself when its data is missing, silently, is how the
+  # leak got out. The universal policy still runs; say out loud that the private
+  # layer is not. Never fatal: an outside contributor legitimately has no
+  # blocklist, and the repo must stay pushable for them.
+  echo "pre-push: NOTE — company/brain-blocklist.txt not found; the private" >&2
+  echo "  client-name layer is NOT active for this push (universal policy still runs)." >&2
+fi
 if [ ${#BLOCKLIST_TOKENS[@]} -gt 0 ]; then
   # join tokens with | for a single alternation; escape regex metachars
   for t in "${BLOCKLIST_TOKENS[@]}"; do

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 # NEVER commit this directory. It contains all company-specific data.
 # Leading slash anchors to repo root — does NOT match templates/company/.
 /company/
+# ...and as a bare entry, because worktree-init creates `company` as a
+# SYMLINK to the main checkout, and `company/` only matches a directory.
+# Without this the link shows up untracked in every worktree and could be
+# committed, publishing the private path layout.
+company
 
 # External reference repos (cloned separately, not part of the brain repo)
 *-ref/

--- a/scripts/octo-dim.py
+++ b/scripts/octo-dim.py
@@ -693,8 +693,34 @@ def cmd_worktree_init(args) -> int:
             print(f"worktree-init: could not create worktree: {msg}")
             return 0  # never hard-fail
 
+    _link_private_data(repo, target)
     print(str(target))
     return 0
+
+
+def _link_private_data(repo: Path, target: Path) -> None:
+    """Point the new worktree at the main checkout's gitignored private data.
+
+    A worktree receives TRACKED files only, so `company/` never appears in one.
+    Everything that reads it therefore ran blind from a worktree: the pre-push
+    leak guard soft-failed open, check-generic found no blocklist, brain_doctor
+    reported it absent. A client's company name reached a public branch through
+    exactly that gap, from a worktree this very function had created.
+
+    A symlink, not a copy: the blocklist must never be duplicated, and an
+    inherited link keeps the two in sync with no staleness window. Best-effort
+    on purpose, since worktree creation must never hard-fail; when it cannot be
+    made (Windows without privileges, for one), pre-push still resolves the
+    blocklist through --git-common-dir, which is the guard that actually blocks.
+    """
+    source = repo / "company"
+    link = target / "company"
+    if not source.is_dir() or link.exists() or link.is_symlink():
+        return
+    try:
+        link.symlink_to(source, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pass  # pre-push's own resolution covers this case
 
 
 # ── main ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## The gap

`company/brain-blocklist.txt` is gitignored, and a git worktree receives tracked files only, so the file never exists in one. `.githooks/pre-push` resolved it from the current worktree root, found nothing, and fell through with an empty pattern.

**Every push from a worktree ran with the private client-name layer silently disabled.**

Not hypothetical: a client's company name reached a public branch exactly this way, from a worktree the session-isolation hook creates automatically. The mechanism built to isolate sessions had disabled the mechanism built to protect clients, and nothing anywhere said so.

## The fix, in three layers

1. **Resolution (the one that matters).** `pre-push` now falls back to `--git-common-dir`, which points at the main `.git` even from a linked worktree, so its parent is the main checkout where the private data lives. This repairs worktrees that already exist, with no setup step and no migration.
2. **Coverage.** `worktree-init` symlinks `company/` into each new worktree, because `pre-push` is not the only reader: `check-generic.py` and `brain_doctor.py` were blind there too. A symlink and never a copy, so the list is never duplicated. Best-effort, since worktree creation must not hard-fail.
3. **Visibility.** An absent blocklist is now announced on stderr instead of passing in silence. Deliberately non-fatal: an outside contributor legitimately has no blocklist and this repo must stay pushable for them. Silence is what let the gap survive.

## Verification

Ran against the **real leaked commit**, from a worktree with no `company/` link:

| hook | leaking commit | clean commit |
|---|---|---|
| before | exit 0 (allowed) | exit 0 |
| after | **exit 1**, naming the offending line | exit 0 |

The benign leg matters as much as the blocking one: a guard that blocked everything would pass a violation-only test while being unusable. Also confirmed the fresh-worktree symlink creates the link, and that the absent-blocklist notice prints when the file is missing everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuNmVBAMoM5XeDKkqR4hAc