### PR TITLE
docs(changelog): backfill v6.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ machine-generated growth ledger lives at
 
 ## [Unreleased]
 
+## [2026-09-04]: v6.23.1
+### Fixes
+- fix(registry): single anchor line for Do-it-today; backfill CHANGELOG v6.23.0 (#255)
+### Other
+- docs(changelog): backfill v6.21.4 through v6.21.6 (#254)
+
 ## [2026-09-03]: v6.23.0
 ### Features
 - feat(gate): block unsourced classifying attributes in outward drafts (#250)


### PR DESCRIPTION
Closes the release-drift warn left after #255 cut v6.23.1. Entry generated by `changelog-sync.py --apply` from the GitHub Release notes. Changelog-only, so version-bump skips the tag (#238) and CHANGELOG top converges with the newest tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPPcRmXDTe7ZSKbCX5dosS