### PR TITLE
docs(changelog): backfill v6.24.0 and v6.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ machine-generated growth ledger lives at
 ### Other
 - docs(architecture): v7 plan, nothing ships unverified (#258)
 
-## [2026-09-04]: v6.24.0
+## [2026-09-05]: v6.24.0
 ### Features
 - feat(gate): block unsourced absence claims in outward drafts without a seek receipt (#257)
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ machine-generated growth ledger lives at
 
 ## [Unreleased]
 
+## [2026-09-05]: v6.24.1
+### Other
+- docs(architecture): v7 plan, nothing ships unverified (#258)
+
+## [2026-09-04]: v6.24.0
+### Features
+- feat(gate): block unsourced absence claims in outward drafts without a seek receipt (#257)
+### Other
+- docs(changelog): backfill v6.23.1 (#256)
+
 ## [2026-09-04]: v6.23.1
 ### Fixes
 - fix(registry): single anchor line for Do-it-today; backfill CHANGELOG v6.23.0 (#255)


### PR DESCRIPTION
Backfills the two releases cut today so brain_doctor release-drift converges. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPPcRmXDTe7ZSKbCX5dosS