### PR TITLE
docs(changelog): promote the v7.0.0 notes from Unreleased to the dated entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ machine-generated growth ledger lives at
 `knowledge/repo-watch/<date>.md` (daily watchlist digests).
 
 ## [Unreleased]
+
+## [2026-09-06]: v7.0.0
 **v7.0.0 "Nothing Ships Unverified"**
 
 ### The contract


### PR DESCRIPTION
changelog-sync --apply after the v7.0.0 tag: the Unreleased body becomes `## [2026-09-06]: v7.0.0`, Unreleased is left empty as the standing intake. Docs-only; release-drift converges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPPcRmXDTe7ZSKbCX5dosS