### PR TITLE
docs(changelog): backfill v7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ machine-generated growth ledger lives at
 
 ## [Unreleased]
 
+## [2026-09-06]: v7.1.0
+### Features
+- feat(doctor): stale-merged-branches audit (#266)
+### Other
+- docs(changelog): promote the v7.0.0 notes from Unreleased to the dated entry (#265)
+
 ## [2026-09-06]: v7.0.0
 **v7.0.0 "Nothing Ships Unverified"**
 


### PR DESCRIPTION
changelog-sync --apply after the v7.1.0 tag (#266). Docs-only; the bump's changelog-only guard cuts no new tag, so release-drift converges. Docs-only merge: the documented `OCTO_QA_OK=1` bypass applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPPcRmXDTe7ZSKbCX5dosS