### PR TITLE
docs(changelog): backfill v7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ machine-generated growth ledger lives at
 
 ## [Unreleased]
 
+## [2026-09-06]: v7.2.0
+- feat(ci): version-bump heals CHANGELOG.md through an auto-merged bot PR (#268)
+- docs(changelog): backfill v7.1.0 (#267)
+
 ## [2026-09-06]: v7.1.0
 ### Features
 - feat(doctor): stale-merged-branches audit (#266)


### PR DESCRIPTION
Automated heal branch pushed by version-bump.yml after cutting v7.2.0; the PR step failed with HTTP 401 on OCTORATO_PAT, so this PR is opened by hand. Docs-only: the bump's changelog-only guard cuts no new tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPPcRmXDTe7ZSKbCX5dosS