### PR TITLE
docs(changelog): backfill v7.2.1 + triage decision for the session-isolation lesson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ machine-generated growth ledger lives at
 
 ## [Unreleased]
 
+## [2026-09-06]: v7.2.1
+- docs: long-document revision pass (changelog, README, capability manifest, architecture) (#270)
+
 ## [2026-09-06]: v7.2.0
 ### Features
 - feat(ci): version-bump heals CHANGELOG.md through an auto-merged bot PR (#268)

--- a/registry/reflex-triage.yaml
+++ b/registry/reflex-triage.yaml
@@ -152,3 +152,8 @@ decisions:
     decision: demote
     reason: "a negotiation tactic; deliberately not automated"
     decided: 2026-09-05
+  - slug: lesson_session_isolation_worktree
+    decision: gate
+    mechanism: scripts/dimension-awareness-hook.py
+    reason: "the session half is live (session-isolation-hook forks a newcomer into its own worktree; the dimension gate denies broad staging on a shared tree while other dimensions are live); the subagent half (a builder running git checkout/restore on files another builder owns) has no detector yet: candidate is a PreToolUse deny on git checkout -- / restore / stash / reset --hard against paths dirty in the tree, or one worktree per writing subagent by protocol"
+    decided: 2026-09-06


### PR DESCRIPTION
Heal branch pushed by version-bump.yml after cutting v7.2.1 (its PR step still fails with HTTP 401 on OCTORATO_PAT, so the PR is opened by hand), plus one registry entry: the reflex-triage decision for lesson_session_isolation_worktree, which became recurrent today (three builders on one worktree, one reverted the others with git checkout). The session half is a live gate; the subagent half is recorded as a candidate. Docs and registry only; no script changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPPcRmXDTe7ZSKbCX5dosS