### PR TITLE
docs(changelog): backfill v7.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ machine-generated growth ledger lives at
 
 ## [Unreleased]
 
+## [2026-09-06]: v7.2.2
+- docs(changelog): backfill v7.2.1 + triage decision for the session-isolation lesson (#271)
+
 ## [2026-09-06]: v7.2.1
 - docs: long-document revision pass (changelog, README, capability manifest, architecture) (#270)
 


### PR DESCRIPTION
Heal branch pushed by version-bump.yml after cutting v7.2.2 (PR step fails with HTTP 401 on OCTORATO_PAT; opened by hand). Changelog-only on purpose: the bump's changelog-only guard cuts no new tag on merge, which ends the tag-heal loop that #271 caused by carrying a registry change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPPcRmXDTe7ZSKbCX5dosS