### PR TITLE
docs(i18n): English descriptions for 71 skills and 10 script headers

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -97,7 +97,7 @@
 | gh-fix-ci | Use when a user asks to debug or fix failing GitHub PR checks that run in GitHub Actions; use `gh` to inspect checks and... |
 | github-trending-curation | Daily brain discovery loop. Pulls top trending from GitHub + HN + Product Hunt, runs heuristic + LLM filter against exis... |
 | graphify-code-graph | Deterministic, queryable knowledge graph over a codebase with graphify (tree-sitter, 25+ languages, no LLM cost). Use it... |
-| gsap-core | API core de GSAP: to(), from(), fromTo(), easing, duration, stagger, defaults y matchMedia (responsive, prefers-reduced-... |
+| gsap-core | GSAP core API: to(), from(), fromTo(), easing, duration, stagger, defaults and matchMedia (responsive, prefers-reduced-m... |
 | gsap-frameworks | Official GSAP skill for Vue, Svelte, and other non-React frameworks , lifecycle, scoping selectors, cleanup on unmount. ... |
 | gsap-performance | Official GSAP skill for performance , prefer transforms, avoid layout thrashing, will-change, batching. Use when optimiz... |
 | gsap-plugins | Official GSAP skill for GSAP plugins , registration, ScrollToPlugin, ScrollSmoother, Flip, Draggable, Inertia, Observer,... |
@@ -246,7 +246,7 @@
 | web-perf | Audits web performance with the Chrome DevTools MCP: Core Web Vitals (LCP, INP, CLS), render-blocking resources, network... |
 | whatsapp-mcp-bridge-gotchas | Fixes for the lharries/whatsapp-mcp bridge: 403 media download, 405 client-outdated, QR vs phone-code pairing, encrypt-a... |
 | windows-brain-script-portability | Scripts in ~/.claude/scripts/ that run on a Windows brain: use the python3.cmd shim and not bare python3, and reconfigur... |
-| winui-app | Crea, desarrolla y disena apps de escritorio WinUI 3 con C# y Windows App SDK segun guia oficial de Microsoft y Communit... |
+| winui-app | Create, build and design WinUI 3 desktop apps with C# and the Windows App SDK following Microsoft's official guidance an... |
 | workers-best-practices | Reviews and authors Cloudflare Workers code against production best practices. Load when writing new Workers, reviewing ... |
 | workspace-skill-discovery | Discover and include ALL skills across the workspace , not just global ones. Use at the start of every session or when t... |
 | wrangler | Cloudflare Workers CLI for deploying, developing, and managing Workers, KV, R2, D1, Vectorize, Hyperdrive, Workers AI, C... |

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -18,49 +18,49 @@
 
 | Name | Description |
 |---|---|
-| 4d-paradigm-protocol | Protocolo completo del paradigma 4D (Describe, Delegate, Diligent, Disclose): el gate de 3 preguntas del 2D, el formato ... |
+| 4d-paradigm-protocol | Full 4D paradigm protocol (Describe, Delegate, Diligent, Disclose): the 2D 3-question gate, the Change Manifest format, ... |
 | 4d-spec | 4D+S: Spec-Driven 4D Orchestrator |
-| ado-pr-merge-via-api | Completa merges de Pull Request en Azure DevOps por REST API cuando la UI no sirve o hay que scriptear en lote. Cubre lo... |
+| ado-pr-merge-via-api | Completes Pull Request merges in Azure DevOps through the REST API when the UI fails or you need to script them in bulk.... |
 | ado-refactor-performance-gate | Mandatory performance gate for Azure DevOps SQL refactor tickets. Use when a ticket includes stored procedure refactor/r... |
-| agent-browser | CLI de automatizacion de navegador para agentes, nativo en Rust, sin Playwright. Navega, llena formularios, da clic, tom... |
+| agent-browser | Rust-native browser automation CLI for agents, no Playwright. Navigates, fills forms, clicks, takes screenshots and extr... |
 | agent-proof-approval-gate | Build a fail-closed PreToolUse gate for merge/deploy/destructive actions that the AI agent provably cannot self-bypass. ... |
 | agents-sdk | Build AI agents on Cloudflare Workers using the Agents SDK. Load when creating stateful agents, durable workflows, real-... |
 | anthropic-enterprise-analytics | Pull Anthropic's Admin API usage_report into ~/.claude/analytics/ so brain-digest can reconcile estimated cost (from ses... |
-| arm-onboarding | Protocolo paso a paso para crear un arm nuevo de cliente: archivos requeridos, sync-ai-docs, el grafo de linaje sellado ... |
+| arm-onboarding | Step-by-step protocol to create a new client arm: required files, sync-ai-docs, the arm's sealed lineage graph, QueryMas... |
 | arm-synthetics | Per-arm health check templates. Each arm defines a synthetics.yaml with endpoints to probe + expected responses + cron s... |
-| ask-with-recommendation | Toda pregunta de opcion multiple al operador lleva recomendacion explicita marcada mas su razon (impacto, alcance, tiemp... |
+| ask-with-recommendation | Every multiple-choice question to the operator carries an explicit marked recommendation plus its reason (impact, scope,... |
 | aspnet-core | Build, review, refactor, or architect ASP.NET Core web applications using current official guidance for .NET web develop... |
 | atomic-3phase-ddl-scripts | Atomic 3-Phase DDL Scripts |
 | autovacuum-bloat-management | Autovacuum & Table Bloat Management |
 | backward-compatible-schema-changes | Backward-Compatible Schema Changes |
 | batch-import-relative-paths | When you batch-add an `import` line to N source files via sed/awk, the relative path must be computed PER-FILE (depth va... |
 | browser-bearer-graph-auth | Conditional-Access-resilient OAuth alternative for Microsoft Graph: drive a Playwright + Edge persistent context to capt... |
-| bruno-postman-alternative | Cliente de API open-source donde las colecciones son archivos de texto en el repo, revisables por PR, sin nube ni licenc... |
+| bruno-postman-alternative | Open-source API client where collections are text files in the repo, reviewable by PR, with no cloud and no per-seat lic... |
 | bug-hunter | Adversarial bug hunting with a sequential-first pipeline (Recon, Hunter, Skeptic, Referee) that can optionally use safe ... |
 | cache-bust-deploy-validation | After a production deploy of a CDN-fronted site, force cache-bust on every validation request and inspect Age/cache-stat... |
-| canary-symbiont | Centinela cross-plane: un watcher en el plano B detecta la muerte SILENCIOSA del scheduler del plano A (bloqueo de billi... |
-| capture-ends-with-triage | Un pipeline programado que solo vuelca datos crudos obliga al humano a sintetizar, y por eso se omite. Todo capture debe... |
+| canary-symbiont | Cross-plane sentinel: a watcher on plane B detects the SILENT death of plane A's scheduler (billing block, cron load-she... |
+| capture-ends-with-triage | A scheduled pipeline that only dumps raw data forces the human to synthesize, and that is why it gets skipped. Every cap... |
 | case-insensitive-uniqueness | Case-Insensitive Uniqueness (Functional Indexes) |
-| ccxt-python | Libreria CCXT para exchanges de cripto en Python, REST y WebSocket: conectar, bajar datos de mercado, colocar ordenes y ... |
-| chatgpt-apps | Construye y depura apps del ChatGPT Apps SDK que combinan servidor MCP y UI de widget: definir tools, registrar recursos... |
-| claude-mem-persistent-memory | Memoria persistente entre sesiones para agentes de codigo: captura la sesion, la comprime y reinyecta lo relevante despu... |
+| ccxt-python | CCXT library for crypto exchanges in Python, REST and WebSocket: connect, pull market data, place orders and stream tick... |
+| chatgpt-apps | Build and debug ChatGPT Apps SDK apps that pair an MCP server with a widget UI: defining tools, registering UI resources... |
+| claude-mem-persistent-memory | Persistent cross-session memory for coding agents: captures the session, compresses it and re-injects what is relevant l... |
 | claude-plugins-official | Official, Anthropic-managed directory of high quality Claude Code Plugins. |
 | claude-usage-report | Aggregate Claude Code usage (tokens, sessions, API-equivalent cost) by day, week, month, model, and project from local J... |
-| client-doc-lint | Reflejo de QA antes de mandar un entregable generado a cliente: revisa acentos rotos, em-dash, fechas ya pasadas, falta ... |
+| client-doc-lint | QA reflex before sending a generated deliverable to a client: checks broken accents, em-dashes, dates already past, a mi... |
 | cloudflare | Comprehensive Cloudflare platform skill covering Workers, Pages, storage (KV, D1, R2), AI (Workers AI, Vectorize, Agents... |
 | cloudflare-deploy | Deploy applications and infrastructure to Cloudflare using Workers, Pages, and related platform services. Use when the u... |
-| cloudflare-email-service | Envia y recibe correo transaccional con Cloudflare Email Service (Sending mas Routing), por binding de Workers o REST. C... |
+| cloudflare-email-service | Send and receive transactional email with Cloudflare Email Service (Sending plus Routing), through a Workers binding or ... |
 | column-renames-metadata-only | Column Renames (Metadata-Only) |
 | command-boundary-hook-matching | Pattern-match what a Bash command actually does in a PreToolUse hook without false-firing on mentions inside quoted args... |
 | config-driven-diagrams | Build config-driven architecture diagrams as dark-themed SVG/PNG with swimlanes, embedded logos, auto-layout, and overla... |
 | connection-pooling-timeout-safety | Connection Pooling & Timeout Safety |
 | content-deduplication-discipline | Content Deduplication Discipline |
-| coolify-self-hosted-paas | Alternativa autoalojada a Vercel, Heroku y Render: despliega apps, bases y servicios en tu propio servidor con git-push,... |
-| cotizacion-legal-baseline | Clausulado legal base Mexico B2B que TODA cotizacion o propuesta lleva desde el borrador 1: propiedad intelectual, LFPDP... |
+| coolify-self-hosted-paas | Self-hosted alternative to Vercel, Heroku and Render: deploy apps, databases and services on your own server with git-pu... |
+| cotizacion-legal-baseline | Baseline Mexico B2B legal clauses that EVERY quote or proposal carries from draft 1: intellectual property, LFPDPPP, con... |
 | coworking-concept-collision | Protocol for when two live sessions are codifying the SAME concept concurrently (not just sharing a working tree). Detec... |
-| cron-bridge-daily-publisher | Patron para autopublicar a diario N elementos curados desde D1 a una plataforma social via el worker programador. Incluy... |
+| cron-bridge-daily-publisher | Pattern to auto-publish N curated items per day from D1 to a social platform through the scheduler worker. Includes fair... |
 | cross-reference-integrity | Cross-Reference Integrity |
-| daily-reflection | Retro honesta de fin de sesion, errores primero, que destila la leccion a memoria del cerebro. Dispara con 'que aprendis... |
+| daily-reflection | Honest end-of-session retro, errors first, that distills the lesson into brain memory. Triggers on 'que aprendiste hoy?'... |
 | data-retention-policy-lifecycle | Data Retention Policy Lifecycle |
 | database-guard-pattern | Database Guard Pattern |
 | database-naming-conventions | Database Naming Conventions |
@@ -68,7 +68,7 @@
 | deep-grep-code-review | Deep Grep Code Review |
 | deterministic-shutdown-backstop | A long-lived service that hangs INTERMITTENTLY on SIGTERM (non-reproducible, the init system kills it at the timeout, a ... |
 | develop-web-game | Use when Codex is building or iterating on a web game (HTML/JS) and needs a reliable development + testing loop: impleme... |
-| do-it-right-not-fast | Canonico del operador: arregla la CAUSA RAIZ, nunca el parche rapido ni una pila de archivos paliativos. Dos olores obli... |
+| do-it-right-not-fast | Operator canon: fix the ROOT CAUSE, never the quick patch and never a pile of palliative files. Two smells force a stop:... |
 | do-not-ask-to-pause | Canonical mandate , never ask the operator "should we pause?" or "do we close the session?" when there is queued work, a... |
 | doc | Use when the task involves reading, creating, or editing `.docx` documents, especially when formatting or layout fidelit... |
 | doc-tree-consolidation | Collapse N fragmented markdown docs into a small canonical set without losing content or breaking cross-references. Dist... |
@@ -76,27 +76,27 @@
 | document-semantic-coherence | Document Semantic Coherence |
 | dry-run-gate-pattern | Dry-Run Gate Pattern |
 | durable-objects | Create and review Cloudflare Durable Objects. Use when building stateful coordination (chat rooms, multiplayer games, bo... |
-| eli5 | Explica cualquier documento, concepto o arquitectura en lenguaje adulto y claro, con analogias y sin jerga. Dispara con ... |
+| eli5 | Explains any document, concept or architecture in plain adult language, with analogies and no jargon. Triggers on 'eli5'... |
 | execution-bias | Don't defer to 'later / follow-up / next session' what can be done now. If no real blocker and auto-mode is on, execute ... |
 | explain-analyze-validation | EXPLAIN ANALYZE Query Validation |
 | fb-carousel-cap-4 | Meta Graph /feed?attached_media= silently 500s with N>=5 photos + a long caption , cap defensively at 4 inside any FB Pa... |
 | fb-page-dual-id | A Facebook Page has TWO different identifiers: the URL ID seen in `profile.php?id=N` (and in the page's vanity URL) and ... |
 | figma | Use the Figma MCP server to fetch design context, screenshots, variables, and assets from Figma, and to translate Figma ... |
 | figma-implement-design | Translates Figma designs into production-ready application code with 1:1 visual fidelity. Use when implementing UI code ... |
-| figma-use | MANDATORY prerequisite: invocalo ANTES de cada llamada a use_figma, nunca llames esa herramienta sin cargar esto. Aplica... |
+| figma-use | MANDATORY prerequisite: invoke it BEFORE every use_figma call, never call that tool without loading this first. Applies ... |
 | fillfactor-storage-tuning | Fillfactor & Storage Parameter Tuning |
 | financial-formula-verification | Financial Formula Verification for Cloud Cost Documents |
 | finops-budget-policy | Per-arm monthly USD budget caps with three escalation levels (alert / warn / hard_stop). Config lives in ~/.claude/budge... |
-| finops-observability | Mide el costo del cerebro y sus agentes y rutea la pregunta a la herramienta correcta: gasto por arm, KPI de ruteo, cost... |
+| finops-observability | Measures what the brain and its agents cost and routes the question to the right tool: spend per arm, routing KPIs, marg... |
 | floci-local-aws | Run AWS services locally , S3, DynamoDB, SQS, Lambda, ECS, ECR, OpenSearch, MSK/Kafka, Athena and ~45 more , using Floci... |
 | foreign-key-constraints | Foreign Key Constraints |
 | frontend-skill | Use when the task asks for a visually strong landing page, website, app, prototype, demo, or game UI. This skill enforce... |
 | gap-analysis-pattern | Gap Analysis Pattern |
-| gemini-vision | DISPARADOR OBLIGATORIO: 'analiza imagen', 'nano banana', 'gemini vision', 'que ves en la imagen', o al pegar una imagen ... |
+| gemini-vision | MANDATORY TRIGGER: 'analiza imagen', 'nano banana', 'gemini vision', 'que ves en la imagen', or when an image is pasted ... |
 | gh-address-comments | Help address review/issue comments on the open GitHub PR for the current branch using gh CLI; verify gh auth first and p... |
 | gh-fix-ci | Use when a user asks to debug or fix failing GitHub PR checks that run in GitHub Actions; use `gh` to inspect checks and... |
 | github-trending-curation | Daily brain discovery loop. Pulls top trending from GitHub + HN + Product Hunt, runs heuristic + LLM filter against exis... |
-| graphify-code-graph | Grafo de conocimiento determinista y consultable sobre un codebase con graphify (tree-sitter, 25+ lenguajes, sin costo d... |
+| graphify-code-graph | Deterministic, queryable knowledge graph over a codebase with graphify (tree-sitter, 25+ languages, no LLM cost). Use it... |
 | gsap-core | API core de GSAP: to(), from(), fromTo(), easing, duration, stagger, defaults y matchMedia (responsive, prefers-reduced-... |
 | gsap-frameworks | Official GSAP skill for Vue, Svelte, and other non-React frameworks , lifecycle, scoping selectors, cleanup on unmount. ... |
 | gsap-performance | Official GSAP skill for performance , prefer transforms, avoid layout thrashing, will-change, batching. Use when optimiz... |
@@ -107,37 +107,37 @@
 | harmonization-over-accretion | Reusable rebuttal pattern for "let's import all N items from competitor X" temptations. Explains why connectome-graph br... |
 | hook-profile-gating | Runtime gate hooks via OCTO_HOOK_PROFILE (minimal|standard|strict) and OCTO_DISABLED_HOOKS (comma-separated ids) , disab... |
 | horizontal-scroll-html-vs-body | Android Chrome ignores overflow-x:hidden on <body> if <html> still allows it , clip the root, not just the body, to kill... |
-| human-cadence | Las 10 no-reglas que quitan los tics de IA a cualquier texto para que lea como persona: sin em-dash, sin muletillas, sin... |
+| human-cadence | The 10 no-rules that strip AI tells from any text so it reads like a person: no em-dash, no filler words, no forced tria... |
 | idempotent-sql-design | Idempotent SQL Design |
-| image-analyzer | DISPARADOR OBLIGATORIO: 'imagen', 'mira la imagen', 'screenshot', 'foto', 'captura', 'que ves', 'look at this', o cuando... |
+| image-analyzer | MANDATORY TRIGGER: 'imagen', 'mira la imagen', 'screenshot', 'foto', 'captura', 'que ves', 'look at this', or when an im... |
 | image-transparency | Use when the user asks to remove a white/grey background from an image, logo, or signature to make it transparent, using... |
-| imagegen | Genera o edita imagenes raster con IA: fotos, ilustraciones, texturas, sprites, mockups, recortes con fondo transparente... |
-| inbox-triage-classifier | Triage de bandejas (correo, Slack, Teams, JIRA, PRs): clasifica que requiere accion y devuelve veredicto por item con ur... |
+| imagegen | Generates or edits raster images with AI: photos, illustrations, textures, sprites, mockups, cutouts with a transparent ... |
+| inbox-triage-classifier | Triage for inboxes (email, Slack, Teams, JIRA, PRs): classifies what needs action and returns a per-item verdict with ur... |
 | incident-capture | Capture a structured incident when the brain produces a bad outcome , bad skill output, redone task, critical 3D Diligen... |
 | index-creation-concurrently | Index Creation (CONCURRENTLY) |
-| infinite-monitor | Arma dashboards con IA sobre Infinite Monitor, app Next.js open-source donde describes el widget en lenguaje natural y u... |
+| infinite-monitor | Builds AI dashboards on Infinite Monitor, an open-source Next.js app where you describe the widget in natural language a... |
 | investigate-before-asking | Canonical mandate , before asking the operator any clarifying question, spend 30-60 seconds doing read-only investigatio... |
 | jupyter-notebook | Use when the user asks to create, scaffold, or edit Jupyter notebooks (`.ipynb`) for experiments, explorations, or tutor... |
 | knowledge-corpus | Build and query focused knowledge corpora from brain skills, git history, and workspace files. Use when users want to co... |
-| lii5 | Explica cualquier documento, concepto o arquitectura en lenguaje adulto y claro, con analogias y sin jerga. Dispara con ... |
+| lii5 | Explains any document, concept or architecture in plain adult language, with analogies and no jargon. Triggers on 'lii5'... |
 | linear | Manage issues, projects & team workflows in Linear. Use when the user wants to read, create or updates tickets in Linear... |
 | llm-system-prompt-engineering | Design, debug, and optimize LLM system prompts for production chatbots , especially smaller/medium models (7B-70B) that ... |
 | long-document-revision-protocol | Long Document Revision Protocol |
 | long-lived-negative-dns-cache | A long-running process (a cron supervisor, a daemon, a worker pool parent) caches a NEGATIVE DNS result after a transien... |
-| market-research-framework | Marco de investigacion de mercado a nivel consultoria, 12 modulos del sizing a la estrategia de entrada. Dispara con 'ma... |
-| mcp-stack-setup | Instala y configura el stack MCP de un arm respetando Arm Isolation: los MCP de nube van a scope user, los de base de da... |
-| model-routing-by-complexity | Enruta el trabajo por complejidad a traves del ladder de modelos (mechanical, bulk, build, judgment), vendor-agnostico. ... |
+| market-research-framework | Consulting-grade market research framework, 12 modules from sizing to entry strategy. Triggers on 'market research', 'TA... |
+| mcp-stack-setup | Installs and configures an arm's MCP stack while respecting Arm Isolation: cloud MCPs go to user scope, database MCPs to... |
+| model-routing-by-complexity | Routes work by complexity across the model ladder (mechanical, bulk, build, judgment), vendor-agnostic. Load when fannin... |
 | multi-object-rename-convergence | Multi-Object Rename Convergence |
 | multi-specialist-doc-audit | Audit a long technical document for hallucinations and uncited claims by dispatching N specialist agents in parallel, ea... |
 | netlify-deploy | Deploy web projects to Netlify using the Netlify CLI (`npx netlify`). Use when the user asks to deploy, host, publish, o... |
-| news-article-curation | Loop diario sobre feeds RSS de IA (Willison, OpenAI, DeepMind, arXiv cs.AI): filtra los articulos que ensenan algo que e... |
-| no-history-in-docs | Los documentos llevan solo contenido vigente; git es el control de versiones. Nunca tachado para marcar lo hecho, nunca ... |
+| news-article-curation | Daily loop over AI RSS feeds (Willison, OpenAI, DeepMind, arXiv cs.AI): filters the articles that teach something the br... |
+| no-history-in-docs | Documents carry only current content; git is the version history. Never strikethrough to mark what is done, never old te... |
 | notion-knowledge-capture | Capture conversations and decisions into structured Notion pages; use when turning chats/notes into wiki entries, how-to... |
 | notion-meeting-intelligence | Prepare meeting materials with Notion context and Codex research; use when gathering context, drafting agendas/pre-reads... |
 | notion-research-documentation | Research across Notion and synthesize into structured documentation; use when gathering info from multiple Notion source... |
 | notion-spec-to-implementation | Turn Notion specs into implementation plans, tasks, and progress tracking; use when implementing PRDs/feature specs and ... |
-| octorato-harmony | Cuando un mismo valor vale 10 en un lado y 12 en otro, converge ambos a un canonico referenciado en todas partes, nunca ... |
-| octorato-isomorphism | Los tres anclajes de Octorato (pulpo, Linux, teseracto) son una misma estructura mostrada tres veces, no tres marcas peg... |
+| octorato-harmony | When the same value reads 10 in one place and 12 in another, converge both to a canonical one referenced everywhere, nev... |
+| octorato-isomorphism | Octorato's three anchors (octopus, Linux, tesseract) are one structure shown three times, not three brands glued togethe... |
 | octorato-symbolism | The two symbolic anchors of the Octorato framework , the 8 → ∞ (lay the octopus's eight arms sideways and you get the le... |
 | openai-docs | Use when the user asks how to build with OpenAI products or APIs and needs up-to-date official documentation with citati... |
 | openstock | OpenStock is an open-source alternative to expensive market platforms. Track real-time prices, set personalized alerts, ... |
@@ -163,24 +163,24 @@
 | project-timeline-report | Generate a "Journey Into [Project]" narrative report analyzing a project's entire development history from git log, CHAN... |
 | prompt-master | Generates optimized prompts for AI tools. Activates only when the user explicitly asks to write, fix, improve, or adapt ... |
 | qa-deployment-prompts | QA Deployment Prompts |
-| querymaster | Router maestro multi-motor: recibe un prompt en lenguaje natural, identifica el motor (PostgreSQL, Snowflake, SQL Server... |
-| querymaster-adx | Skill hijo de querymaster para Azure Data Explorer. ADX usa KQL, NUNCA SQL. Conexion azure-kusto-data con SSO y buenas p... |
-| querymaster-databricks | Skill hijo de querymaster para Databricks. PLACEHOLDER: aun no hay workspace ni cluster provisionado, solo la plantilla ... |
-| querymaster-postgresql | Skill hijo de querymaster para PostgreSQL (estandar, Azure Database, Aurora): patrones de conexion psycopg2 y Node, sesi... |
-| querymaster-snowflake | Skill hijo de querymaster para Snowflake: conexion por Browser SSO, OAuth y usuario/contrasena de servicio, REST SQL API... |
-| querymaster-sqlite | Skill hijo de querymaster para SQLite: bases locales en archivo, storage de Optuna, barridos analiticos y uso embebido, ... |
-| querymaster-sqlserver | Skill hijo de querymaster para SQL Server y Azure SQL (Database, Managed Instance, on-prem): conexion pyodbc con token d... |
+| querymaster | Multi-engine master router: takes a natural-language prompt, identifies the engine (PostgreSQL, Snowflake, SQL Server, A... |
+| querymaster-adx | Child skill of querymaster for Azure Data Explorer. ADX uses KQL, NEVER SQL. azure-kusto-data connection with SSO, plus ... |
+| querymaster-databricks | Child skill of querymaster for Databricks. PLACEHOLDER: no workspace or cluster provisioned yet, only the connection tem... |
+| querymaster-postgresql | Child skill of querymaster for PostgreSQL (standard, Azure Database, Aurora): psycopg2 and Node connection patterns, rea... |
+| querymaster-snowflake | Child skill of querymaster for Snowflake: connection via Browser SSO, OAuth and service user/password, REST SQL API and ... |
+| querymaster-sqlite | Child skill of querymaster for SQLite: local file databases, Optuna storage, analytical sweeps and embedded use, with WA... |
+| querymaster-sqlserver | Child skill of querymaster for SQL Server and Azure SQL (Database, Managed Instance, on-prem): pyodbc connection with an... |
 | range-partitioning-growth-tables | Range Partitioning for Growth Tables |
 | reflexes-over-discipline | When a rule or gate is chronically ignored, when designing enforcement for a new policy, or when the operator says a rul... |
 | render-deploy | Deploy applications to Render by analyzing codebases, generating render.yaml Blueprints, and providing Dashboard deeplin... |
-| repo-deep-learn | Analisis profundo de UN repo de GitHub: inventaria el codigo, extrae patrones que podrian volverse skill y escribe repor... |
-| repo-watch | Monitor diario de una watchlist de repos de GitHub: compara el HEAD SHA contra el snapshot previo y escribe un digest en... |
-| repomix-codebase-packer | Empaqueta un repo completo, local o remoto, en un solo archivo optimizado para LLM, con compresion Tree-sitter (~70% men... |
+| repo-deep-learn | Deep analysis of ONE GitHub repo: inventories the code, extracts patterns that could become a skill and writes a report ... |
+| repo-watch | Daily monitor over a watchlist of GitHub repos: compares the HEAD SHA against the previous snapshot and writes a digest ... |
+| repomix-codebase-packer | Packs a whole repo, local or remote, into a single LLM-optimized file, with Tree-sitter compression (~70% fewer tokens) ... |
 | research-checklist-discipline | Research Checklist Discipline |
 | runtime-adaptation-over-source-edit | Decision rule for WHERE a new behavior or lesson belongs , the runtime layer (skill / memory / config / hook) vs the cor... |
 | sandbox-sdk | Build sandboxed applications for secure code execution. Load when building AI code execution, code interpreters, CI/CD s... |
-| save-transcript | Rescata el transcript COMPLETO de una grabacion de reunion (Microsoft Stream, SharePoint) a partir de su URL, y entrega ... |
-| schema-as-code-three-layer-sync | Mantiene sincronizadas las tres capas de un proyecto schema-as-code: diagrama ER, diccionario de datos y el SQL declarat... |
+| save-transcript | Recovers the COMPLETE transcript of a meeting recording (Microsoft Stream, SharePoint) from its URL, and delivers a clea... |
+| schema-as-code-three-layer-sync | Keeps the three layers of a schema-as-code project in sync: ER diagram, data dictionary and the declarative SQL. Defines... |
 | schema-row-counts | Get exact row counts per table in a given schema , PostgreSQL primary, with notes for other engines. Two-column result: ... |
 | schema-separation-orm-control | Schema Separation for ORM/Scaffolding Control |
 | screenshot | Use when the user explicitly asks for a desktop or system screenshot (full screen, specific app or window, or a pixel re... |
@@ -193,59 +193,59 @@
 | sdd-review | SDD: Code Review |
 | sdd-yolo | SDD: YOLO Full Pipeline |
 | security-best-practices | Perform language and framework specific security best-practice reviews and suggest improvements. Trigger only when the u... |
-| security-ownership-map | Topologia de propiedad de codigo orientada a seguridad desde el historial de git: bus factor, duenos de codigo sensible,... |
+| security-ownership-map | Security-oriented code ownership topology from git history: bus factor, owners of sensitive code, orphans, CSV/JSON expo... |
 | security-roles-least-privilege | Security Roles & Least-Privilege Grants |
 | security-threat-model | Repository-grounded threat modeling that enumerates trust boundaries, assets, attacker capabilities, abuse paths, and mi... |
 | sentinel-blocks-rerun | Diagnose daily-idempotent endpoints that silently no-op because an earlier same-day run set a 'already-done' sentinel |
 | sentry | Use when the user asks to inspect Sentry issues or events, summarize recent production errors, or pull basic Sentry heal... |
 | serial-to-identity-conversion | Serial to Identity Column Conversion |
-| session-isolation | OBLIGATORIO: cada sesion concurrente sobre un repo necesita su propio git worktree y session id. NUNCA dos sesiones viva... |
-| session-learn-extractor | Extrae el patron reusable de la sesion y lo escribe como skill BORRADOR en skills/learned/. Dispara tras 'ya quedo', 'fi... |
+| session-isolation | MANDATORY: every concurrent session on a repo needs its own git worktree and session id. NEVER two live sessions on the ... |
+| session-learn-extractor | Extracts the reusable pattern from the session and writes it as a DRAFT skill in skills/learned/. Triggers after 'ya que... |
 | session-memory-search | Search past work across sessions using native tools (git log, grep, Lessons Learned). Use when user asks "did we already... |
 | skill-creator | Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an exist... |
 | skill-installer | Install Codex skills into $CODEX_HOME/skills from a curated list or a GitHub repo path. Use when a user asks to list ins... |
-| skillsmp | Busca, descubre e instala agent skills desde skillsmp.com, la coleccion abierta mas grande de archivos SKILL.md. Dispara... |
+| skillsmp | Searches, discovers and installs agent skills from skillsmp.com, the largest open collection of SKILL.md files. Triggers... |
 | slides | Create and edit presentation slide decks (`.pptx`) with PptxGenJS, bundled layout helpers, and render/validation utiliti... |
-| snowflake-dbt-pitfalls | Trampas de Snowflake y dbt que fallan en silencio o destruyen datos: CREATE OR REPLACE, Dynamic Tables, PIVOT, freshness... |
-| social-video-mining | Extrae insights de video corto (TikTok, Shorts, Reels, Douyin) sin speech-to-text de paga: yt-dlp, ffmpeg y vision sobre... |
+| snowflake-dbt-pitfalls | Snowflake and dbt traps that fail silently or destroy data: CREATE OR REPLACE, Dynamic Tables, PIVOT, sources.yml freshn... |
+| social-video-mining | Extracts insights from short video (TikTok, Shorts, Reels, Douyin) without paid speech-to-text: yt-dlp, ffmpeg and visio... |
 | sops-age-git-encryption | SOPS + age (per-user keys) as the default encryption stack for HIPAA / GDPR / SOC-2 / regulated-data git repos. Two-laye... |
-| sora | Genera, edita, extiende, lista o descarga videos de Sora, crea referencias de personaje y corre colas locales con script... |
+| sora | Generates, edits, extends, lists or downloads Sora videos, creates character references and runs local queues with scrip... |
 | source-citation-tagging | Tag taxonomy for mixed-source technical documents , every factual claim must carry a source marker. Defends against hall... |
-| spacetimedb-backend-as-database | Base de datos que REEMPLAZA al backend: la logica corre como modulos dentro de la DB y los clientes se suscriben al esta... |
+| spacetimedb-backend-as-database | A database that REPLACES the backend: logic runs as modules inside the DB and clients subscribe to live state, with no A... |
 | speech | Use when the user asks for text-to-speech narration or voiceover, accessibility reads, audio prompts, or batch speech ge... |
 | spreadsheet | Use when tasks involve creating, editing, analyzing, or formatting spreadsheets (`.xlsx`, `.csv`, `.tsv`) with formula-a... |
 | stacked-pr-squash-delete-gotcha | Recover from and prevent stacked-PR breakage caused by squash-merge + auto-delete-branch on the base PR. Use when workin... |
 | status-marker-hygiene | Status Marker Hygiene |
 | stored-procedure-logic-hardening | Stored Procedure Logic Hardening |
-| stream-transcript-dom-scrape | Cuando una grabacion de Microsoft Stream es de solo lectura y la descarga del transcript dice 'sin permiso', el reproduc... |
-| stripe-payments | Elige e implementa el tier correcto de Stripe (Payment Link, Checkout, Elements, Connect, Billing), con registro del MCP... |
+| stream-transcript-dom-scrape | When a Microsoft Stream recording is read-only and the transcript download says 'no permission', the player still render... |
+| stripe-payments | Pick and implement the right Stripe tier (Payment Link, Checkout, Elements, Connect, Billing), with MCP registration, lo... |
 | structural-completeness-verification | Structural Completeness Verification |
 | submission-checklist-gate | Before sending a reply to a formal requirement (bank, government agency, any institution), build an explicit checklist o... |
-| summarize-100 | Comprime cualquier tema, documento o respuesta a ~100 palabras, las mas densas semanticamente. Dispara con '100 palabras... |
+| summarize-100 | Compresses any topic, document or answer to ~100 words, the most semantically dense ones. Triggers on '100 palabras', 'v... |
 | svelte-tailwind-gotchas | Known gotchas and workarounds when combining Svelte (4/5) with Tailwind CSS. Use when Svelte template compilation fails ... |
 | table-normalization-1nf | Table Normalization (1NF Violations) |
-| tabularis-db-client | Cliente SQL open-source para PostgreSQL, MySQL y SQLite con servidor MCP integrado, Apache 2.0. Para recomendar un GUI d... |
-| teams-1on1-send-no-chat-read | Manda un mensaje 1:1 de Teams por Graph API aunque el token NO traiga scopes Chat.Read: deriva el chat ID de los OIDs or... |
+| tabularis-db-client | Open-source SQL client for PostgreSQL, MySQL and SQLite with a built-in MCP server, Apache 2.0. To recommend a database ... |
+| teams-1on1-send-no-chat-read | Sends a Teams 1:1 message through the Graph API even when the token does NOT carry Chat.Read scopes: derives the chat ID... |
 | technical-document-craftsmanship | Skill #37 , Technical Document Craftsmanship |
-| theory-plus-practice-prompts | Todo documento tecnico largo que explica un marco y demuestra un caso DEBE llevar prompts ejecutables con datos reales j... |
+| theory-plus-practice-prompts | Any long technical document that explains a framework and demonstrates a case MUST carry runnable prompts with real data... |
 | timestamptz-standardization | Timestamp Standardization (timestamptz) |
 | toc-audit-commit-push | TOC Audit, Commit & Push Workflow |
-| token-efficient-prompting | Reduce 50-75% los tokens de salida sin perder senal, eliminando adulacion, relleno, preambulo y sugerencias no pedidas. ... |
+| token-efficient-prompting | Cuts output tokens by 50-75% without losing signal, removing flattery, filler, preamble and unrequested suggestions. Tri... |
 | tos-safe-social-share-helper | Architectural pattern for cases where a client wants to "auto-publish to social platform X" but the platform's ToS forbi... |
-| tramite-mx-assistant | Asistente de tramites gubernamentales MX: maneja el portal con agent-browser, se DETIENE en captcha, OTP y pago con tarj... |
+| tramite-mx-assistant | Assistant for MX government procedures: drives the portal with agent-browser, STOPS at captcha, OTP and card payment, an... |
 | transcribe | Transcribe audio files to text with optional diarization and known-speaker hints. Use when a user asks to transcribe spe... |
 | tsql-to-plpgsql-conversion | AI-Assisted T-SQL to PL/pgSQL Stored Procedure Conversion |
 | unicode-symbol-compatibility | Unicode Symbol Compatibility in Markdown Documents |
 | vercel-deploy | Deploy applications and websites to Vercel. Use when the user requests deployment actions like "deploy my app", "deploy ... |
-| verify-generated-config-identifiers | Config generada schema-valida no es semanticamente correcta: verifica cada identificador externo (metrica, campo, column... |
-| verify-root-cause-before-claiming | Antes de decirle a alguien la CAUSA de una falla, verificala contra el dato, no contra el sintoma. Una causa plausible s... |
-| vibevoice-elevenlabs-alternative | Modelo open-source de sintesis de voz de Microsoft, local y en tiempo real, sustituto de ElevenLabs. MIT. Para clientes ... |
-| video-commercial-production | Produce comerciales en video HD 9:16 desde paginas HTML animadas con GSAP, capturando con Playwright y codificando con f... |
+| verify-generated-config-identifiers | Schema-valid generated config is not semantically correct: check every external identifier (metric, field, column, env k... |
+| verify-root-cause-before-claiming | Before telling anyone the CAUSE of a failure, verify it against the data, not against the symptom. A plausible unverifie... |
+| vibevoice-elevenlabs-alternative | Microsoft open-source speech synthesis model, local and real-time, a stand-in for ElevenLabs. MIT. For clients that cann... |
+| video-commercial-production | Produces HD 9:16 video commercials from GSAP-animated HTML pages, capturing with Playwright and encoding with ffmpeg. Ou... |
 | voice-and-cadence-consistency | Document Voice and Cadence Consistency |
-| wa-guardia | Modo guardia sobre un chat de mensajeria. Arma un watcher cuando un turno cierra esperando respuesta de un tercero, y le... |
-| web-perf | Audita rendimiento web con Chrome DevTools MCP: Core Web Vitals (LCP, INP, CLS), recursos que bloquean el render, cadena... |
+| wa-guardia | Watch mode over a messaging chat. Arms a watcher when a turn closes waiting on a reply from a third party, and reads wha... |
+| web-perf | Audits web performance with the Chrome DevTools MCP: Core Web Vitals (LCP, INP, CLS), render-blocking resources, network... |
 | whatsapp-mcp-bridge-gotchas | Fixes for the lharries/whatsapp-mcp bridge: 403 media download, 405 client-outdated, QR vs phone-code pairing, encrypt-a... |
-| windows-brain-script-portability | Scripts de ~/.claude/scripts/ que corren en un cerebro Windows: usa el shim python3.cmd y no python3 pelado, y reconfigu... |
+| windows-brain-script-portability | Scripts in ~/.claude/scripts/ that run on a Windows brain: use the python3.cmd shim and not bare python3, and reconfigur... |
 | winui-app | Crea, desarrolla y disena apps de escritorio WinUI 3 con C# y Windows App SDK segun guia oficial de Microsoft y Communit... |
 | workers-best-practices | Reviews and authors Cloudflare Workers code against production best practices. Load when writing new Workers, reviewing ... |
 | workspace-skill-discovery | Discover and include ALL skills across the workspace , not just global ones. Use at the start of every session or when t... |
@@ -531,7 +531,7 @@
 | connectome-heartbeat.py | connectome-heartbeat.py , the Delegate-phase heartbeat (UserPromptSubmit hook). | wired |
 | cost-vs-change.py | cost-vs-change.py , "is the new thing making me cheaper or more expensive?" Correlates the daily Cla... | wired |
 | d__posttool__delegation-ledger.py | d__posttool__delegation-ledger.py: PostToolUse detector (matcher *) for FLOW.bulk-fetch-delegation. | wired |
-| d__stop__wa-guardia.py | d__stop__wa-guardia.py , Stop detector: si mande un mensaje y espero respuesta, arma la guardia. | wired |
+| d__stop__wa-guardia.py | d__stop__wa-guardia.py: Stop detector: if I sent a message and I am waiting on a reply, arm the watc... | wired |
 | delegate-check | delegate-check , Mandatory 2D Delegate pre-flight for the Octopus brain. Scans REGISTRY.md (agents) ... | wired |
 | delegate-gate.py | PreToolUse hook , involuntary delegation reflex (FAIL-OPEN, by design). | wired |
 | dimension-awareness-hook.py | dimension-awareness-hook.py , PreToolUse hook for 4D session dimension awareness | wired |
@@ -541,12 +541,12 @@
 | g__pretool-bash__prod-write.py | PreToolUse Bash hook , compuerta de ESCRITURA EN PRODUCCION (FAIL-CLOSED). | wired |
 | g__pretool-mcp__chat-context.py | g__pretool-mcp__chat-context.py: PreToolUse gate for COMMS.chat-context-before-send. | wired |
 | g__pretool-mcp__outward-send.py | g__pretool-mcp__outward-send.py: the ONE outward-send gate (v7 phase 2). | wired |
-| g__stop__defer-today.py | g__stop__defer-today.py , Stop gate: no dejes para mañana lo que puedas hacer hoy. | wired |
+| g__stop__defer-today.py | g__stop__defer-today.py: Stop gate: "no dejes para mañana lo que puedas hacer hoy" (do not put off u... | wired |
 | g__stop__delegation-audit.py | g__stop__delegation-audit.py: Stop gate for FLOW.bulk-fetch-delegation. | wired |
 | g__stop__draft-promise.py | g__stop__draft-promise.py , Stop gate: no future-tense promises in paste-ready drafts. | wired |
-| g__stop__goal-anchor.py | g__stop__goal-anchor.py , Stop gate: la pila de objetivos no se erosiona. | wired |
-| g__stop__paste-ready-raw.py | g__stop__paste-ready-raw.py , Stop gate: un mensaje para pegar se entrega CRUDO y AL FINAL. | wired |
-| g__stop__unsourced-absence.py | g__stop__unsourced-absence.py , Stop gate: no "this has no origin" claim ships | wired |
+| g__stop__goal-anchor.py | g__stop__goal-anchor.py: Stop gate: the goal stack does not erode. | wired |
+| g__stop__paste-ready-raw.py | g__stop__paste-ready-raw.py: Stop gate: a message meant for pasting ships RAW and LAST. | wired |
+| g__stop__unsourced-absence.py | g__stop__unsourced-absence.py: Stop gate: no "this has no origin" claim ships | wired |
 | g__stop__unsourced-attribute.py | g__stop__unsourced-attribute.py , Stop gate: no unsourced classifying attribute | wired |
 | gap-capture.py | gap-capture.py , capture 2D-Delegate SELF misses as a gap backlog. When the delegate gate finds no a... | wired |
 | gate-check | gate-check , 4D Gate Enforcement Validator for the Octopus brain. Validates that the 4D paradigm pha... | wired |
@@ -567,7 +567,7 @@
 | install-observability-timer.py | install-observability-timer.py - schedule the brain's daily observability digest. | wired |
 | install-runners.py | install-runners.py , make ~/.local/bin runners thin thunks into the tracked ai_sync.py. | wired |
 | lineage-doctor.py | lineage-doctor.py , fail-closed integrity check for the surface/derivation graph. | wired |
-| mail-guardia.py | Guardia de correo: que llego y no hemos contestado. Hermana de wa-guardia.py. | wired |
+| mail-guardia.py | Mail watch: what arrived and we have not answered. Sibling of wa-guardia.py. | wired |
 | memory_lexicon_es_en.json |  | orphan |
 | memory_sync.py | memory_sync , sync the brain's private memory store to a standalone remote. | wired |
 | merge-hooks-cursor.py | merge-hooks-cursor.py , project hooks.json into Cursor's native ~/.cursor/hooks.json. | wired |
@@ -599,10 +599,10 @@
 | trace-hook.py | trace-hook.py , observability surface 1 , capture hook. Reads a Claude Code hook event from stdin an... | wired |
 | update_neural_activity.py | update_neural_activity.py , observability surface 1 , connectome integration. Reads the JSONL trace ... | wired |
 | validate-skill-manifest.py | validate-skill-manifest.py , validate a skill.json against the M5 manifest schema (issue #31). | wired |
-| wa-guardia.py | Guardia de chat: que llego y no hemos contestado, aqui y ahora. | wired |
-| wa-latido.py | Latido activo de puentes de WhatsApp: mide la TUBERIA, no el proceso. | wired |
-| wa-sin-respuesta.py | Vigia de silencio: avisa cuando un cliente escribio y nadie contesto. | wired |
-| wa-soporte.sh | Envia un WhatsApp por el canal de SOPORTE, no por el numero personal del operador. | wired |
+| wa-guardia.py | Chat watch: what arrived and we have not answered, here and now. | wired |
+| wa-latido.py | Active heartbeat for WhatsApp bridges: it measures the PIPE, not the process. | wired |
+| wa-sin-respuesta.py | Silence sentry: alerts when a client wrote and nobody answered. | wired |
+| wa-soporte.sh | Sends a WhatsApp through the SUPPORT channel, never through the operator's personal number. | wired |
 | watchdog.py | watchdog.py , observability surface 4 anomaly detector. Reads the JSONL trace files written by trace... | wired |
 
 ## Rules (72)

--- a/scripts/d__stop__wa-guardia.py
+++ b/scripts/d__stop__wa-guardia.py
@@ -1,36 +1,38 @@
 #!/usr/bin/env python3
-"""d__stop__wa-guardia.py — Stop detector: si mande un mensaje y espero respuesta, arma la guardia.
+"""d__stop__wa-guardia.py: Stop detector: if I sent a message and I am waiting on a reply, arm the watch.
 
-Directiva del operador (2026-08-04): "el hook que arme la guardia solo". Los
-watchers le sirven, pero "a veces entran y a veces no" porque hasta ahora
-dependian de que el modelo se acordara de armarlos, y una regla que depende de
-la memoria del modelo se salta bajo carga (skills/reflexes-over-discipline).
-Su propia acotacion fija el alcance: "al menos cuando esperemos algo, si no pues
-no". Un watcher sin espera es ruido que entrena a ignorar avisos.
+Operator directive (2026-08-04): "el hook que arme la guardia solo" (the hook
+should arm the watch by itself). The watchers are useful to him, but "a veces
+entran y a veces no" (sometimes they fire and sometimes they do not) because so
+far they depended on the model remembering to arm them, and a rule that depends
+on the model memory gets skipped under load (skills/reflexes-over-discipline).
+His own qualifier sets the scope: "al menos cuando esperemos algo, si no pues
+no" (at least when we are waiting on something, otherwise no). A watcher with
+nothing to wait for is noise that trains you to ignore alerts.
 
-La condicion NO es mi intencion, es un hecho verificable en el store del puente:
-mande un mensaje saliente hace poco a un chat y no hay guardia viva para ese
-chat. La evidencia es el mensaje enviado, no lo que yo crea haber hecho.
+The condition is NOT my intent, it is a verifiable fact in the bridge store: I
+sent an outbound message to a chat recently and there is no live watch for that
+chat. The evidence is the sent message, not what I believe I did.
 
-Dispara sobre la CONJUNCION de:
-  1. hay >=1 mensaje saliente en los ultimos VENTANA_MIN minutos, en cualquiera
-     de los dos puentes,
-  2. ese chat no tiene un proceso `wa-guardia.py ... --vigilar` corriendo,
-  3. no se aviso ya por ese chat en esta sesion.
+Fires on the CONJUNCTION of:
+  1. there is >=1 outbound message in the last VENTANA_MIN minutes, on either
+     of the two bridges,
+  2. that chat has no `wa-guardia.py ... --vigilar` process running,
+  3. no alert was raised for that chat in this session already.
 
-Sobre un acierto BLOQUEA una vez con el comando exacto, para que el modelo arme
-el Monitor antes de cerrar el turno.
+On a hit it BLOCKS once with the exact command, so the model arms the Monitor
+before closing the turn.
 
-Que NO cuenta como espera:
-  - los latidos de salud del puente (contenido "latido-...")
-  - mensajes al propio numero del puente (auto-envios de diagnostico)
+What does NOT count as waiting:
+  - bridge health heartbeats (content "latido-...")
+  - messages to the bridge own number (diagnostic self-sends)
 
-Loop safety: stop_hook_active=true significa que ya bloqueamos este turno, pasa.
-Fail-open en todo error: un detector roto jamas debe secuestrar la conversacion.
+Loop safety: stop_hook_active=true means we already blocked this turn, pass.
+Fail-open on every error: a broken detector must never hijack the conversation.
 
 Stdin:  {"transcript_path": str, "stop_hook_active": bool, "session_id": str, ...}
-Stdout: {"decision": "block", "reason": "..."} sobre un acierto, si no nada.
-Exit:   siempre 0.
+Stdout: {"decision": "block", "reason": "..."} on a hit, else nothing.
+Exit:   always 0.
 """
 from __future__ import annotations
 

--- a/scripts/g__stop__defer-today.py
+++ b/scripts/g__stop__defer-today.py
@@ -1,46 +1,45 @@
 #!/usr/bin/env python3
-"""g__stop__defer-today.py — Stop gate: no dejes para mañana lo que puedas hacer hoy.
+"""g__stop__defer-today.py: Stop gate: "no dejes para mañana lo que puedas hacer hoy" (do not put off until tomorrow what you can do today).
 
-Directiva del operador, repetida hasta el hartazgo y elevada a canónica el
-18-ago-2026: *"NO DEJES PARA MAÑANA LO QUE PUEDAS HACER HOY, canónico. Todos los
-días te lo tengo que recordar, ya cablealo de una vez en octorato."* Que haya que
-recordarlo a diario es la prueba de que la prosa no basta: un rezago que depende
-de que el modelo se acuerde se salta bajo carga. Esto es la regla
-`reflexes-over-discipline` aplicada al aplazamiento.
+Operator directive, repeated to exhaustion and raised to canonical on
+2026-08-18: *"NO DEJES PARA MAÑANA LO QUE PUEDAS HACER HOY, canónico. Todos los
+días te lo tengo que recordar, ya cablealo de una vez en octorato."* Having to
+be reminded daily is the proof that prose is not enough: a backlog that depends
+on the model remembering gets skipped under load. This is the
+`reflexes-over-discipline` rule applied to deferral.
 
-La forma sutil del aplazamiento no es decir "no lo hago". Es REPORTAR un pendiente
-que yo mismo podía ejecutar, y dejárselo al operador en la bandeja. Por eso el
-gate no busca pereza declarada, busca la frase de cierre que empuja trabajo mío
-hacia adelante.
+The subtle form of deferral is not saying "I will not do it". It is REPORTING a
+pending item I could have executed myself, and leaving it in the operator inbox.
+So the gate does not look for declared laziness, it looks for the closing
+sentence that pushes my own work forward in time.
 
-CUÁNDO DISPARA. En la última respuesta del asistente, cuando aparece un marcador
-de aplazamiento en PRIMERA PERSONA sobre trabajo propio ("lo dejo para mañana",
-"queda pendiente", "lo retomo la próxima sesión") y NO hay ninguna de las dos
-salidas legítimas:
+WHEN IT FIRES. In the last assistant response, when a deferral marker shows up
+in FIRST PERSON about my own work ("lo dejo para mañana", "queda pendiente", "lo
+retomo la próxima sesión") and NEITHER of the two legitimate exits is present:
 
-  1. El pendiente es del operador y viaja con su acción exacta: un bloque de
-     comando o una línea que empieza con "! ". Un paso irreducible suyo (un clic
-     de consentimiento, una contraseña, un permiso) es un pendiente válido, y
-     entregado así no le cuesta trabajo: le cuesta pegar.
-  2. La línea nombra el bloqueo real y verificado (el clasificador lo negó, la
-     regla del repositorio lo rechazó, requiere su decisión). Un bloqueo medido
-     no es un aplazamiento.
+  1. The pending item is the operator own and travels with his exact action: a
+     command block or a line starting with "! ". An irreducible step of his (a
+     consent click, a password, a permission) is a valid pending item, and
+     delivered that way it costs him no work: it costs him a paste.
+  2. The line names the real, verified blocker (the classifier denied it, the
+     repository rule rejected it, it needs his decision). A measured blocker is
+     not a deferral.
 
-Un "mañana" que no habla de trabajo mío no cuenta: citar a la clienta diciendo
-"espero mañana me puedas contestar", o informar que una oficina abre mañana, son
-hechos, no rezagos. Por eso se exige un verbo de aplazamiento en primera persona
-cerca del marcador y se descartan los tramos entrecomillados.
+A "tomorrow" that is not about my work does not count: quoting the client saying
+"espero mañana me puedas contestar", or reporting that an office opens tomorrow,
+are facts, not backlog. That is why a first-person deferral verb is required
+near the marker and quoted spans are discarded.
 
-Bloquea UNA vez (stop_hook_active), como sus hermanos. Obliga a VER, no a
-obedecer: si de verdad no se puede hoy, la segunda pasada sigue.
+Blocks ONCE (stop_hook_active), like its siblings. It forces you to SEE, not to
+obey: if it really cannot be done today, the second pass goes through.
 
-FALLA ABIERTO. Cualquier error sale con 0 y en silencio.
+FAILS OPEN. Any error exits 0 and silently.
 
-Escape deliberado: poner `defer-ok` en la línea.
+Deliberate escape: put `defer-ok` on the line.
 
 Stdin:  {"transcript_path": str, "stop_hook_active": bool, ...}
-Stdout: {"decision": "block", "reason": "..."} si pega, si no nada.
-Exit:   siempre 0.
+Stdout: {"decision": "block", "reason": "..."} on a hit, else nothing.
+Exit:   always 0.
 """
 from __future__ import annotations
 

--- a/scripts/g__stop__goal-anchor.py
+++ b/scripts/g__stop__goal-anchor.py
@@ -1,40 +1,41 @@
 #!/usr/bin/env python3
-"""g__stop__goal-anchor.py — Stop gate: la pila de objetivos no se erosiona.
+"""g__stop__goal-anchor.py: Stop gate: the goal stack does not erode.
 
-Problema que resuelve: tras encadenar obstaculos (un permiso, una region
-apagada, un binario que falta), el agente cierra el sub-objetivo con evidencia
-legitima y reporta victoria. El objetivo RAIZ de la sesion lleva turnos sin
-mencionarse. El contexto reescribe `intent` en cada obstaculo, asi que la raiz
-se pierde sin que nadie lo note. Ningun otro mecanismo del cerebro la persiste
-entre turnos.
+The problem it solves: after chaining obstacles (a permission, a disabled
+region, a missing binary), the agent closes the sub-goal with legitimate
+evidence and reports victory. The ROOT goal of the session has gone unmentioned
+for turns. Context rewrites `intent` at every obstacle, so the root is lost
+without anyone noticing. No other mechanism in the brain persists it across
+turns.
 
-Este gate la persiste en disco y bloquea UNA vez cuando el agente declara
-cierre habiendo perdido de vista la raiz.
+This gate persists it to disk and blocks ONCE when the agent declares closure
+having lost sight of the root.
 
-Ciclo por turno (todo dentro del mismo Stop; el payload trae transcript_path):
-  1. Lee del transcript el ultimo mensaje del operador y el ultimo del asistente.
-  2. Ancla. Sin estado previo: el prompt del operador, cortado a 240 chars.
-     Re-ancla SOLO con marcador determinista (prefijo `objetivo:` / `goal:`,
-     frase de pivote, o un ancla ya cerrada mas prompt nuevo). Fuera de eso el
-     ancla es pegajosa toda la sesion: "no me deja entrar" o "sale AccessDenied"
-     son reacciones del operador al obstaculo, NO objetivos nuevos.
-  3. Mencion. Saca palabras de contenido del ancla y las busca en la respuesta.
-     Dos distintas bastan: turns_since_mention vuelve a 0.
-  4. Dispara solo con la conjuncion completa (ver _should_fire).
-  5. Gobernador: techo duro de 2 interrupciones por ancla; en la segunda el
-     ancla se cierra sola y el gate no vuelve a hablar de ella.
+Per-turn cycle (all inside the same Stop; the payload carries transcript_path):
+  1. Read the last operator message and the last assistant message from the
+     transcript.
+  2. Anchor. With no prior state: the operator prompt, cut to 240 chars.
+     Re-anchors ONLY on a deterministic marker (prefix `objetivo:` / `goal:`, a
+     pivot phrase, or an already-closed anchor plus a new prompt). Outside that
+     the anchor is sticky for the whole session: "no me deja entrar" or "sale
+     AccessDenied" are the operator reacting to the obstacle, NOT new goals.
+  3. Mention. Pull content words out of the anchor and look for them in the
+     response. Two distinct ones are enough: turns_since_mention returns to 0.
+  4. Fires only on the full conjunction (see _should_fire).
+  5. Governor: hard ceiling of 2 interruptions per anchor; on the second one the
+     anchor closes itself and the gate stops talking about it.
 
-Conservador por construccion: cualquier duda pasa. Un falso positivo aqui
-interrumpe trabajo real; un falso negativo solo deja pasar un turno.
+Conservative by construction: any doubt passes. A false positive here interrupts
+real work; a false negative only lets one turn through.
 
-Estado: ~/.claude/.cache/goal-anchor/<session_id>.json
+State: ~/.claude/.cache/goal-anchor/<session_id>.json
 
-Escape deliberado: cualquier linea de la respuesta con `goal-anchor-ok` exime
-el turno.
+Deliberate escape: any line of the response carrying `goal-anchor-ok` exempts
+the turn.
 
 Stdin:  {"session_id": str, "transcript_path": str, "stop_hook_active": bool}
-Stdout: {"decision": "block", "reason": "..."} al disparar, si no nada.
-Exit:   siempre 0.
+Stdout: {"decision": "block", "reason": "..."} on a hit, else nothing.
+Exit:   always 0.
 """
 from __future__ import annotations
 

--- a/scripts/g__stop__paste-ready-raw.py
+++ b/scripts/g__stop__paste-ready-raw.py
@@ -1,58 +1,58 @@
 #!/usr/bin/env python3
-"""g__stop__paste-ready-raw.py — Stop gate: un mensaje para pegar se entrega CRUDO y AL FINAL.
+"""g__stop__paste-ready-raw.py: Stop gate: a message meant for pasting ships RAW and LAST.
 
-Problema que resuelve (queja diaria del operador, 2026-08-05 y 2026-08-11:
-"todos los dias te repito esto una y otra vez"): pide un mensaje para pegar en
-Teams o WhatsApp y la respuesta se lo envuelve en blockquote, le mete negritas y
-encabezados, o le cuelga el footer de procedencia detras. El operador tiene que
-limpiarlo a mano ANTES de pegarlo, dentro de una ventana con cliente. Cada dia.
-La regla lleva escrita meses en memoria y aun asi se incumple, asi que deja de
-ser disciplina y pasa a ser ganglio: un hook que dispara solo.
+The problem it solves (daily operator complaint, 2026-08-05 and 2026-08-11:
+"todos los dias te repito esto una y otra vez"): he asks for a message to paste
+into Teams or WhatsApp and the response wraps it in a blockquote, adds bold and
+headings, or hangs the provenance footer behind it. The operator has to clean it
+by hand BEFORE pasting, inside a window with a client. Every day. The rule has
+been written in memory for months and is still broken, so it stops being
+discipline and becomes a ganglion: a hook that fires on its own.
 
-El entregable ES el mensaje. Tres formas de romperlo, las tres se detectan aqui:
+The deliverable IS the message. Three ways to break it, all three detected here:
 
-  1. BLOCKQUOTE: el mensaje va con `>` al inicio de cada linea. El operador
-     borra los `>` uno por uno antes de pegar.
-  2. MARKDOWN DENTRO: negritas, encabezados, vinetas de asterisco, enlaces
-     `[x](y)`. Se pegan literales en el chat del cliente.
-  3. TEXTO DESPUES: cualquier linea detras del bloque contamina la seleccion.
-     El footer de procedencia va ANTES del bloque, nunca despues.
+  1. BLOCKQUOTE: the message ships with `>` at the start of every line. The
+     operator deletes the `>` one by one before pasting.
+  2. MARKDOWN INSIDE: bold, headings, asterisk bullets, `[x](y)` links. They
+     paste literally into the client chat.
+  3. TEXT AFTER: any line behind the block contaminates the selection. The
+     provenance footer goes BEFORE the block, never after.
 
-Dispara solo con la CONJUNCION de dos condiciones:
-  A. el ultimo prompt del operador pedia un mensaje para pegar
-     ("pasame el mensaje", "sin formato", "para pegar", "paste-ready", ...), y
-  B. la respuesta incumple alguno de los tres puntos.
+Fires only on the CONJUNCTION of two conditions:
+  A. the last operator prompt asked for a message to paste
+     ("pasame el mensaje", "sin formato", "para pegar", "paste-ready", ...), and
+  B. the response breaks one of the three points.
 
-Sin la condicion A no hay entregable que proteger, asi que no se mira siquiera.
+Without condition A there is no deliverable to protect, so it does not even look.
 
-Falsos positivos evitados a proposito (un gate que grita de mas se ignora, y
-ese es justo el fallo que este cerebro persigue):
-  - Citar el mensaje ENTRANTE de un tercero con `>` es legitimo. Si la
-    respuesta ya trae un bloque cercado, ese bloque es el entregable y todo `>`
-    de afuera es contexto: no dispara.
-  - Un lead-in de cita ("el te escribio:", "su mensaje dice:") marca el
-    blockquote como entrante: no dispara.
-  - Un `>` dentro de un bloque de codigo no cuenta (las cercas se recortan
-    antes de mirar).
-  - Una respuesta de analisis que habla de un mensaje sin entregarlo no tiene
-    ni bloque ni blockquote largo: no dispara.
-  - Un bloque cercado CON etiqueta de lenguaje (```bash) es codigo, no el
-    mensaje: las reglas 2 y 3 no lo tocan.
-  - Vinetas con guion (`- item`) NO se marcan: en texto plano son legibles y
-    marcarlas seria gritar de mas. Solo `*` y `+`, que son markdown puro.
+False positives avoided on purpose (a gate that shouts too much gets ignored,
+and that is exactly the failure this brain chases):
+  - Quoting the INCOMING message of a third party with `>` is legitimate. If the
+    response already carries a fenced block, that block is the deliverable and
+    every `>` outside it is context: no fire.
+  - A quote lead-in ("el te escribio:", "su mensaje dice:") marks the
+    blockquote as incoming: no fire.
+  - A `>` inside a code block does not count (fences are stripped before
+    looking).
+  - An analysis response that talks about a message without delivering it has
+    neither a block nor a long blockquote: no fire.
+  - A fenced block WITH a language tag (```bash) is code, not the message:
+    rules 2 and 3 leave it alone.
+  - Dash bullets (`- item`) are NOT flagged: in plain text they read fine and
+    flagging them would be shouting. Only `*` and `+`, which are pure markdown.
 
-Ante la duda, PASA. Un falso negativo cuesta un turno; un falso positivo
-ensena a ignorar el gate y mata todos los demas.
+When in doubt, PASS. A false negative costs a turn; a false positive teaches
+people to ignore the gate and kills all the others.
 
-Escape deliberado: cualquier linea de la respuesta con `paste-raw-ok` exime el
-turno, al estilo de `draft-promise-ok` y `goal-anchor-ok`.
+Deliberate escape: any line of the response carrying `paste-raw-ok` exempts the
+turn, in the style of `draft-promise-ok` and `goal-anchor-ok`.
 
-Loop safety: stop_hook_active=true significa que ya bloqueamos este turno, se
-pasa. Fail-open en todo error: un linter roto jamas secuestra la conversacion.
+Loop safety: stop_hook_active=true means we already blocked this turn, pass.
+Fail-open on every error: a broken linter never hijacks the conversation.
 
 Stdin:  {"transcript_path": str, "stop_hook_active": bool, ...}
-Stdout: {"decision": "block", "reason": "..."} al disparar, si no nada.
-Exit:   siempre 0.
+Stdout: {"decision": "block", "reason": "..."} on a hit, else nothing.
+Exit:   always 0.
 """
 from __future__ import annotations
 

--- a/scripts/g__stop__unsourced-absence.py
+++ b/scripts/g__stop__unsourced-absence.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""g__stop__unsourced-absence.py — Stop gate: no "this has no origin" claim ships
+"""g__stop__unsourced-absence.py: Stop gate: no "this has no origin" claim ships
 outward without a seek receipt in the same turn.
 
 THE FAILURE THIS EXISTS FOR

--- a/scripts/mail-guardia.py
+++ b/scripts/mail-guardia.py
@@ -1,26 +1,27 @@
 #!/usr/bin/env python3
-"""Guardia de correo: que llego y no hemos contestado. Hermana de wa-guardia.py.
+"""Mail watch: what arrived and we have not answered. Sibling of wa-guardia.py.
 
-MISMO CONCEPTO, OTRO CANAL. `wa-guardia.py` cubre WhatsApp y `wa-sin-respuesta.py`
-es el vigia durable de ese canal. Esto es lo equivalente para el correo, que no
-tenia ninguna vigilancia: la unica forma de enterarse era que alguien preguntara.
+SAME CONCEPT, DIFFERENT CHANNEL. `wa-guardia.py` covers WhatsApp and
+`wa-sin-respuesta.py` is the durable sentry of that channel. This is the
+equivalent for email, which had no watch at all: the only way to find out was
+for someone to ask.
 
-Por que existe con credencial propia y no via MCP: un MCP solo responde dentro
-del turno del agente. Para vigilar hace falta un proceso que siga corriendo
-cuando el agente no esta, y eso necesita hablarle directo a la API.
+Why it exists with its own credential and not through MCP: an MCP only answers
+inside the agent turn. Watching needs a process that keeps running when the
+agent is gone, and that means talking to the API directly.
 
-OJO CON LA CREDENCIAL. En `~/.gmail-mcp/` hay DOS archivos con refresh_token y
-solo uno sirve para leer:
-  - token.json        -> scope gmail.compose. Redacta, NO lee. Da 403 al listar.
-  - credentials.json  -> scope gmail.modify. Este es el bueno.
-Leer el equivocado cuesta un diagnostico falso de "faltan permisos" y termina
-pidiendole al operador un consentimiento OAuth que no hacia falta.
+MIND THE CREDENTIAL. `~/.gmail-mcp/` holds TWO files with a refresh_token and
+only one can read:
+  - token.json        -> scope gmail.compose. Drafts, does NOT read. 403 on list.
+  - credentials.json  -> scope gmail.modify. This is the good one.
+Reading the wrong one costs a false "missing permissions" diagnosis and ends in
+asking the operator for an OAuth consent that was never needed.
 
-Solo LEE: unicamente hace GET. Nunca marca, archiva ni manda.
+Read only: it only does GET. It never marks, archives or sends.
 
-Uso:
-  mail-guardia.py --de dragon.com.mx                  # sin contestar, ahora
-  mail-guardia.py --de dragon.com.mx --vigilar        # una linea por correo nuevo
+Usage:
+  mail-guardia.py --de dragon.com.mx                  # unanswered, right now
+  mail-guardia.py --de dragon.com.mx --vigilar        # one line per new mail
   mail-guardia.py --consulta "in:all newer_than:3d from:alguien@x.com"
 """
 import argparse

--- a/scripts/wa-guardia.py
+++ b/scripts/wa-guardia.py
@@ -1,28 +1,30 @@
 #!/usr/bin/env python3
-"""Guardia de chat: que llego y no hemos contestado, aqui y ahora.
+"""Chat watch: what arrived and we have not answered, here and now.
 
-DONDE ENCAJA. La vigilancia DURABLE de un canal es de `wa-sin-respuesta.py`, que
-corre como timer de systemd fuera de cualquier sesion y alerta por correo cuando
-un cliente pasa el umbral sin respuesta. Ese es el dueño del concepto "nadie
-contesto", y una sesion no es infraestructura.
+WHERE IT FITS. The DURABLE watch over a channel belongs to
+`wa-sin-respuesta.py`, which runs as a systemd timer outside any session and
+alerts by email when a client crosses the no-reply threshold. That is the owner
+of the "nobody answered" concept, and a session is not infrastructure.
 
-Esto es la capa de SESION, y contesta otra pregunta: "ponme al dia AHORA".
-No tiene umbral ni alerta, y no sustituye al vigia: si un chat importa de verdad,
-va en la seccion `vigilancia` de la config, no colgado de una sesion viva.
+This is the SESSION layer, and it answers a different question: "catch me up
+NOW". It has no threshold and no alert, and it does not replace the sentry: if a
+chat really matters, it belongs in the `vigilancia` section of the config, not
+hanging off a live session.
 
-Para no tener dos definiciones de lo mismo, la logica que decide QUE cuenta como
-pendiente (el filtro de acuses) y DONDE viven los puentes se importan del vigia.
-Un "gracias" no es un pendiente, y esa regla se escribe una sola vez.
+To avoid two definitions of the same thing, the logic that decides WHAT counts
+as pending (the acknowledgement filter) and WHERE the bridges live are imported
+from the sentry. A "thanks" is not a pending item, and that rule is written
+once.
 
-  --desde-ultimo-mio  (por omision) lo entrante DESPUES de mi ultimo envio.
-                      Responde "que me deben" sin fijar una ventana de horas a
-                      mano, que siempre queda corta o larga.
-  --vigilar           una linea por mensaje nuevo, no termina. Para colgarlo de
-                      un Monitor mientras dura la sesion.
+  --desde-ultimo-mio  (default) what came in AFTER my last send. Answers "who
+                      owes me" without setting a window of hours by hand, which
+                      always ends up too short or too long.
+  --vigilar           one line per new message, never exits. To hang off a
+                      Monitor for as long as the session lasts.
 
-Solo LEE. Nunca escribe en la base ni manda nada.
+Read only. It never writes to the database and never sends anything.
 
-Uso:
+Usage:
   wa-guardia.py <chat_jid> [--puente soporte|personal] [--vigilar] [--con-acuses]
   wa-guardia.py <chat_jid> --horas 24
 """

--- a/scripts/wa-latido.py
+++ b/scripts/wa-latido.py
@@ -1,40 +1,41 @@
 #!/usr/bin/env python3
-"""Latido activo de puentes de WhatsApp: mide la TUBERIA, no el proceso.
+"""Active heartbeat for WhatsApp bridges: it measures the PIPE, not the process.
 
-POR QUE EXISTE. Un puente puede estar caido dias sin que nadie se entere, porque
-las dos sondas obvias mienten:
+WHY IT EXISTS. A bridge can be down for days without anyone noticing, because
+the two obvious probes lie:
 
-  1. "el proceso existe" (pgrep). Un puente puede estar vivo, autenticado y con
-     socket abierto, y llevar horas sin persistir un solo mensaje.
-  2. "la base se escribio hace poco" (mtime). No distingue ROTO de QUIETO. En un
-     canal de poco trafico, horas sin escribir puede ser silencio legitimo o un
-     atasco, y la sonda no puede decir cual.
+  1. "the process exists" (pgrep). A bridge can be alive, authenticated and with
+     an open socket, and go hours without persisting a single message.
+  2. "the database was written recently" (mtime). It does not tell BROKEN from
+     QUIET. On a low-traffic channel, hours without a write can be legitimate
+     silence or a jam, and the probe cannot say which.
 
-La sonda que no miente es ACTIVA: mandar un mensaje y comprobar que aterriza.
-Es la diferencia entre preguntar "¿respiras?" y ponerle un espejo en la boca.
+The probe that does not lie is ACTIVE: send a message and check that it lands.
+It is the difference between asking "are you breathing?" and holding a mirror to
+the mouth.
 
-ALCANCE HONESTO. Ejercita el camino de SALIDA (API -> whatsmeow -> ack del
-servidor -> escritura a SQLite). NO ejercita el de ENTRADA, que es otro manejador
-del mismo binario. Un puente que envia pero tiene la recepcion atorada pasaria en
-verde. Es mucho mas que pgrep y menos que "la tuberia completa".
+HONEST SCOPE. It exercises the OUTBOUND path (API -> whatsmeow -> server ack ->
+SQLite write). It does NOT exercise the INBOUND one, which is a different
+handler of the same binary. A bridge that sends but has reception stuck would
+pass green. It is far more than pgrep and less than "the whole pipe".
 
-DONDE VIVE EL PUENTE. Un puente puede correr en esta maquina o en un servidor.
-Si su config trae la clave `remoto`, TODAS las sondas (proceso, enlace,
-aterrizaje) y la cura van contra ese servidor por SSM, y levantar el binario
-local queda PROHIBIDO. El 18-ago-2026 esta distincion no existia: el puente de
-soporte ya vivia en la EC2, la sonda de aterrizaje leia la replica local (que se
-refresca cada 5 min, o sea que un sello de hace 40 segundos jamas podia
-aparecer), y la cura levantaba el binario de aqui. Resultado: FAIL garantizado
-cada 10 minutos y una segunda sesion de WhatsApp clonada en cada vuelta.
+WHERE THE BRIDGE LIVES. A bridge can run on this machine or on a server. If its
+config carries the `remoto` key, ALL the probes (process, link, landing) and the
+cure go against that server over SSM, and starting the local binary is
+FORBIDDEN. On 2026-08-18 this distinction did not exist: the support bridge
+already lived on the EC2, the landing probe read the local replica (which
+refreshes every 5 min, so a stamp from 40 seconds ago could never show up), and
+the cure started the binary here. Result: a guaranteed FAIL every 10 minutes and
+a second WhatsApp session cloned on every pass.
 
-CONFIGURACION. Los datos del canal (numeros, rutas) viven en
-company/config/wa-puentes.json, que esta gitignored. Este script es publico y no
-debe contener ningun identificador de cliente.
+CONFIGURATION. The channel data (numbers, paths) lives in
+company/config/wa-puentes.json, which is gitignored. This script is public and
+must not contain any client identifier.
 
-Uso:
-    wa-latido.py                 comprueba, y si hace falta cura
-    wa-latido.py --sin-curar     solo diagnostica
-    wa-latido.py --selftest      autoprueba con fixtures
+Usage:
+    wa-latido.py                 check, and cure if needed
+    wa-latido.py --sin-curar     diagnose only
+    wa-latido.py --selftest      self-test with fixtures
 """
 import argparse
 import fcntl

--- a/scripts/wa-sin-respuesta.py
+++ b/scripts/wa-sin-respuesta.py
@@ -1,125 +1,127 @@
 #!/usr/bin/env python3
-"""Vigia de silencio: avisa cuando un cliente escribio y nadie contesto.
+"""Silence sentry: alerts when a client wrote and nobody answered.
 
-Por que existe
---------------
-El 2026-08-02 una clienta mando el dato que se le habia pedido, se le contesto
-con silencio, y se fue a dormir creyendo que habia fallado. El arreglo ya estaba
-aplicado y nadie se lo dijo. La causa no fue el puente, que estaba vivo: fue que
-la unica vigilancia del canal corria DENTRO de una sesion de agente, y una
-sesion no es infraestructura.
+Why it exists
+-------------
+On 2026-08-02 a client sent the data she had been asked for, got silence back,
+and went to bed believing she had failed. The fix was already applied and nobody
+told her. The cause was not the bridge, which was alive: it was that the only
+watch over the channel ran INSIDE an agent session, and a session is not
+infrastructure.
 
-Este script no contesta por nadie. Solo rompe el silencio: si un mensaje de
-cliente lleva mas del umbral sin respuesta, avisa por el canal que le toque
-(ver "UN SOLO ARCHIVO, DOS CASAS"). El operador decide que hacer.
+This script answers for nobody. It only breaks the silence: if a client message
+goes past the threshold with no reply, it alerts through whichever channel
+applies (see "ONE FILE, TWO HOMES"). The operator decides what to do.
 
-DOS SENSORES, UN VIGIA (6-ago). Nacio mirando solo WhatsApp y el correo no tenia
-NINGUNA vigilancia durable: la unica forma de enterarse era que alguien
-preguntara. El 5-ago eso costo dos correos del cliente sin leer durante dos
-dias, porque el unico vigilante del buzon vivia dentro de una sesion y murio
-con ella. El correo entra aqui, no en un script aparte, porque la pregunta del
-operador nunca fue "¿contesto por WhatsApp?" sino "¿contesto el cliente?": la
-unidad es el CLIENTE, no el canal.
+TWO SENSORS, ONE SENTRY (Aug 6). It was born watching only WhatsApp and email
+had NO durable watch at all: the only way to find out was for someone to ask. On
+Aug 5 that cost two client emails unread for two days, because the only watcher
+of the mailbox lived inside a session and died with it. Email belongs here, not
+in a separate script, because the operator question was never "did they answer
+on WhatsApp?" but "did the client answer?": the unit is the CLIENT, not the
+channel.
 
-El nombre `wa-` se quedo corto con ese cambio. Renombrarlo toca dos unidades de
-systemd vivas y varios importadores, asi que va como cambio propio y separado.
+The `wa-` name fell short with that change. Renaming it touches two live systemd
+units and several importers, so it goes as its own separate change.
 
-UN SOLO ARCHIVO, DOS CASAS (11-ago). El puente de soporte se mudo a una
-instancia de AWS y el vigia se quedo en la laptop midiendo una base que ya no
-estaba ahi, asi que se apago y nadie vigilo ningun canal. La respuesta NO fue
-copiar el script al servidor: dos copias se separan al primer ajuste y entonces
-los dos mecanismos se contradicen, que es peor que uno solo. Lo que cambia entre
-las dos casas es el ENTORNO, no la logica:
+ONE FILE, TWO HOMES (Aug 11). The support bridge moved to an AWS instance and
+the sentry stayed on the laptop measuring a database that was no longer there,
+so it shut down and nobody watched any channel. The answer was NOT to copy the
+script to the server: two copies drift apart on the first tweak and then the two
+mechanisms contradict each other, which is worse than one. What changes between
+the two homes is the ENVIRONMENT, not the logic:
 
-    WA_VIGIA_CONFIG   ruta de la config          (def. ~/.claude/company/...)
-    WA_VIGIA_ESTADO   ruta del anti-repeticion   (def. ~/.cache/...)
+    WA_VIGIA_CONFIG   config path                (def. ~/.claude/company/...)
+    WA_VIGIA_ESTADO   anti-repeat state path     (def. ~/.cache/...)
     WA_VIGIA_CANAL    gmail | canario | whatsapp (def. gmail)
     WA_VIGIA_GMAIL    archivos | secretsmanager  (def. archivos)
-    WA_VIGIA_WA_DEST  numero destino del canal whatsapp (o config)
-    WA_VIGIA_WA_ENDPOINT  REST del puente (def. http://127.0.0.1:8081/api/send)
+    WA_VIGIA_WA_DEST  destination number of the whatsapp channel (or config)
+    WA_VIGIA_WA_ENDPOINT  bridge REST (def. http://127.0.0.1:8081/api/send)
 
-`gmail` no manda el correo desde aqui: sale con error y systemd dispara
-`OnFailure=wa-alerta@%N.service`, que es quien tiene el OAuth. `canario`
-publica el aviso EL MISMO en el tema de SNS que el canario de Cloudflare tiene
-suscrito. `whatsapp` manda el aviso por el puente de soporte (REST local
-127.0.0.1:8081) al numero del operador; ese numero sale de la config privada o
-del entorno, NUNCA de este archivo, que es publico.
+`gmail` does not send the mail from here: it exits with an error and systemd
+fires `OnFailure=wa-alerta@%N.service`, which is what holds the OAuth. `canario`
+publishes the alert ITSELF to the same SNS topic the Cloudflare canary is
+subscribed to. `whatsapp` sends the alert through the support bridge (local REST
+127.0.0.1:8081) to the operator number; that number comes from the private
+config or from the environment, NEVER from this file, which is public.
 
-LA FUENTE DE LA CREDENCIAL TAMBIEN ES ENTORNO (11-ago). El sensor de correo
-buscaba la credencial de Gmail como ARCHIVOS en `~/.gmail-mcp/`, asi que en la
-instancia se saltaba solo y ningun remitente quedaba vigilado: la laptop tenia
-el timer apagado y el servidor no podia mirar el buzon. Eso es un punto ciego
-con cara de vigia sano. `WA_VIGIA_GMAIL=secretsmanager` lee la MISMA credencial
-desde AWS Secrets Manager con el rol de la instancia, EN MEMORIA: se pide,
-se usa y se tira. Nunca toca el disco del servidor, ni siquiera un rato, porque
-un disco de instancia se lo puede llevar alguien y un secreto en disco es un
-secreto perdido. El default sigue siendo `archivos`: la laptop no cambia.
+THE CREDENTIAL SOURCE IS ENVIRONMENT TOO (Aug 11). The mail sensor looked for
+the Gmail credential as FILES in `~/.gmail-mcp/`, so on the instance it skipped
+itself and no sender stayed watched: the laptop had the timer off and the server
+could not look at the mailbox. That is a blind spot wearing the face of a
+healthy sentry. `WA_VIGIA_GMAIL=secretsmanager` reads the SAME credential from
+AWS Secrets Manager with the instance role, IN MEMORY: requested, used and
+dropped. It never touches the server disk, not even briefly, because an instance
+disk can be carried off and a secret on disk is a lost secret. The default stays
+`archivos`: the laptop does not change.
 
-Diseno
+Design
 ------
-- Lee la config PRIVADA (`company/config/wa-puentes.json`). Los JID y los
-  dominios son dato de cliente y este archivo vive en un repo publico, asi que
-  aqui no hay ninguno. El ARN del tema de SNS tambien vive ahi: lleva el numero
-  de cuenta y ese numero no se publica.
-- Base de datos en modo SOLO LECTURA. El vigia nunca escribe en el puente, y
-  contra Gmail solo hace GET.
-- Avisa UNA vez por mensaje. Si el cliente manda otro y tampoco se contesta,
-  ese si vuelve a avisar, porque es un silencio nuevo.
-- Cada sensor trae su filtro de ruido, y los dos existen por la misma razon: un
-  vigia que grita por algo que no pide respuesta entrena al operador a
-  ignorarlo, y ahi se muere el mecanismo. En WhatsApp son los acuses; en correo
-  son los autorespondedores.
-- Un fallo de red del sensor de correo NO tumba el de WhatsApp. Se avisa como
-  ruido y se sigue, porque "no llego nada" y "no pude mirar" no pueden verse
-  igual.
-- Y ese "no pude mirar" VIAJA EN EL AVISO, no solo en el journal. Un vigia que
-  revisa un sensor de dos y avisa igual que si hubiera revisado los dos es un
-  falso verde: el operador lee "un silencio" y entiende "solo uno", cuando la
-  verdad es "uno de los que si pude mirar". Por eso cada aviso lleva su linea
-  de cobertura, tambien cuando la cobertura esta completa.
-- `--selftest` prueba los dos sensores sin tocar nada real ni salir a la red.
-  Los tiempos de las pruebas son RELATIVOS a `ahora` a proposito: con marcas
-  fijas, un error de signo pasa igual y la prueba aprueba un detector muerto.
+- Reads the PRIVATE config (`company/config/wa-puentes.json`). The JIDs and the
+  domains are client data and this file lives in a public repo, so there are
+  none here. The SNS topic ARN lives there too: it carries the account number
+  and that number is not published.
+- Database in READ-ONLY mode. The sentry never writes to the bridge, and against
+  Gmail it only does GET.
+- Alerts ONCE per message. If the client sends another one and that one also
+  goes unanswered, it does alert again, because it is a new silence.
+- Each sensor brings its own noise filter, and both exist for the same reason: a
+  sentry that shouts about something that needs no reply trains the operator to
+  ignore it, and there the mechanism dies. On WhatsApp it is the
+  acknowledgements; on email it is the autoresponders.
+- A network failure of the mail sensor does NOT take down the WhatsApp one. It
+  is reported as noise and the run continues, because "nothing arrived" and "I
+  could not look" must not look the same.
+- And that "I could not look" TRAVELS IN THE ALERT, not only in the journal. A
+  sentry that checks one sensor out of two and alerts as if it had checked both
+  is a false green: the operator reads "one silence" and understands "only one",
+  when the truth is "one of the ones I could look at". So every alert carries
+  its coverage line, including when coverage is complete.
+- `--selftest` exercises both sensors without touching anything real and without
+  going to the network. The test times are RELATIVE to `ahora` on purpose: with
+  fixed stamps, a sign error passes anyway and the test approves a dead detector.
 
-EL VERDE HAY QUE AFIRMARLO (11-ago). El vigia solo hablaba cuando habia
-silencio NUEVO, asi que del lado del tablero la ausencia de aviso significaba
-dos cosas OPUESTAS: "ya contestaron" o "el vigia se murio". Un tablero que no
-sabe distinguirlas no puede pintar un verde honesto, y un verde que nadie
-afirma es adivinanza. Por eso cada publicacion cierra con un bloque
-estructurado que lleva el estado de TODOS los vigilados, tambien los sanos:
+GREEN HAS TO BE ASSERTED (Aug 11). The sentry only spoke when there was NEW
+silence, so from the dashboard side the absence of an alert meant two OPPOSITE
+things: "they already answered" or "the sentry died". A dashboard that cannot
+tell them apart cannot paint an honest green, and a green nobody asserts is
+guesswork. So every publication closes with a structured block carrying the
+state of ALL the watched entries, the healthy ones included:
 
     --- canario:v1 ---
     {"emisor":..,"ts":..,"cobertura":{..},"chats":[{..}]}
 
-Reglas del bloque, que son contrato con el receptor y no se cambian de un lado
-solo:
-- `chats` trae todos los chats y remitentes que SI se pudieron medir en esa
-  vuelta. Un sano va con `silencio_min: null` y `desde: null`; sin los sanos no
-  hay verdes. Lo que NO se pudo mirar se queda FUERA de la lista a proposito:
-  mandarlo con null seria decir "esta bien" sin haberlo visto, que es el mismo
-  falso verde con otro disfraz. Quien no pudo mirarse sale en `cobertura`.
-- `cliente` es la identidad (un cliente puede tener varios canales) y `canal`
-  es `whatsapp` o `correo`. Los dos salen de la config, no se adivinan aqui.
-- `id` es un slug estable y unico: nombre del cliente, canal y una firma del
-  JID o del dominio. Estable entre corridas y sin publicar el identificador.
-- `prueba` marca lo que viene de un fixture o de una corrida de prueba, para
-  que el receptor lo excluya del tablero. Se prende con WA_VIGIA_PRUEBA=1 o
-  por entrada de config.
-- `cobertura` dice que sensores alcanzaron a mirar, con su motivo.
+Rules of the block, which are a contract with the receiver and are not changed
+from one side alone:
+- `chats` carries every chat and sender that COULD be measured on that pass. A
+  healthy one goes with `silencio_min: null` and `desde: null`; without the
+  healthy ones there are no greens. What could NOT be looked at stays OUT of the
+  list on purpose: sending it with null would be saying "this is fine" without
+  having seen it, the same false green in another disguise. Whoever could not be
+  looked at shows up in `cobertura`.
+- `cliente` is the identity (a client can have several channels) and `canal` is
+  `whatsapp` or `correo`. Both come from the config, they are not guessed here.
+- `id` is a stable, unique slug: client name, channel and a signature of the JID
+  or the domain. Stable across runs and without publishing the identifier.
+- `prueba` marks what comes from a fixture or a test run, so the receiver
+  excludes it from the dashboard. Turned on with WA_VIGIA_PRUEBA=1 or by a
+  config entry.
+- `cobertura` says which sensors managed to look, with their reason.
 
-EL PULSO (11-ago). El bloque no sirve de nada si el vigia solo publica cuando
-algo falla: un tablero sin datos frescos no puede pintar verde, solo gris. Asi
-que en el canal `canario` el estado completo se republica cada
-WA_VIGIA_PULSO_MIN minutos (def. 30) aunque no haya ni un silencio. No cada 5,
-que es cada cuanto corre el timer, porque un aviso cada 5 minutos se vuelve
-ruido y el ruido se ignora. En el canal `gmail` NO hay pulso: ahi "avisar" es
-salir con error y eso mandaria un correo cada media hora.
+THE PULSE (Aug 11). The block is useless if the sentry only publishes when
+something fails: a dashboard without fresh data cannot paint green, only grey.
+So on the `canario` channel the full state is republished every
+WA_VIGIA_PULSO_MIN minutes (def. 30) even with not a single silence. Not every
+5, which is how often the timer runs, because an alert every 5 minutes turns
+into noise and noise gets ignored. On the `gmail` channel there is NO pulse:
+there "alerting" means exiting with an error and that would send an email every
+half hour.
 
-Uso
----
-    wa-sin-respuesta.py              # revisa y avisa por el canal elegido
-    wa-sin-respuesta.py --seco       # calcula e imprime, sin publicar nada
-    wa-sin-respuesta.py --selftest   # prueba la logica sin tocar nada real
+Usage
+-----
+    wa-sin-respuesta.py              # check and alert on the chosen channel
+    wa-sin-respuesta.py --seco       # compute and print, publishing nothing
+    wa-sin-respuesta.py --selftest   # test the logic without touching anything real
 """
 import argparse
 import hashlib

--- a/scripts/wa-soporte.sh
+++ b/scripts/wa-soporte.sh
@@ -1,24 +1,24 @@
 #!/usr/bin/env bash
 # Sends a WhatsApp through the SUPPORT channel, never through the operator's personal number.
 #
-# Por que existe: el MCP `whatsapp` esta cableado al puente personal (puerto 8080).
-# Cualquier mcp__whatsapp__send_message sale desde el numero del operador. Para
-# hablarle a un cliente el canal correcto es el puente de soporte (puerto 8081).
-# Se mando un aviso a una clienta desde el numero personal por no tener esta via.
+# Why it exists: the `whatsapp` MCP is wired to the personal bridge (port 8080).
+# Every mcp__whatsapp__send_message leaves from the operator's number. To talk
+# to a client the right channel is the support bridge (port 8081). A notice
+# once went out to a client from the personal number because this path did not exist.
 #
-# Uso:  wa-soporte.sh <destinatario> <mensaje>
-#       destinatario: telefono con lada sin + ni signos, o JID completo
+# Usage:  wa-soporte.sh <recipient> <message>
+#         recipient: phone with country code, no + or symbols, or a full JID
 #
-# Adjuntos:  wa-soporte.sh <destinatario> <mensaje> --archivo <ruta-local>
-# El puente lee `media_path` en SU disco, y desde el cutover ese disco es el de
-# la EC2, no el de aqui. Asi que el archivo viaja: local -> bucket de paso ->
-# EC2 -> /api/send. Las dos copias intermedias se borran siempre, tambien si el
-# envio falla. Antes esto se hacia a mano en cuatro pasos cada vez.
+# Attachments:  wa-soporte.sh <recipient> <message> --archivo <local-path>
+# The bridge reads `media_path` on ITS disk, and since the cutover that disk is
+# the EC2's, not this machine's. So the file travels: local -> staging bucket ->
+# EC2 -> /api/send. Both intermediate copies are always deleted, also when the
+# send fails. This used to be four manual steps every time.
 #
-# Menciones (grupos): exporta WA_MENCIONES con los telefonos separados por coma.
-# El texto TIENE que traer "@<telefono>" para que WhatsApp lo pinte como etiqueta;
-# el celular de quien lee lo cambia por el nombre que tenga guardado. Sin esto la
-# mencion no notifica a nadie, se ve como texto gris.
+# Mentions (groups): export WA_MENCIONES with comma-separated phone numbers.
+# The text MUST contain "@<telefono>" for WhatsApp to render it as a tag; the
+# reader's phone swaps it for the saved contact name. Without it the mention
+# notifies nobody and shows as grey text.
 #   WA_MENCIONES=5215550001111 wa-soporte.sh 1203...@g.us "@5215550001111 buenos dias"
 set -euo pipefail
 
@@ -59,11 +59,12 @@ if [ -n "$archivo" ] && [ ! -f "$archivo" ]; then
   exit 66
 fi
 
-# Desde el cutover del 14-ago-2026 el puente vive en la EC2 octorato-ops.
-# Camino rapido: el tunel SSM local (localhost:8081). Si el tunel no esta
-# (laptop recien encendida, otra maquina, sesion en la nube), NO se cae al
-# personal: se envia DIRECTO por SSM ejecutando curl EN el servidor. El canal
-# deja de depender de esta laptop; solo pide credenciales AWS dataqbs-ops.
+# Since the 2026-08-14 cutover the bridge lives on the octorato-ops EC2.
+# Fast path: the local SSM tunnel (localhost:8081). When the tunnel is down
+# (laptop just booted, another machine, a cloud session) it does NOT fall back
+# to the personal bridge: it sends DIRECTLY over SSM by running curl ON the
+# server. The channel no longer depends on this laptop; it only needs the AWS
+# ops profile credentials.
 INSTANCIA_PUENTE="i-0c0112bf1431dc99e"
 REGION_PUENTE="mx-central-1"
 PERFIL_PUENTE="dataqbs-ops"
@@ -72,9 +73,9 @@ if ! ss -lnt 2>/dev/null | grep -q ":${PUERTO_SOPORTE} "; then
   VIA="ssm"
 fi
 
-# ---- Adjunto: el archivo tiene que existir en el disco DEL PUENTE ----------
-# El identificador de la instancia, la region, el perfil y el bucket de paso
-# salen de la config PRIVADA, no de aqui: este script se publica.
+# ---- Attachment: the file must exist on the BRIDGE's disk -----------------
+# The instance id, region, profile and staging bucket come from the PRIVATE
+# config, not from here: this script is published.
 if [ -n "$archivo" ]; then
   respuesta=$(WA_MENCIONES="${WA_MENCIONES:-}" python3 - "$destinatario" "$mensaje" "$archivo" "$PUERTO_SOPORTE" <<'PY'
 import base64, json, os, shlex, subprocess, sys, time, uuid

--- a/scripts/wa-soporte.sh
+++ b/scripts/wa-soporte.sh
@@ -113,8 +113,8 @@ try:
     if menciones:
         cuerpo["mentions"] = menciones
     b64 = base64.b64encode(json.dumps(cuerpo).encode()).decode()
-    # El borrado del temporal remoto va en trap: si el envio falla, el archivo
-    # de un cliente NO se queda tirado en el servidor.
+    # Remote temp file deletion goes in a trap: if the send fails, a client's
+    # file is NOT left lying on the server.
     q_dir = shlex.quote(destino_remoto)
     q_uri = shlex.quote(s3_uri)
     q_dst = shlex.quote(f"{destino_remoto}/{nombre}")
@@ -170,8 +170,8 @@ if menciones:
 datos = json.dumps(cuerpo).encode()
 
 if os.environ.get("WA_VIA") == "ssm":
-    # Sin tunel local: curl EN el servidor via SSM. El JSON viaja en base64
-    # para que ninguna comilla se rompa en el camino shell -> SSM -> shell.
+    # No local tunnel: curl ON the server via SSM. The JSON travels as base64
+    # so no quote breaks along the shell -> SSM -> shell path.
     import base64
     b64 = base64.b64encode(datos).decode()
     aws = ["aws", "--profile", os.environ["WA_PERFIL"], "--region", os.environ["WA_REGION"], "ssm"]

--- a/scripts/wa-soporte.sh
+++ b/scripts/wa-soporte.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Envia un WhatsApp por el canal de SOPORTE, no por el numero personal del operador.
+# Sends a WhatsApp through the SUPPORT channel, never through the operator's personal number.
 #
 # Por que existe: el MCP `whatsapp` esta cableado al puente personal (puerto 8080).
 # Cualquier mcp__whatsapp__send_message sale desde el numero del operador. Para

--- a/skills/4d-paradigm-protocol/SKILL.md
+++ b/skills/4d-paradigm-protocol/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 4d-paradigm-protocol
-description: "Protocolo completo del paradigma 4D (Describe, Delegate, Diligent, Disclose): el gate de 3 preguntas del 2D, el formato del Change Manifest, la matriz de validacion 3D y el Impact Radius. CLAUDE.md solo trae el resumen. Carga antes de escribir archivos o armar un manifiesto."
+description: "Full 4D paradigm protocol (Describe, Delegate, Diligent, Disclose): the 2D 3-question gate, the Change Manifest format, the 3D validation matrix and the Impact Radius. CLAUDE.md only carries the summary. Load before writing files or assembling a manifest."
 metadata:
   type: paradigm-protocol
   short-description: "Operational templates: 4D gate format, 3Q delegate protocol, diligent matrix, impact radius scan, anti-patterns"

--- a/skills/ado-pr-merge-via-api/SKILL.md
+++ b/skills/ado-pr-merge-via-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ado-pr-merge-via-api
-description: "Completa merges de Pull Request en Azure DevOps por REST API cuando la UI no sirve o hay que scriptear en lote. Cubre los 403 por threads sin resolver, voto en 'waiting for author' y CI gate rancio."
+description: "Completes Pull Request merges in Azure DevOps through the REST API when the UI fails or you need to script them in bulk. Covers 403s from unresolved threads, votes stuck in 'waiting for author' and stale CI gates."
 ---
 
 # ADO Pull Request Merge via REST API

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-browser
-description: "CLI de automatizacion de navegador para agentes, nativo en Rust, sin Playwright. Navega, llena formularios, da clic, toma screenshots y extrae datos. Dispara con 'abre el sitio', 'toma screenshot', 'prueba esta web', 'QA'."
+description: "Rust-native browser automation CLI for agents, no Playwright. Navigates, fills forms, clicks, takes screenshots and extracts data. Triggers on 'abre el sitio', 'toma screenshot', 'prueba esta web', 'QA'."
 ---
 
 # agent-browser: Browser Automation CLI for AI Agents

--- a/skills/arm-onboarding/SKILL.md
+++ b/skills/arm-onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arm-onboarding
-description: "Protocolo paso a paso para crear un arm nuevo de cliente: archivos requeridos, sync-ai-docs, el grafo de linaje sellado del arm, alta en QueryMaster y la higiene de gitignore. Dispara con 'crear un arm' u 'onboard a un cliente'."
+description: "Step-by-step protocol to create a new client arm: required files, sync-ai-docs, the arm's sealed lineage graph, QueryMaster registration and gitignore hygiene. Triggers on 'crear un arm' or 'onboard a un cliente'."
 metadata:
   type: workflow
   short-description: "How to onboard a new client arm: required files, sync-ai-docs, sealed lineage graph, QueryMaster connections, one-file rule"

--- a/skills/ask-with-recommendation/SKILL.md
+++ b/skills/ask-with-recommendation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ask-with-recommendation
-description: "Toda pregunta de opcion multiple al operador lleva recomendacion explicita marcada mas su razon (impacto, alcance, tiempo, riesgo de esperar). Aplica a cada AskUserQuestion y a cada 'quieres X o Y?' en prosa."
+description: "Every multiple-choice question to the operator carries an explicit marked recommendation plus its reason (impact, scope, time, risk of waiting). Applies to every AskUserQuestion and to every 'quieres X o Y?' written in prose."
 ---
 
 # Ask With Recommendation

--- a/skills/bruno-postman-alternative/SKILL.md
+++ b/skills/bruno-postman-alternative/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bruno-postman-alternative
-description: "Cliente de API open-source donde las colecciones son archivos de texto en el repo, revisables por PR, sin nube ni licencias por equipo. MIT. Para equipos que viven en git o cuando Postman sale caro."
+description: "Open-source API client where collections are text files in the repo, reviewable by PR, with no cloud and no per-seat licenses. MIT. For teams that live in git or when Postman gets expensive."
 ---
 
 # Bruno — Postman Alternative with Git-Native Collections

--- a/skills/canary-symbiont/SKILL.md
+++ b/skills/canary-symbiont/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: canary-symbiont
-description: "Centinela cross-plane: un watcher en el plano B detecta la muerte SILENCIOSA del scheduler del plano A (bloqueo de billing, cron load-shedding) y avisa por correo. Fail-open. Incluye el test en vivo obligatorio."
+description: "Cross-plane sentinel: a watcher on plane B detects the SILENT death of plane A's scheduler (billing block, cron load-shedding) and alerts by email. Fail-open. Includes the mandatory live test."
 metadata:
   short-description: "A sentinel on a different plane senses what the host can't, alerts once, dies harmlessly"
   type: pattern

--- a/skills/capture-ends-with-triage/SKILL.md
+++ b/skills/capture-ends-with-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: capture-ends-with-triage
-description: "Un pipeline programado que solo vuelca datos crudos obliga al humano a sintetizar, y por eso se omite. Todo capture debe cerrar con un paso de TRIAGE que diagnostique causa y siguiente accion. Aplica al construir o revisar cualquier job periodico."
+description: "A scheduled pipeline that only dumps raw data forces the human to synthesize, and that is why it gets skipped. Every capture must close with a TRIAGE step that diagnoses cause and next action. Applies when building or reviewing any periodic job."
 metadata:
   type: reference
 ---

--- a/skills/ccxt-python/SKILL.md
+++ b/skills/ccxt-python/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ccxt-python
-description: "Libreria CCXT para exchanges de cripto en Python, REST y WebSocket: conectar, bajar datos de mercado, colocar ordenes y transmitir tickers. Para bots de trading y analisis, sync o asyncio."
+description: "CCXT library for crypto exchanges in Python, REST and WebSocket: connect, pull market data, place orders and stream tickers. For trading bots and analysis, sync or asyncio."
 ---
 
 # CCXT for Python

--- a/skills/chatgpt-apps/SKILL.md
+++ b/skills/chatgpt-apps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chatgpt-apps
-description: "Construye y depura apps del ChatGPT Apps SDK que combinan servidor MCP y UI de widget: definir tools, registrar recursos de UI, puente MCP Apps, metadata, CSP y dominios. Consulta la doc antes de generar codigo."
+description: "Build and debug ChatGPT Apps SDK apps that pair an MCP server with a widget UI: defining tools, registering UI resources, the MCP Apps bridge, metadata, CSP and domains. Check the docs before generating code."
 ---
 
 # ChatGPT Apps

--- a/skills/claude-mem-persistent-memory/SKILL.md
+++ b/skills/claude-mem-persistent-memory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-mem-persistent-memory
-description: "Memoria persistente entre sesiones para agentes de codigo: captura la sesion, la comprime y reinyecta lo relevante despues, con ~75% menos tokens. AGPL 3.0, ojo con el copyleft en entregables comerciales."
+description: "Persistent cross-session memory for coding agents: captures the session, compresses it and re-injects what is relevant later, with ~75% fewer tokens. AGPL 3.0, watch the copyleft in commercial deliverables."
 ---
 
 # claude-mem — Persistent Memory for Claude Code

--- a/skills/client-doc-lint/SKILL.md
+++ b/skills/client-doc-lint/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: client-doc-lint
-description: "QA reflex before sending a generated deliverable to a client: checks broken accents, em-dashes, dates already past, a missing tax note when amounts appear, and inventories every amount. Run it before you say it is ready to send."
+description: "QA reflex before sending a generated deliverable to a client: checks broken accents, em-dashes, dates already past, a missing tax note when amounts appear, and inventories every amount. Run it before saying 'listo para enviar' (ready to send)."
 metadata:
   type: reference
 ---

--- a/skills/client-doc-lint/SKILL.md
+++ b/skills/client-doc-lint/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: client-doc-lint
-description: "Reflejo de QA antes de mandar un entregable generado a cliente: revisa acentos rotos, em-dash, fechas ya pasadas, falta de nota fiscal cuando hay montos, e inventaria cada monto. Correlo antes de decir 'listo para enviar'."
+description: "QA reflex before sending a generated deliverable to a client: checks broken accents, em-dashes, dates already past, a missing tax note when amounts appear, and inventories every amount. Run it before you say it is ready to send."
 metadata:
   type: reference
 ---

--- a/skills/cloudflare-email-service/SKILL.md
+++ b/skills/cloudflare-email-service/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cloudflare-email-service
-description: "Envia y recibe correo transaccional con Cloudflare Email Service (Sending mas Routing), por binding de Workers o REST. Cubre entregabilidad, SPF, DKIM, DMARC y setup con wrangler."
+description: "Send and receive transactional email with Cloudflare Email Service (Sending plus Routing), through a Workers binding or REST. Covers deliverability, SPF, DKIM, DMARC and wrangler setup."
 ---
 
 # Cloudflare Email Service

--- a/skills/coolify-self-hosted-paas/SKILL.md
+++ b/skills/coolify-self-hosted-paas/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coolify-self-hosted-paas
-description: "Alternativa autoalojada a Vercel, Heroku y Render: despliega apps, bases y servicios en tu propio servidor con git-push, SSL automatico y sin costo por asiento. Apache 2.0."
+description: "Self-hosted alternative to Vercel, Heroku and Render: deploy apps, databases and services on your own server with git-push, automatic SSL and no per-seat cost. Apache 2.0."
 ---
 
 # Coolify — Self-Hosted PaaS

--- a/skills/cotizacion-legal-baseline/SKILL.md
+++ b/skills/cotizacion-legal-baseline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cotizacion-legal-baseline
-description: "Clausulado legal base Mexico B2B que TODA cotizacion o propuesta lleva desde el borrador 1: propiedad intelectual, LFPDPPP, confidencialidad, limite de responsabilidad, garantia, licenciamiento e IVA."
+description: "Baseline Mexico B2B legal clauses that EVERY quote or proposal carries from draft 1: intellectual property, LFPDPPP, confidentiality, liability cap, warranty, licensing and VAT."
 metadata:
   type: reference
 ---

--- a/skills/cron-bridge-daily-publisher/SKILL.md
+++ b/skills/cron-bridge-daily-publisher/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cron-bridge-daily-publisher
-description: "Patron para autopublicar a diario N elementos curados desde D1 a una plataforma social via el worker programador. Incluye rotacion justa, idempotencia por hash, dedup por sentinel y barrido de retraccion."
+description: "Pattern to auto-publish N curated items per day from D1 to a social platform through the scheduler worker. Includes fair rotation, idempotency by hash, sentinel dedup and a retraction sweep."
 when_to_use: When a client wants "post N things per day to one or more social platforms, picked from a catalog, without duplicates within a cycle". Especially when there's an upstream feed (REST API, scraping target, manual catalog) → D1 → social. Examples — real-estate listings, e-commerce products, restaurant menus, event calendars.
 triggers: ["daily social publisher", "fair rotation", "auto-post N per day", "multireach bridge", "EB-to-FB", "catalog to social"]
 ---

--- a/skills/daily-reflection/SKILL.md
+++ b/skills/daily-reflection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daily-reflection
-description: "Retro honesta de fin de sesion, errores primero, que destila la leccion a memoria del cerebro. Dispara con 'que aprendiste hoy?', 'reflexiona', '/reflect', 'what did you learn today', 'how would you be better tomorrow'."
+description: "Honest end-of-session retro, errors first, that distills the lesson into brain memory. Triggers on 'que aprendiste hoy?', 'reflexiona', '/reflect', 'what did you learn today', 'how would you be better tomorrow'."
 metadata:
   type: reflex
   short-description: "Honest session retro → 3 questions → distil the lesson to memory (reflection becomes reflex)"

--- a/skills/do-it-right-not-fast/SKILL.md
+++ b/skills/do-it-right-not-fast/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: do-it-right-not-fast
-description: "Canonico del operador: arregla la CAUSA RAIZ, nunca el parche rapido ni una pila de archivos paliativos. Dos olores obligan a parar: la frase 'la solucion rapida es' y acumular curitas en vez de reparar lo roto. Carga antes de proponer un fix."
+description: "Operator canon: fix the ROOT CAUSE, never the quick patch and never a pile of palliative files. Two smells force a stop: the phrase 'the quick fix is' and stacking band-aids instead of repairing what is broken. Load before proposing a fix."
 metadata:
   type: feedback
 ---

--- a/skills/do-it-right-not-fast/SKILL.md
+++ b/skills/do-it-right-not-fast/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: do-it-right-not-fast
-description: "Operator canon: fix the ROOT CAUSE, never the quick patch and never a pile of palliative files. Two smells force a stop: the phrase 'the quick fix is' and stacking band-aids instead of repairing what is broken. Load before proposing a fix."
+description: "Operator canon: fix the ROOT CAUSE, never the quick patch and never a pile of palliative files. Two smells force a stop: the phrase 'la solucion rapida es' (the quick fix is) and stacking band-aids instead of repairing what is broken. Load before proposing a fix."
 metadata:
   type: feedback
 ---

--- a/skills/eli5/SKILL.md
+++ b/skills/eli5/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: eli5
-description: "Explica cualquier documento, concepto o arquitectura en lenguaje adulto y claro, con analogias y sin jerga. Dispara con 'eli5', 'explicame como si tuviera 5', 'hazlo simple', 'en cristiano'. Alias de lii5."
+description: "Explains any document, concept or architecture in plain adult language, with analogies and no jargon. Triggers on 'eli5', 'explicame como si tuviera 5', 'hazlo simple', 'en cristiano'. Alias of lii5."
 metadata:
   short-description: ELI5 alias (universal naming for lii5)
   triggers: "eli5, ELI5, /eli5, explain like i'm 5, explícame, hazlo simple, dumb it down, en cristiano"

--- a/skills/figma-use/SKILL.md
+++ b/skills/figma-use/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: figma-use
-description: "MANDATORY prerequisite: invocalo ANTES de cada llamada a use_figma, nunca llames esa herramienta sin cargar esto. Aplica a crear o editar nodos, variables, componentes, auto-layout y fills."
+description: "MANDATORY prerequisite: invoke it BEFORE every use_figma call, never call that tool without loading this first. Applies to creating or editing nodes, variables, components, auto-layout and fills."
 ---
 
 # use_figma — Figma Plugin API Skill

--- a/skills/finops-observability/SKILL.md
+++ b/skills/finops-observability/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finops-observability
-description: "Mide el costo del cerebro y sus agentes y rutea la pregunta a la herramienta correcta: gasto por arm, KPI de ruteo, costo marginal de cada capacidad. Dispara con 'cuanto gastamos', 'cuanto cuesta', 'que se esta comiendo los tokens'."
+description: "Measures what the brain and its agents cost and routes the question to the right tool: spend per arm, routing KPIs, marginal cost of each capability. Triggers on 'cuanto gastamos', 'cuanto cuesta', 'que se esta comiendo los tokens'."
 ---
 
 # FinOps Observability

--- a/skills/gemini-vision/SKILL.md
+++ b/skills/gemini-vision/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gemini-vision
-description: "DISPARADOR OBLIGATORIO: 'analiza imagen', 'nano banana', 'gemini vision', 'que ves en la imagen', o al pegar una imagen pidiendo analisis. Vision con Gemini Flash. Preferido sobre image-analyzer si hay GEMINI_API_KEY."
+description: "MANDATORY TRIGGER: 'analiza imagen', 'nano banana', 'gemini vision', 'que ves en la imagen', or when an image is pasted asking for analysis. Vision with Gemini Flash. Preferred over image-analyzer when GEMINI_API_KEY is set."
 metadata:
   short-description: Gemini Flash vision analysis (Nano Banana)
 ---

--- a/skills/graphify-code-graph/SKILL.md
+++ b/skills/graphify-code-graph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: graphify-code-graph
-description: "Grafo de conocimiento determinista y consultable sobre un codebase con graphify (tree-sitter, 25+ lenguajes, sin costo de LLM). Usalo para impact analysis a nivel de codigo dentro de un repo cliente, donde grep responde mal."
+description: "Deterministic, queryable knowledge graph over a codebase with graphify (tree-sitter, 25+ languages, no LLM cost). Use it for code-level impact analysis inside a client repo, where grep answers poorly."
 metadata:
   type: tool-skill
   source: https://github.com/Graphify-Labs/graphify (MIT)

--- a/skills/gsap-core/SKILL.md
+++ b/skills/gsap-core/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gsap-core
-description: "API core de GSAP: to(), from(), fromTo(), easing, duration, stagger, defaults y matchMedia (responsive, prefers-reduced-motion). Para animacion JS en React, Vue o vanilla, sobre DOM o SVG."
+description: "GSAP core API: to(), from(), fromTo(), easing, duration, stagger, defaults and matchMedia (responsive, prefers-reduced-motion). For JS animation in React, Vue or vanilla, over DOM or SVG."
 license: MIT
 ---
 

--- a/skills/human-cadence/SKILL.md
+++ b/skills/human-cadence/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: human-cadence
-description: "Las 10 no-reglas que quitan los tics de IA a cualquier texto para que lea como persona: sin em-dash, sin muletillas, sin triadas forzadas. SIEMPRE ACTIVO en todo output: chat, correo, doc, commit, PR. CLAUDE.md trae el resumen, aqui esta el detalle."
+description: "The 10 no-rules that strip AI tells from any text so it reads like a person: no em-dash, no filler words, no forced triads. ALWAYS ON in every output: chat, email, doc, commit, PR. CLAUDE.md carries the summary, the detail is here."
 metadata:
   short-description: "10 anti-AI-tell no-rules for human-sounding, token-lean output"
   type: reference

--- a/skills/image-analyzer/SKILL.md
+++ b/skills/image-analyzer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: image-analyzer
-description: "DISPARADOR OBLIGATORIO: 'imagen', 'mira la imagen', 'screenshot', 'foto', 'captura', 'que ves', 'look at this', o cuando pegan una imagen en el chat. Analiza, describe y clasifica imagenes con vision GPT-4o."
+description: "MANDATORY TRIGGER: 'imagen', 'mira la imagen', 'screenshot', 'foto', 'captura', 'que ves', 'look at this', or when an image is pasted into the chat. Analyzes, describes and classifies images with GPT-4o vision."
 metadata:
   short-description: Analyze images with GPT-4o vision
 ---

--- a/skills/imagegen/SKILL.md
+++ b/skills/imagegen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "imagegen"
-description: "Genera o edita imagenes raster con IA: fotos, ilustraciones, texturas, sprites, mockups, recortes con fondo transparente. No la uses si el activo debe ser SVG, vector o HTML/CSS."
+description: "Generates or edits raster images with AI: photos, illustrations, textures, sprites, mockups, cutouts with a transparent background. Do not use it when the asset must be SVG, vector or HTML/CSS."
 ---
 
 # Image Generation Skill

--- a/skills/inbox-triage-classifier/SKILL.md
+++ b/skills/inbox-triage-classifier/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inbox-triage-classifier
-description: "Triage de bandejas (correo, Slack, Teams, JIRA, PRs): clasifica que requiere accion y devuelve veredicto por item con urgencia. Solo lectura, nunca marca leido ni responde. Usalo ante 'que tengo pendiente?', 'do I owe anyone a reply?'."
+description: "Triage for inboxes (email, Slack, Teams, JIRA, PRs): classifies what needs action and returns a per-item verdict with urgency. Read-only, never marks as read and never replies. Use it on 'que tengo pendiente?', 'do I owe anyone a reply?'."
 metadata:
   short-description: "PHI-aware triage classifier for inbox-like streams"
 ---

--- a/skills/infinite-monitor/SKILL.md
+++ b/skills/infinite-monitor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: infinite-monitor
-description: "Arma dashboards con IA sobre Infinite Monitor, app Next.js open-source donde describes el widget en lenguaje natural y un agente lo escribe y despliega en un canvas infinito. Dispara con 'crea un dashboard para'."
+description: "Builds AI dashboards on Infinite Monitor, an open-source Next.js app where you describe the widget in natural language and an agent writes and deploys it on an infinite canvas. Triggers on 'crea un dashboard para'."
 ---
 
 # Infinite Monitor — AI-Powered Dashboard Builder

--- a/skills/lii5/SKILL.md
+++ b/skills/lii5/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lii5
-description: "Explica cualquier documento, concepto o arquitectura en lenguaje adulto y claro, con analogias y sin jerga. Dispara con 'lii5', 'li5', 'explicame como si tuviera 5 anos', 'hazlo simple', 'en cristiano'."
+description: "Explains any document, concept or architecture in plain adult language, with analogies and no jargon. Triggers on 'lii5', 'li5', 'explicame como si tuviera 5 anos', 'hazlo simple', 'en cristiano'."
 ---
 
 # LII5 — Bridge the Technical Gap

--- a/skills/market-research-framework/SKILL.md
+++ b/skills/market-research-framework/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: market-research-framework
-description: "Marco de investigacion de mercado a nivel consultoria, 12 modulos del sizing a la estrategia de entrada. Dispara con 'market research', 'TAM/SAM/SOM', 'analisis competitivo', 'segmentacion de clientes', 'SWOT', 'Porter', 'pricing', 'go-to-market'."
+description: "Consulting-grade market research framework, 12 modules from sizing to entry strategy. Triggers on 'market research', 'TAM/SAM/SOM', 'analisis competitivo', 'segmentacion de clientes', 'SWOT', 'Porter', 'pricing', 'go-to-market'."
 ---
 
 # Market Research Framework — Consulting-Grade Analysis

--- a/skills/mcp-stack-setup/SKILL.md
+++ b/skills/mcp-stack-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-stack-setup
-description: "Instala y configura el stack MCP de un arm respetando Arm Isolation: los MCP de nube van a scope user, los de base de datos a .mcp.json dentro del repo del cliente. Dispara con 'setup MCP para X', 'agregar MCP al arm', o al dar de alta un arm nuevo."
+description: "Installs and configures an arm's MCP stack while respecting Arm Isolation: cloud MCPs go to user scope, database MCPs to .mcp.json inside the client repo. Triggers on 'setup MCP para X', 'agregar MCP al arm', or when onboarding a new arm."
 ---
 
 # Skill: MCP Stack Setup for Octopus Arms

--- a/skills/model-routing-by-complexity/SKILL.md
+++ b/skills/model-routing-by-complexity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: model-routing-by-complexity
-description: "Enruta el trabajo por complejidad a traves del ladder de modelos (mechanical, bulk, build, judgment), vendor-agnostico. Carga al abanicar sub-agentes o al elegir el override de model en un Workflow/Agent."
+description: "Routes work by complexity across the model ladder (mechanical, bulk, build, judgment), vendor-agnostic. Load when fanning out sub-agents or when picking the model override in a Workflow/Agent."
 ---
 
 # Model Routing by Complexity

--- a/skills/news-article-curation/SKILL.md
+++ b/skills/news-article-curation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: news-article-curation
-description: "Loop diario sobre feeds RSS de IA (Willison, OpenAI, DeepMind, arXiv cs.AI): filtra los articulos que ensenan algo que el cerebro aun no sabe. Promueve un keeper a skill real con /news-promote."
+description: "Daily loop over AI RSS feeds (Willison, OpenAI, DeepMind, arXiv cs.AI): filters the articles that teach something the brain does not know yet. Promotes a keeper to a real skill with /news-promote."
 metadata:
   type: brain-routine
   schedule: daily 06:45 UTC

--- a/skills/no-history-in-docs/SKILL.md
+++ b/skills/no-history-in-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: no-history-in-docs
-description: "Los documentos llevan solo contenido vigente; git es el control de versiones. Nunca tachado para marcar lo hecho, nunca texto viejo junto al nuevo 'para historia', nunca secciones comentadas 'de referencia'. Aplica a toda edicion o revision de documento."
+description: "Documents carry only current content; git is the version history. Never strikethrough to mark what is done, never old text next to the new one 'for the record', never sections commented out 'for reference'. Applies to every document edit or revision."
 ---
 
 # No History in Documents

--- a/skills/octorato-harmony/SKILL.md
+++ b/skills/octorato-harmony/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: octorato-harmony
-description: "Cuando un mismo valor vale 10 en un lado y 12 en otro, converge ambos a un canonico referenciado en todas partes, nunca bifurcado. Dispara al editar tokens de diseno, estilos o convenciones en varios archivos, y ante 'converge' o 'armoniza'."
+description: "When the same value reads 10 in one place and 12 in another, converge both to a canonical one referenced everywhere, never forked. Triggers when editing design tokens, styles or conventions across several files, and on 'converge' or 'armoniza'."
 metadata:
   type: pattern-reference
   origin: octorato-harmony-canon + innate-harmony-research panels — 2026-05-30

--- a/skills/octorato-isomorphism/SKILL.md
+++ b/skills/octorato-isomorphism/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: octorato-isomorphism
-description: "Los tres anclajes de Octorato (pulpo, Linux, teseracto) son una misma estructura mostrada tres veces, no tres marcas pegadas. Nombra el metodo de abstraccion. Invoca al explicar por que cohesionan o al anadir un anclaje nuevo."
+description: "Octorato's three anchors (octopus, Linux, tesseract) are one structure shown three times, not three brands glued together. Names the abstraction method. Invoke when explaining why they cohere or when adding a new anchor."
 metadata:
   type: identity
   short-description: "octopus ∧ linux ∧ tesseract share one structure; the shared words ARE the brain's required primitives. The fractal/self-similar primitive is owned by octorato-symbolism; this skill is the method that measures the invariant."

--- a/skills/querymaster-adx/SKILL.md
+++ b/skills/querymaster-adx/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: querymaster-adx
-description: "Skill hijo de querymaster para Azure Data Explorer. ADX usa KQL, NUNCA SQL. Conexion azure-kusto-data con SSO y buenas practicas para telemetria en tiempo real. Se activa cuando el motor resuelto es ADX."
+description: "Child skill of querymaster for Azure Data Explorer. ADX uses KQL, NEVER SQL. azure-kusto-data connection with SSO, plus best practices for real-time telemetry. Activates when the resolved engine is ADX."
 ---
 
 # QueryMaster — Azure Data Explorer (ADX) / KQL Engine Skill

--- a/skills/querymaster-databricks/SKILL.md
+++ b/skills/querymaster-databricks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: querymaster-databricks
-description: "Skill hijo de querymaster para Databricks. PLACEHOLDER: aun no hay workspace ni cluster provisionado, solo la plantilla de conexion con databricks-sql-connector. Se completa cuando exista acceso."
+description: "Child skill of querymaster for Databricks. PLACEHOLDER: no workspace or cluster provisioned yet, only the connection template with databricks-sql-connector. Completed once access exists."
 ---
 
 # QueryMaster — Databricks Engine Skill (Placeholder)

--- a/skills/querymaster-postgresql/SKILL.md
+++ b/skills/querymaster-postgresql/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: querymaster-postgresql
-description: "Skill hijo de querymaster para PostgreSQL (estandar, Azure Database, Aurora): patrones de conexion psycopg2 y Node, sesion readonly y buenas practicas de consulta. Se activa cuando el motor resuelto es PostgreSQL."
+description: "Child skill of querymaster for PostgreSQL (standard, Azure Database, Aurora): psycopg2 and Node connection patterns, read-only session and query best practices. Activates when the resolved engine is PostgreSQL."
 ---
 
 # QueryMaster — PostgreSQL Engine Skill

--- a/skills/querymaster-snowflake/SKILL.md
+++ b/skills/querymaster-snowflake/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: querymaster-snowflake
-description: "Skill hijo de querymaster para Snowflake: conexion por Browser SSO, OAuth y usuario/contrasena de servicio, REST SQL API y buenas practicas de warehouse. Se activa cuando el motor resuelto es Snowflake."
+description: "Child skill of querymaster for Snowflake: connection via Browser SSO, OAuth and service user/password, REST SQL API and warehouse best practices. Activates when the resolved engine is Snowflake."
 ---
 
 # QueryMaster — Snowflake Engine Skill

--- a/skills/querymaster-sqlite/SKILL.md
+++ b/skills/querymaster-sqlite/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: querymaster-sqlite
-description: "Skill hijo de querymaster para SQLite: bases locales en archivo, storage de Optuna, barridos analiticos y uso embebido, con PRAGMA de WAL y foreign_keys. Se activa cuando el motor resuelto es SQLite."
+description: "Child skill of querymaster for SQLite: local file databases, Optuna storage, analytical sweeps and embedded use, with WAL and foreign_keys PRAGMA. Activates when the resolved engine is SQLite."
 ---
 
 # QueryMaster — SQLite Engine Skill

--- a/skills/querymaster-sqlserver/SKILL.md
+++ b/skills/querymaster-sqlserver/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: querymaster-sqlserver
-description: "Skill hijo de querymaster para SQL Server y Azure SQL (Database, Managed Instance, on-prem): conexion pyodbc con token de Azure AD y buenas practicas T-SQL. Se activa cuando el motor resuelto es SQL Server."
+description: "Child skill of querymaster for SQL Server and Azure SQL (Database, Managed Instance, on-prem): pyodbc connection with an Azure AD token and T-SQL best practices. Activates when the resolved engine is SQL Server."
 ---
 
 # QueryMaster — SQL Server / Azure SQL Engine Skill

--- a/skills/querymaster/SKILL.md
+++ b/skills/querymaster/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: querymaster
-description: "Router maestro multi-motor: recibe un prompt en lenguaje natural, identifica el motor (PostgreSQL, Snowflake, SQL Server, ADX, SQLite, Databricks), genera la consulta y la ejecuta con dry-run por defecto. Dispara al pedir consultar una base, correr SQL o inspeccionar un esquema."
+description: "Multi-engine master router: takes a natural-language prompt, identifies the engine (PostgreSQL, Snowflake, SQL Server, ADX, SQLite, Databricks), generates the query and runs it with dry-run by default. Triggers when asked to query a database, run SQL or inspect a schema."
 ---
 
 # QueryMaster — Multi-Engine Database Agent (Master Skill)

--- a/skills/repo-deep-learn/SKILL.md
+++ b/skills/repo-deep-learn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: repo-deep-learn
-description: "Analisis profundo de UN repo de GitHub: inventaria el codigo, extrae patrones que podrian volverse skill y escribe reporte en ~/.claude/knowledge/repo-deep-learn/. Usalo cuando el operador te entrega un repo y pregunta que se puede aprender de el."
+description: "Deep analysis of ONE GitHub repo: inventories the code, extracts patterns that could become a skill and writes a report to ~/.claude/knowledge/repo-deep-learn/. Use it when the operator hands you a repo and asks what can be learned from it."
 metadata:
   type: brain-routine
   trigger: manual (operator-initiated)

--- a/skills/repo-watch/SKILL.md
+++ b/skills/repo-watch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: repo-watch
-description: "Monitor diario de una watchlist de repos de GitHub: compara el HEAD SHA contra el snapshot previo y escribe un digest en ~/.claude/knowledge/repo-watch/. Usalo para seguir el pulso de competidores sin mirar GitHub todo el dia."
+description: "Daily monitor over a watchlist of GitHub repos: compares the HEAD SHA against the previous snapshot and writes a digest to ~/.claude/knowledge/repo-watch/. Use it to track the pulse of competitors without watching GitHub all day."
 metadata:
   type: brain-routine
   trigger: cron (daily) — register in ~/dataqbs-local-cron/runner.py

--- a/skills/repomix-codebase-packer/SKILL.md
+++ b/skills/repomix-codebase-packer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: repomix-codebase-packer
-description: "Empaqueta un repo completo, local o remoto, en un solo archivo optimizado para LLM, con compresion Tree-sitter (~70% menos tokens) y escaneo de secretos. Para auditar un repo entero o preparar contexto de un subagente."
+description: "Packs a whole repo, local or remote, into a single LLM-optimized file, with Tree-sitter compression (~70% fewer tokens) and secret scanning. For auditing an entire repo or preparing subagent context."
 ---
 
 # Repomix — Codebase to Single AI-Friendly File

--- a/skills/save-transcript/SKILL.md
+++ b/skills/save-transcript/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: save-transcript
-description: "Rescata el transcript COMPLETO de una grabacion de reunion (Microsoft Stream, SharePoint) a partir de su URL, y entrega un .txt limpio, con procedencia y listo para compartir. Dispara con 'save-transcript', 'baja el transcript', 'saca el transcript de esta junta', 'transcript de <URL>'. Para audio crudo sin transcript ya renderizado usa transcribe."
+description: "Recovers the COMPLETE transcript of a meeting recording (Microsoft Stream, SharePoint) from its URL, and delivers a clean .txt with provenance, ready to share. Triggers on 'save-transcript', 'baja el transcript', 'saca el transcript de esta junta', 'transcript de <URL>'. For raw audio with no rendered transcript use transcribe."
 ---
 
 # save-transcript

--- a/skills/schema-as-code-three-layer-sync/SKILL.md
+++ b/skills/schema-as-code-three-layer-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: schema-as-code-three-layer-sync
-description: "Mantiene sincronizadas las tres capas de un proyecto schema-as-code: diagrama ER, diccionario de datos y el SQL declarativo. Define la cadena de verdad y el flujo de diff cuando divergen."
+description: "Keeps the three layers of a schema-as-code project in sync: ER diagram, data dictionary and the declarative SQL. Defines the chain of truth and the diff flow when they drift."
 ---
 
 # Schema-as-Code Three-Layer Sync

--- a/skills/security-ownership-map/SKILL.md
+++ b/skills/security-ownership-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "security-ownership-map"
-description: "Topologia de propiedad de codigo orientada a seguridad desde el historial de git: bus factor, duenos de codigo sensible, huerfanos, exporta CSV/JSON. Solo cuando piden analisis de seguridad, no listas de mantenedores."
+description: "Security-oriented code ownership topology from git history: bus factor, owners of sensitive code, orphans, CSV/JSON export. Only when a security analysis is requested, not for maintainer lists."
 ---
 
 # Security Ownership Map

--- a/skills/session-isolation/SKILL.md
+++ b/skills/session-isolation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-isolation
-description: "OBLIGATORIO: cada sesion concurrente sobre un repo necesita su propio git worktree y session id. NUNCA dos sesiones vivas sobre el mismo working tree. Carga antes de abrir una segunda sesion, o al investigar 'mis cambios se fueron en el commit de otra sesion'."
+description: "MANDATORY: every concurrent session on a repo needs its own git worktree and session id. NEVER two live sessions on the same working tree. Load before opening a second session, or when investigating 'mis cambios se fueron en el commit de otra sesion'."
 metadata:
   short-description: "Each concurrent session gets its own git worktree. Period."
   type: reference

--- a/skills/session-learn-extractor/SKILL.md
+++ b/skills/session-learn-extractor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-learn-extractor
-description: "Extrae el patron reusable de la sesion y lo escribe como skill BORRADOR en skills/learned/. Dispara tras 'ya quedo', 'fixed', 'shipped', 'merged' sobre algo que costo varios pasos de investigacion, o via /learn."
+description: "Extracts the reusable pattern from the session and writes it as a DRAFT skill in skills/learned/. Triggers after 'ya quedo', 'fixed', 'shipped', 'merged' on something that took several investigation steps, or via /learn."
 metadata:
   type: brain-routine
   trigger: post-resolution (auto) or /learn (manual)

--- a/skills/skillsmp/SKILL.md
+++ b/skills/skillsmp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skillsmp
-description: "Busca, descubre e instala agent skills desde skillsmp.com, la coleccion abierta mas grande de archivos SKILL.md. Dispara al pedir 'busca skills para X', instalar uno de skillsmp, o pedir recomendaciones de skills de la comunidad."
+description: "Searches, discovers and installs agent skills from skillsmp.com, the largest open collection of SKILL.md files. Triggers on 'busca skills para X', on installing one from skillsmp, or on asking for community skill recommendations."
 ---
 
 # SkillsMP - Agent Skills Marketplace Integration

--- a/skills/snowflake-dbt-pitfalls/SKILL.md
+++ b/skills/snowflake-dbt-pitfalls/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: snowflake-dbt-pitfalls
-description: "Trampas de Snowflake y dbt que fallan en silencio o destruyen datos: CREATE OR REPLACE, Dynamic Tables, PIVOT, freshness de sources.yml, modelos versionados. Cada una con su prevencion."
+description: "Snowflake and dbt traps that fail silently or destroy data: CREATE OR REPLACE, Dynamic Tables, PIVOT, sources.yml freshness, versioned models. Each one with its prevention."
 ---
 
 # Snowflake and dbt pitfalls (silent / destructive)

--- a/skills/social-video-mining/SKILL.md
+++ b/skills/social-video-mining/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: social-video-mining
-description: "Extrae insights de video corto (TikTok, Shorts, Reels, Douyin) sin speech-to-text de paga: yt-dlp, ffmpeg y vision sobre los frames. Usalo cuando el texto en pantalla carga la senal o cuando no hay transcript."
+description: "Extracts insights from short video (TikTok, Shorts, Reels, Douyin) without paid speech-to-text: yt-dlp, ffmpeg and vision over the frames. Use it when on-screen text carries the signal or when there is no transcript."
 ---
 
 # Social Video Mining — Frames Over Audio

--- a/skills/sora/SKILL.md
+++ b/skills/sora/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "sora"
-description: "Genera, edita, extiende, lista o descarga videos de Sora, crea referencias de personaje y corre colas locales con scripts/sora.py. Requiere OPENAI_API_KEY y acceso a la API de Sora."
+description: "Generates, edits, extends, lists or downloads Sora videos, creates character references and runs local queues with scripts/sora.py. Requires OPENAI_API_KEY and access to the Sora API."
 ---
 
 

--- a/skills/spacetimedb-backend-as-database/SKILL.md
+++ b/skills/spacetimedb-backend-as-database/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spacetimedb-backend-as-database
-description: "Base de datos que REEMPLAZA al backend: la logica corre como modulos dentro de la DB y los clientes se suscriben al estado vivo, sin capa API. Para multijugador en tiempo real. Paradigma nuevo, no default."
+description: "A database that REPLACES the backend: logic runs as modules inside the DB and clients subscribe to live state, with no API layer. For real-time multiplayer. A new paradigm, not a default."
 ---
 
 # SpacetimeDB — Database-as-Backend

--- a/skills/stream-transcript-dom-scrape/SKILL.md
+++ b/skills/stream-transcript-dom-scrape/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stream-transcript-dom-scrape
-description: "Cuando una grabacion de Microsoft Stream es de solo lectura y la descarga del transcript dice 'sin permiso', el reproductor igual renderiza el texto en el DOM y Playwright lo captura. Ojo: puede constituir elusion bajo el acuerdo de servicios de MS."
+description: "When a Microsoft Stream recording is read-only and the transcript download says 'no permission', the player still renders the text in the DOM and Playwright captures it. Careful: this may amount to circumvention under the MS services agreement."
 metadata:
   short-description: "Microsoft Stream transcript DOM-scrape (with legal caveat)"
 ---

--- a/skills/stripe-payments/SKILL.md
+++ b/skills/stripe-payments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stripe-payments
-description: "Elige e implementa el tier correcto de Stripe (Payment Link, Checkout, Elements, Connect, Billing), con registro del MCP, CLI local e higiene de llaves. Usalo al anadir donate, checkout o suscripcion, o al comparar contra PayPal."
+description: "Pick and implement the right Stripe tier (Payment Link, Checkout, Elements, Connect, Billing), with MCP registration, local CLI and key hygiene. Use it when adding donate, checkout or subscription, or when comparing against PayPal."
 ---
 
 # Stripe Payments — Pick the Right Tier First

--- a/skills/summarize-100/SKILL.md
+++ b/skills/summarize-100/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: summarize-100
-description: "Comprime cualquier tema, documento o respuesta a ~100 palabras, las mas densas semanticamente. Dispara con '100 palabras', 'version 100', 'tldr 100', 'elevator pitch', 'comprime a 100'."
+description: "Compresses any topic, document or answer to ~100 words, the most semantically dense ones. Triggers on '100 palabras', 'version 100', 'tldr 100', 'elevator pitch', 'comprime a 100'."
 ---
 
 # summarize-100 — 100-Word Compression Skill

--- a/skills/tabularis-db-client/SKILL.md
+++ b/skills/tabularis-db-client/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tabularis-db-client
-description: "Cliente SQL open-source para PostgreSQL, MySQL y SQLite con servidor MCP integrado, Apache 2.0. Para recomendar un GUI de base a un cliente o exponer una DB a agentes sin entregar credenciales. Complementa a querymaster."
+description: "Open-source SQL client for PostgreSQL, MySQL and SQLite with a built-in MCP server, Apache 2.0. To recommend a database GUI to a client or expose a DB to agents without handing over credentials. Complements querymaster."
 ---
 
 # Tabularis — DB Client with AI + Built-in MCP Server

--- a/skills/teams-1on1-send-no-chat-read/SKILL.md
+++ b/skills/teams-1on1-send-no-chat-read/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: teams-1on1-send-no-chat-read
-description: "Manda un mensaje 1:1 de Teams por Graph API aunque el token NO traiga scopes Chat.Read: deriva el chat ID de los OIDs ordenados en la forma canonica 19:{oid1}_{oid2}@unq.gbl.spaces."
+description: "Sends a Teams 1:1 message through the Graph API even when the token does NOT carry Chat.Read scopes: derives the chat ID from the sorted OIDs in the canonical form 19:{oid1}_{oid2}@unq.gbl.spaces."
 metadata:
   short-description: Send 1:1 Teams chat without Chat.Read scope (deterministic chat-id derivation)
   status: stable

--- a/skills/theory-plus-practice-prompts/SKILL.md
+++ b/skills/theory-plus-practice-prompts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: theory-plus-practice-prompts
-description: "Todo documento tecnico largo que explica un marco y demuestra un caso DEBE llevar prompts ejecutables con datos reales junto a las afirmaciones. Ni teoria sin prompts ni prompts sin teoria. Aplica a POCs, whitepapers y entregables."
+description: "Any long technical document that explains a framework and demonstrates a case MUST carry runnable prompts with real data next to the claims. No theory without prompts, no prompts without theory. Applies to POCs, whitepapers and deliverables."
 ---
 
 # theory-plus-practice-prompts

--- a/skills/token-efficient-prompting/SKILL.md
+++ b/skills/token-efficient-prompting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: token-efficient-prompting
-description: "Reduce 50-75% los tokens de salida sin perder senal, eliminando adulacion, relleno, preambulo y sugerencias no pedidas. Dispara al armar el CLAUDE.md de un proyecto nuevo o al configurar pipelines de agentes que necesitan salida terse y parseable."
+description: "Cuts output tokens by 50-75% without losing signal, removing flattery, filler, preamble and unrequested suggestions. Triggers when writing the CLAUDE.md of a new project or configuring agent pipelines that need terse, parseable output."
 ---
 
 # Token-Efficient Prompting

--- a/skills/tramite-mx-assistant/SKILL.md
+++ b/skills/tramite-mx-assistant/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tramite-mx-assistant
-description: "Asistente de tramites gubernamentales MX: maneja el portal con agent-browser, se DETIENE en captcha, OTP y pago con tarjeta, y recoge el PDF del correo. Para antecedentes penales, actas, apostillas, citas consulares, SAT e IMSS."
+description: "Assistant for MX government procedures: drives the portal with agent-browser, STOPS at captcha, OTP and card payment, and picks up the PDF from email. For criminal-record checks, civil registry certificates, apostilles, consular appointments, SAT and IMSS."
 ---
 
 # Trámite MX Assistant (asistente de trámites guiado)

--- a/skills/verify-generated-config-identifiers/SKILL.md
+++ b/skills/verify-generated-config-identifiers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-generated-config-identifiers
-description: "Config generada schema-valida no es semanticamente correcta: verifica cada identificador externo (metrica, campo, columna, env key) contra la doc del vendor antes de enviar. Dispara al generar dashboards, monitores, IaC o pipelines."
+description: "Schema-valid generated config is not semantically correct: check every external identifier (metric, field, column, env key) against the vendor docs before sending. Triggers when generating dashboards, monitors, IaC or pipelines."
 metadata:
   type: reference
 ---

--- a/skills/verify-root-cause-before-claiming/SKILL.md
+++ b/skills/verify-root-cause-before-claiming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-root-cause-before-claiming
-description: "Antes de decirle a alguien la CAUSA de una falla, verificala contra el dato, no contra el sintoma. Una causa plausible sin comprobar dana mas la confianza que decir 'la confirmo en un momento'. Dispara al escribir 'fallo porque' o 'se debe a'."
+description: "Before telling anyone the CAUSE of a failure, verify it against the data, not against the symptom. A plausible unverified cause hurts trust more than saying 'I will confirm it shortly'. Triggers when writing 'fallo porque' or 'se debe a'."
 metadata:
   type: feedback
 ---

--- a/skills/vibevoice-elevenlabs-alternative/SKILL.md
+++ b/skills/vibevoice-elevenlabs-alternative/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibevoice-elevenlabs-alternative
-description: "Modelo open-source de sintesis de voz de Microsoft, local y en tiempo real, sustituto de ElevenLabs. MIT. Para clientes que no pueden mandar audio a un tercero o cuando el costo por minuto se come el margen."
+description: "Microsoft open-source speech synthesis model, local and real-time, a stand-in for ElevenLabs. MIT. For clients that cannot send audio to a third party, or when the per-minute cost eats the margin."
 ---
 
 # VibeVoice — Microsoft's Open-Source Voice Synthesis

--- a/skills/video-commercial-production/SKILL.md
+++ b/skills/video-commercial-production/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: video-commercial-production
-description: "Produce comerciales en video HD 9:16 desde paginas HTML animadas con GSAP, capturando con Playwright y codificando con ffmpeg. Salida compatible con WhatsApp, Instagram y TikTok. Dispara con 'video', 'comercial', 'MP4', 'Reel', 'video desde HTML', 'record animation'."
+description: "Produces HD 9:16 video commercials from GSAP-animated HTML pages, capturing with Playwright and encoding with ffmpeg. Output works on WhatsApp, Instagram and TikTok. Triggers on 'video', 'comercial', 'MP4', 'Reel', 'video desde HTML', 'record animation'."
 ---
 
 # Video Commercial Production

--- a/skills/wa-guardia/SKILL.md
+++ b/skills/wa-guardia/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wa-guardia
-description: Modo guardia sobre un chat de mensajeria. Arma un watcher cuando un turno cierra esperando respuesta de un tercero, y lee lo pendiente al retomar el trabajo de un arm. Usar cuando se mande un mensaje que espera contestacion, cuando el operador pida leer un chat, o al empezar a trabajar con un arm que tiene canal de chat vivo.
+description: "Watch mode over a messaging chat. Arms a watcher when a turn closes waiting on a reply from a third party, and reads what is pending when work on an arm resumes. Use it when sending a message that expects an answer, when the operator asks to read a chat, or when starting work on an arm with a live chat channel."
 ---
 
 # Guardia de chat

--- a/skills/web-perf/SKILL.md
+++ b/skills/web-perf/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web-perf
-description: "Audita rendimiento web con Chrome DevTools MCP: Core Web Vitals (LCP, INP, CLS), recursos que bloquean el render, cadenas de red y saltos de layout. Dispara al pedir auditar, perfilar u optimizar la carga."
+description: "Audits web performance with the Chrome DevTools MCP: Core Web Vitals (LCP, INP, CLS), render-blocking resources, network chains and layout shifts. Triggers when asked to audit, profile or optimize load."
 ---
 
 # Web Performance Audit

--- a/skills/windows-brain-script-portability/SKILL.md
+++ b/skills/windows-brain-script-portability/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: windows-brain-script-portability
-description: "Scripts de ~/.claude/scripts/ que corren en un cerebro Windows: usa el shim python3.cmd y no python3 pelado, y reconfigura stdout a UTF-8 si imprimes simbolos. Usalo al escribir un script del cerebro o al triagear un crash solo-Windows."
+description: "Scripts in ~/.claude/scripts/ that run on a Windows brain: use the python3.cmd shim and not bare python3, and reconfigure stdout to UTF-8 if you print symbols. Use it when writing a brain script or triaging a Windows-only crash."
 metadata:
   type: pattern-reference
   origin: session-learn-extractor — 2026-06-05 after iterating on the same UnicodeEncodeError + python3-stub pair across e5aa67b → install-runners.py → canon-render.py

--- a/skills/winui-app/SKILL.md
+++ b/skills/winui-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: winui-app
-description: "Crea, desarrolla y disena apps de escritorio WinUI 3 con C# y Windows App SDK segun guia oficial de Microsoft y CommunityToolkit. Cubre XAML, navegacion, theming, accesibilidad y despliegue."
+description: "Create, build and design WinUI 3 desktop apps with C# and the Windows App SDK following Microsoft's official guidance and CommunityToolkit. Covers XAML, navigation, theming, accessibility and deployment."
 ---
 
 # WinUI App


### PR DESCRIPTION
Follow-up to #270. The capability manifest rendered 60+ Spanish description rows because the source frontmatters and script docstrings were Spanish.

- 73 `skills/*/SKILL.md`: only the frontmatter `description:` value changed (one line each, YAML double-quoted). Quoted Spanish trigger phrases that users type ('mira la imagen', 'baja el transcript', 'crear un arm'...) stay verbatim so the connectome keeps matching them; the label around them is English.
- 9 `scripts/*.py` module docstrings plus the full `wa-soporte.sh` comment header: English, with detector patterns, CLI flags and operator-canonical sayings kept in their original wording (with an English gloss where they are prose).
- `docs/CAPABILITIES.md` regenerated; `capability_manifest.py --check` passes.
- Skill `name:` fields were already English; SKILL.md bodies are untouched (still Spanish in many skills, separate scope).

Verification: YAML loads for all 71 frontmatters; `py_compile` 9/9; `--selftest` on the 7 gates that expose it identical to the pre-edit baseline (`d__stop__wa-guardia.py --selftest` fails with a pre-existing TypeError, byte-identical before and after, noted for a separate fix); `check-generic` clean; no em-dash in any added line.

Side effect to know: the connectome is TF-IDF over skill text, so recall for Spanish prompts leans a bit more on the (still Spanish) bodies and the quoted triggers; the neural map rebuild in CI reflects the new text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPPcRmXDTe7ZSKbCX5dosS