### PR TITLE
fix(wa-soporte): bridge identity from private config, fail-closed without it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Without this the link shows up untracked in every worktree and could be
 # committed, publishing the private path layout.
 company
+# The public seed templates under templates/company/ are framework, not company data.
+!templates/company/
+!templates/company/**
 
 # External reference repos (cloned separately, not part of the brain repo)
 *-ref/

--- a/scripts/wa-soporte.sh
+++ b/scripts/wa-soporte.sh
@@ -221,10 +221,14 @@ if os.environ.get("WA_VIA") == "ssm":
         except Exception:
             continue
         if estado in ("Success", "Failed", "Cancelled", "TimedOut"):
-            print(salida.strip() if estado == "Success" else json.dumps({"success": False, "message": f"SSM {estado}"}))
+            if estado != "Success":
+                print(json.dumps({"success": False, "message": f"SSM {estado}"}))
+                raise SystemExit(1)
+            print(salida.strip())
             break
     else:
         print(json.dumps({"success": False, "message": "SSM sin respuesta"}))
+        raise SystemExit(1)
 else:
     req = urllib.request.Request(f"http://localhost:{puerto}/api/send", data=datos,
                                  headers={"Content-Type": "application/json"})

--- a/scripts/wa-soporte.sh
+++ b/scripts/wa-soporte.sh
@@ -82,7 +82,10 @@ if [ "$VIA" = "ssm" ]; then
 import json, sys
 try:
     r = json.load(open(sys.argv[1]))["puentes"]["soporte"]["remoto"]
-    print(r["instancia"], r["region"], r["perfil"])
+    vals = [str(r[k]) for k in ("instancia", "region", "perfil")]
+    if any(not v or v.startswith("{{") for v in vals):
+        raise ValueError("placeholder value still in place, fill the template")
+    print(*vals)
 except (OSError, KeyError, ValueError, TypeError) as e:
     print(f"puentes.soporte.remoto (instancia/region/perfil) missing in {sys.argv[1]}: {e}", file=sys.stderr)
     raise SystemExit(1)
@@ -98,12 +101,14 @@ fi
 # The instance id, region, profile and staging bucket come from the same
 # PRIVATE config (`puentes.soporte.remoto`), never from this published file.
 if [ -n "$archivo" ]; then
-  respuesta=$(WA_MENCIONES="${WA_MENCIONES:-}" python3 - "$destinatario" "$mensaje" "$archivo" "$PUERTO_SOPORTE" <<'PY'
+  # `if ! x=$(...)` keeps set -e from aborting before the JSON is echoed: every
+  # fail-closed branch inside prints its reason on stdout and exits 1.
+  if ! respuesta=$(WA_MENCIONES="${WA_MENCIONES:-}" python3 - "$destinatario" "$mensaje" "$archivo" "$PUERTO_SOPORTE" "$CONFIG_PUENTES" <<'PY'
 import base64, json, os, shlex, subprocess, sys, time, uuid
 from pathlib import Path
 
 destinatario, mensaje, archivo, puerto = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
-cfg_path = Path.home() / ".claude" / "company" / "config" / "wa-puentes.json"
+cfg_path = Path(sys.argv[5])
 try:
     remoto = json.loads(cfg_path.read_text())["puentes"]["soporte"]["remoto"]
     instancia, region = remoto["instancia"], remoto["region"]
@@ -176,12 +181,15 @@ finally:
     subprocess.run(aws + ["s3", "rm", s3_uri, "--only-show-errors"],
                    capture_output=True, timeout=60)
 PY
-)
+  ); then
+    echo "$respuesta"
+    exit 1
+  fi
   echo "$respuesta"
   exit 0
 fi
 
-respuesta=$(WA_MENCIONES="${WA_MENCIONES:-}" WA_VIA="$VIA" WA_INSTANCIA="$INSTANCIA_PUENTE" WA_REGION="$REGION_PUENTE" WA_PERFIL="$PERFIL_PUENTE" python3 - "$destinatario" "$mensaje" "$PUERTO_SOPORTE" <<'PY'
+if ! respuesta=$(WA_MENCIONES="${WA_MENCIONES:-}" WA_VIA="$VIA" WA_INSTANCIA="$INSTANCIA_PUENTE" WA_REGION="$REGION_PUENTE" WA_PERFIL="$PERFIL_PUENTE" python3 - "$destinatario" "$mensaje" "$PUERTO_SOPORTE" <<'PY'
 import json, os, subprocess, sys, time, urllib.request
 destinatario, mensaje, puerto = sys.argv[1], sys.argv[2], sys.argv[3]
 cuerpo = {"recipient": destinatario, "message": mensaje}
@@ -223,5 +231,8 @@ else:
     with urllib.request.urlopen(req, timeout=30) as r:
         print(r.read().decode())
 PY
-)
+); then
+  echo "$respuesta"
+  exit 1
+fi
 echo "$respuesta"

--- a/scripts/wa-soporte.sh
+++ b/scripts/wa-soporte.sh
@@ -65,17 +65,38 @@ fi
 # to the personal bridge: it sends DIRECTLY over SSM by running curl ON the
 # server. The channel no longer depends on this laptop; it only needs the AWS
 # ops profile credentials.
-INSTANCIA_PUENTE="i-0c0112bf1431dc99e"
-REGION_PUENTE="mx-central-1"
-PERFIL_PUENTE="dataqbs-ops"
 VIA="tunel"
 if ! ss -lnt 2>/dev/null | grep -q ":${PUERTO_SOPORTE} "; then
   VIA="ssm"
 fi
 
+# The bridge's instance id, region and AWS profile are deployment identity,
+# not framework code: they live in the PRIVATE config (gitignored), the same
+# `puentes.soporte.remoto` block the attachment path already reads. The tunnel
+# path never needs them; the SSM path refuses to run without them (fail-closed,
+# never a fallback to the personal bridge).
+CONFIG_PUENTES="${OCTO_WA_PUENTES:-$HOME/.claude/company/config/wa-puentes.json}"
+INSTANCIA_PUENTE=""; REGION_PUENTE=""; PERFIL_PUENTE=""
+if [ "$VIA" = "ssm" ]; then
+  if ! remoto=$(python3 - "$CONFIG_PUENTES" <<'PY'
+import json, sys
+try:
+    r = json.load(open(sys.argv[1]))["puentes"]["soporte"]["remoto"]
+    print(r["instancia"], r["region"], r["perfil"])
+except (OSError, KeyError, ValueError, TypeError) as e:
+    print(f"puentes.soporte.remoto (instancia/region/perfil) missing in {sys.argv[1]}: {e}", file=sys.stderr)
+    raise SystemExit(1)
+PY
+  ); then
+    echo '{"success": false, "message": "no local tunnel and no private bridge config: see templates/company/config/wa-puentes.json.template"}'
+    exit 1
+  fi
+  read -r INSTANCIA_PUENTE REGION_PUENTE PERFIL_PUENTE <<< "$remoto"
+fi
+
 # ---- Attachment: the file must exist on the BRIDGE's disk -----------------
-# The instance id, region, profile and staging bucket come from the PRIVATE
-# config, not from here: this script is published.
+# The instance id, region, profile and staging bucket come from the same
+# PRIVATE config (`puentes.soporte.remoto`), never from this published file.
 if [ -n "$archivo" ]; then
   respuesta=$(WA_MENCIONES="${WA_MENCIONES:-}" python3 - "$destinatario" "$mensaje" "$archivo" "$PUERTO_SOPORTE" <<'PY'
 import base64, json, os, shlex, subprocess, sys, time, uuid

--- a/templates/company/config/wa-puentes.json.template
+++ b/templates/company/config/wa-puentes.json.template
@@ -32,8 +32,42 @@
     }
   },
   "vigilancia": {
+    "_nota": "Read by wa-guardia.py and wa-sin-respuesta.py. chats[] lists the client chats to watch; correo, canario and whatsapp are optional blocks for the silence sentry.",
     "puente": "soporte",
     "umbral_minutos": 30,
-    "chats": []
+    "chats": [
+      {
+        "jid": "{{CHAT_JID}}",
+        "quien": "{{DISPLAY_NAME}}",
+        "puente": "soporte",
+        "cliente": "{{ARM_CODE}}",
+        "canal": "whatsapp",
+        "prueba": false
+      }
+    ],
+    "correo": {
+      "umbral_minutos": 120,
+      "dias": 7,
+      "secretos": {
+        "region": "{{AWS_REGION}}",
+        "credenciales": "{{SECRETS_MANAGER_NAME_FOR_MAIL_CREDENTIALS}}",
+        "claves": "{{SECRETS_MANAGER_NAME_FOR_MAIL_KEYS}}"
+      },
+      "remitentes": [
+        {
+          "quien": "{{DISPLAY_NAME}}",
+          "de": "{{SENDER_EMAIL}}",
+          "cliente": "{{ARM_CODE}}",
+          "canal": "correo",
+          "prueba": false
+        }
+      ]
+    },
+    "canario": {
+      "tema": "{{SNS_TOPIC_ARN_FOR_THE_CANARY}}"
+    },
+    "whatsapp": {
+      "destino": "{{JID_THAT_RECEIVES_SILENCE_ALERTS}}"
+    }
   }
 }

--- a/templates/company/config/wa-puentes.json.template
+++ b/templates/company/config/wa-puentes.json.template
@@ -1,0 +1,39 @@
+{
+  "_comment": [
+    "Private bridge config for the WhatsApp scripts (wa-soporte.sh, wa-guardia.py, wa-sin-respuesta.py).",
+    "Copy to ~/.claude/company/config/wa-puentes.json (gitignored) and fill the values.",
+    "Deployment identity (instance ids, regions, profiles, buckets) lives here, never in the published scripts."
+  ],
+  "puentes": {
+    "soporte": {
+      "puerto": 8081,
+      "dir": "{{PATH_TO_SUPPORT_BRIDGE_CHECKOUT}}",
+      "bin": "{{PATH_TO_SUPPORT_BRIDGE_BINARY}}",
+      "db": "{{PATH_TO_SUPPORT_BRIDGE_MESSAGES_DB}}",
+      "propio": "{{SUPPORT_NUMBER_JID}}",
+      "remoto": {
+        "_nota": "Where the support bridge runs when it is not on this machine. wa-soporte.sh reads instancia/region/perfil when no local tunnel is listening on puerto, and bucket_tmp for attachments.",
+        "instancia": "{{EC2_INSTANCE_ID}}",
+        "region": "{{AWS_REGION}}",
+        "perfil": "{{AWS_CLI_PROFILE}}",
+        "unidad": "{{SYSTEMD_UNIT_NAME}}",
+        "db": "{{REMOTE_PATH_TO_MESSAGES_DB}}",
+        "sesion": "{{REMOTE_PATH_TO_SESSION_DIR}}",
+        "tunel": "{{SSM_PORT_FORWARD_COMMAND_OR_ALIAS}}",
+        "bucket_tmp": "{{S3_STAGING_BUCKET_FOR_ATTACHMENTS}}"
+      }
+    },
+    "personal": {
+      "puerto": 8080,
+      "dir": "{{PATH_TO_PERSONAL_BRIDGE_CHECKOUT}}",
+      "bin": "{{PATH_TO_PERSONAL_BRIDGE_BINARY}}",
+      "db": "{{PATH_TO_PERSONAL_BRIDGE_MESSAGES_DB}}",
+      "propio": null
+    }
+  },
+  "vigilancia": {
+    "puente": "soporte",
+    "umbral_minutos": 30,
+    "chats": []
+  }
+}


### PR DESCRIPTION
Surfaced while translating the header in #273: `scripts/wa-soporte.sh` hardcoded the support bridge's EC2 instance id, region and AWS profile while its own comment said those come from the private config. Not secrets, but deployment identity in a published file.

- The SSM path now reads `puentes.soporte.remoto.{instancia,region,perfil}` from `company/config/wa-puentes.json` (override with `OCTO_WA_PUENTES`), the same block the attachment path already read. The tunnel path is untouched and needs none of it.
- Fail-closed: no local tunnel and no private config returns `{"success": false, ...}` with exit 1 and points at the template. It never falls back to the personal bridge.
- New `templates/company/config/wa-puentes.json.template` documents the shape with placeholders only.
- `.gitignore`: the bare `company` rule (needed for the worktree symlink) also swallowed `templates/company/**`; an explicit negation keeps the public seed templates tracked by rule rather than by force-add. Same class as the fixture-seeds lesson.

Verified: `bash -n`; fail-closed path exercised in a fake HOME (exit 1, JSON error); the loader reads all three keys from the real private config on this machine; `check-generic` clean on the staged files; no instance id or profile name left in any tracked file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPPcRmXDTe7ZSKbCX5dosS