### PR TITLE
docs(changelog): backfill v7.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ machine-generated growth ledger lives at
 
 ## [Unreleased]
 
+## [2026-09-07]: v7.2.4
+- fix(wa-soporte): bridge identity from private config, fail-closed without it (#275)
+- docs(changelog): backfill v7.2.3 (#274)
+
 ## [2026-09-07]: v7.2.3
 - docs(i18n): English descriptions for 71 skills and 10 script headers (#273)
 - docs(changelog): backfill v7.2.2 (#272)


### PR DESCRIPTION
Heal branch pushed by version-bump.yml after cutting v7.2.4 (PR step fails with HTTP 401 on OCTORATO_PAT; opened by hand). Changelog-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPPcRmXDTe7ZSKbCX5dosS