### PR TITLE
docs(changelog): backfill v7.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ machine-generated growth ledger lives at
 
 ## [Unreleased]
 
+## [2026-09-07]: v7.2.5
+- docs(architecture): v8 kernel plan, panel-reviewed (process, isolation, journal, package) (#278)
+- docs(changelog): backfill v7.2.4 (#276)
+
 ## [2026-09-07]: v7.2.4
 - fix(wa-soporte): bridge identity from private config, fail-closed without it (#275)
 - docs(changelog): backfill v7.2.3 (#274)


### PR DESCRIPTION
Heal branch pushed by version-bump.yml after cutting v7.2.5 (PR step fails with HTTP 401 on OCTORATO_PAT; opened by hand). Changelog-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPPcRmXDTe7ZSKbCX5dosS