### PR TITLE
feat(kernel): phase 1a-2, subagent exit hook and kernel-process-live doctor check (v8)

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -9,10 +9,10 @@
 | Skills | 233 |
 | Agents | 167 |
 | Divisions | 13 |
-| Scripts: wired | 111 |
+| Scripts: wired | 112 |
 | Scripts: orphan | 7 |
 | Rules | 74 |
-| Hook entries | 45 |
+| Hook entries | 48 |
 
 ## Skills (233)
 
@@ -486,7 +486,7 @@
 | Tool Evaluator | Expert technology assessment specialist focused on evaluating, testing, and recommending tools, software, and platforms ... |
 | Workflow Optimizer | Expert process improvement specialist focused on analyzing, optimizing, and automating workflows across all business fun... |
 
-## Scripts (118)
+## Scripts (119)
 
 | Script | Purpose | Status |
 |---|---|---|
@@ -588,6 +588,7 @@
 | r__pretool-write__base-freshness.py | r__pretool-write__base-freshness.py: PreToolUse warner for a STALE EDIT BASE. | wired |
 | r__session__proc-register.py | r__session__proc-register.py: SessionStart reflex that opens a kernel process. | wired |
 | r__subagent-start__proc-register.py | r__subagent-start__proc-register.py: SubagentStart reflex, a child process. | wired |
+| r__subagent-stop__proc-exit.py | r__subagent-stop__proc-exit.py: SubagentStop reflex, the child's exit line. | wired |
 | r__subagent-stop__qa-receipt.py | r__subagent-stop__qa-receipt.py: SubagentStop reflex that writes a QA receipt. | wired |
 | receipt_ledger.py | receipt_ledger.py: the v7 receipt ledger (shared library, not a hook). | wired |
 | repo_watch.py | repo_watch.py , daily monitor for high-value GitHub repos. | wired |
@@ -723,4 +724,6 @@
 | PreToolUse | budget-check.py, config-ship-verify.py, delegate-gate.py, dimension-awareness-hook.py, g__pretool-bash__git-discipline.py, g__pretool-mcp__chat-context.py, g__pretool-mcp__outward-send.py, g__pretool__kernel.py, grafo-gate.py, qa-merge-gate.py, r__pretool-write__base-freshness.py, secrets-grep-guard.py, trace-hook.py |
 | SessionStart | merge-hooks.py, r__session__proc-register.py, session-isolation-hook.py |
 | Stop | cadence-stop-hook.py, claim-verify-stop.py, d__stop__wa-guardia.py, g__stop__defer-today.py, g__stop__delegation-audit.py, g__stop__draft-promise.py, g__stop__goal-anchor.py, g__stop__paste-ready-raw.py, g__stop__unsourced-absence.py, g__stop__unsourced-attribute.py, grafo-ledger-check.py, no-pause-suggestion.py, source-attribution-check.py, trace-hook.py |
+| SubagentStart | r__subagent-start__proc-register.py |
+| SubagentStop | r__subagent-stop__proc-exit.py, r__subagent-stop__qa-receipt.py |
 | UserPromptSubmit | 4d-reminder.py, arm-recall-hook.py, brain-memory-recall.py, connectome-heartbeat.py, eye-check.py, grafo-turn-reset.py, inbox-sweep-reflex.py, trace-hook.py |

--- a/hooks.json
+++ b/hooks.json
@@ -383,6 +383,12 @@
           "statusMessage": "🧾 receipt: QA verdict recorded",
           "timeout": 5,
           "type": "command"
+        },
+        {
+          "command": "python3 ~/.claude/scripts/r__subagent-stop__proc-exit.py",
+          "statusMessage": "⚙ kernel: closing this subagent's record...",
+          "timeout": 5,
+          "type": "command"
         }
       ],
       "matcher": "*"

--- a/registry/fixtures/ARCHITECTURE.kernel-process/subagent_stop.json
+++ b/registry/fixtures/ARCHITECTURE.kernel-process/subagent_stop.json
@@ -1,0 +1,9 @@
+{
+  "hook_event_name": "SubagentStop",
+  "session_id": "kernel-selftest-session",
+  "agent_id": "kernel-selftest-agent",
+  "agent_type": "Reality Checker",
+  "transcript_path": "",
+  "agent_transcript_path": "",
+  "last_assistant_message": "Reviewed the diff and ran the tests. Two findings, both fixed."
+}

--- a/registry/rules.yaml
+++ b/registry/rules.yaml
@@ -1786,6 +1786,10 @@ rules:
     canonical_name: r__subagent-start__proc-register.py
     firing_event: SubagentStart
     firing_matcher: '*'
+  - kind: Reflex
+    canonical_name: r__subagent-stop__proc-exit.py
+    firing_event: SubagentStop
+    firing_matcher: '*'
   proof:
   - method: IN_HOOKS_JSON
     locator: SessionStart|*|r__session__proc-register.py
@@ -1793,8 +1797,14 @@ rules:
   - method: IN_HOOKS_JSON
     locator: SubagentStart|*|r__subagent-start__proc-register.py
     expect: present
+  - method: IN_HOOKS_JSON
+    locator: SubagentStop|*|r__subagent-stop__proc-exit.py
+    expect: present
   - method: EXIT_CODE
     locator: scripts/r__subagent-start__proc-register.py --selftest registry/fixtures/ARCHITECTURE.kernel-process
+    expect: 0
+  - method: EXIT_CODE
+    locator: scripts/r__subagent-stop__proc-exit.py --selftest registry/fixtures/ARCHITECTURE.kernel-process
     expect: 0
   liveness_required: FIRES
 - id: FLOW.kernel-journal

--- a/schemas/kernel-journal.schema.json
+++ b/schemas/kernel-journal.schema.json
@@ -56,6 +56,13 @@
     "last_ts": { "type": "number", "description": "open lines: last unjournaled call" },
     "ok": { "type": "boolean", "description": "exit lines: the subagent finished without an error" },
     "status": { "type": "string", "description": "exit lines: ok | error | quota" },
+    "tool_count": { "type": "integer", "minimum": 0, "description": "exit lines: how many tool calls this process journaled" },
+    "seq_before": { "type": "integer", "description": "exit lines: seq of the last line written before this one, -1 when the exit line is the first" },
+    "duration": { "type": "number", "minimum": 0, "description": "exit lines: seconds between start_ts and the exit" },
+    "spawn_tool_use_id": { "type": "string", "description": "exit lines: the tool_use id of the Agent call that spawned this process, from the harness meta.json; named apart from tool_use_id because that one identifies the call a tool line describes" },
+    "spawn_depth": { "type": "integer", "minimum": 0, "description": "exit lines: spawnDepth from the harness meta.json, how deep in the spawn tree this process sat" },
+    "model": { "type": "string", "description": "exit lines: the engine the child actually ran on, from the harness meta.json" },
+    "agent_transcript_path": { "type": "string", "description": "exit lines: the harness-written transcript of this subagent, the pointer a consumer re-verifies against" },
     "rule": { "type": "string", "description": "deny lines: the registry rule id that refused the call" },
     "reason": { "type": "string", "description": "deny lines: the refusal text shown to the model" }
   },

--- a/scripts/brain_doctor.py
+++ b/scripts/brain_doctor.py
@@ -1398,6 +1398,101 @@ def check_enforcement_floor(fix: bool) -> Result:
     return Result(key, PASS, ledger)
 
 
+def check_kernel_process_live(fix: bool) -> Result:
+    """v8 Phase 1a-2: prove the kernel's PROCESS record is real on THIS machine.
+
+    A selftest proves the hooks work on fixtures; it says nothing about the
+    table those hooks have actually been writing. So this reads the real one,
+    read-only, and asserts the invariant the later phases lean on: a process the
+    liveness rule calls LIVE has a journal. A live row with no journal is a
+    phantom, and Phase 2 would deny writes on its behalf forever. The newest
+    five chains are verified (tamper evidence is worthless unverified), and the
+    `open` lines of the last week are counted, so calls that ran unjournaled
+    under OCTO_KERNEL_OPEN are a number, never a guess.
+
+    Passes on a fresh install with no ptable at all, and never writes."""
+    key = "kernel-process-live"
+    for loc in ("scripts/r__subagent-start__proc-register.py --selftest "
+                "registry/fixtures/ARCHITECTURE.kernel-process",
+                "scripts/r__subagent-stop__proc-exit.py --selftest "
+                "registry/fixtures/ARCHITECTURE.kernel-process"):
+        script = loc.split()[0]
+        if not (CLAUDE_DIR / script).exists():
+            return Result(key, FAIL, f"{script} is missing", "restore the kernel hook")
+        cp = _run_selftest_locator(loc)
+        if cp.returncode != 0:
+            detail = (cp.stderr or cp.stdout or "").strip().splitlines()
+            return Result(key, FAIL,
+                          f"{Path(script).name} selftest failed: "
+                          + (detail[-1] if detail else f"exit {cp.returncode}"),
+                          "the register/exit reflexes no longer prove themselves; fix the hook or the fixture")
+    sys.path.insert(0, str(CLAUDE_DIR / "scripts"))
+    try:
+        import time
+
+        import kernel_proc
+    except Exception as e:
+        return Result(key, FAIL, f"cannot import kernel_proc: {e}", "restore scripts/kernel_proc.py")
+
+    notes = []
+    if not (CLAUDE_DIR / "hooks.json").exists():
+        notes.append("hooks.json absent")
+    else:
+        try:
+            wired = json.loads((CLAUDE_DIR / "hooks.json").read_text(encoding="utf-8"))
+        except ValueError:
+            wired = {}
+        if not wired.get("SubagentStart"):
+            notes.append("runtime fallback: no SubagentStart hook, a child's start line "
+                         "waits for its first tool call (PreToolUse[Agent] + SubagentStop only)")
+
+    table = kernel_proc.read_ptable()
+    procs = table.get("processes", {})
+    now = time.time()
+    live, phantom = [], []
+    for pid in procs:
+        if kernel_proc.is_live(pid, table, now):
+            live.append(pid)
+            if not os.path.exists(kernel_proc.journal_path(pid)):
+                phantom.append(pid)
+    if phantom:
+        return Result(key, FAIL,
+                      f"{len(phantom)} live process(es) with no journal: " + ", ".join(phantom[:5]),
+                      "a live row with no journal holds lanes nothing can release; "
+                      "delete the row from ~/.claude/.cache/kernel/ptable.json")
+
+    jdir = kernel_proc.journal_dir()
+    journals = []
+    if os.path.isdir(jdir):
+        for name in os.listdir(jdir):
+            if not name.endswith(".jsonl"):
+                continue
+            path = os.path.join(jdir, name)
+            try:
+                journals.append((os.stat(path).st_mtime, name[:-6]))
+            except OSError:
+                continue
+    journals.sort(reverse=True)
+    for _, pid in journals[:5]:
+        code, why = kernel_proc.verify_detail(pid)
+        if code != 0:
+            return Result(key, FAIL, f"journal chain broken for pid {pid}: {why}",
+                          "the journal is append-only and hash-chained; a broken chain is tamper "
+                          "evidence, read it before deleting the file")
+    opened = 0
+    cutoff = now - 7 * 24 * 3600
+    for mtime, pid in journals:
+        if mtime < cutoff:
+            continue
+        for line in kernel_proc.read_journal(pid):
+            if isinstance(line, dict) and line.get("kind") == "open" \
+                    and float(line.get("ts") or 0) >= cutoff:
+                opened += int(line.get("count") or 0)
+    msg = (f"2 selftests pass; {len(procs)} process row(s), {len(live)} live, all journaled; "
+           f"{min(len(journals), 5)} newest chain(s) verify; {opened} call(s) ran unjournaled in 7 days")
+    return Result(key, PASS, msg + ("; " + "; ".join(notes) if notes else ""))
+
+
 def check_querymaster_security_detector(fix: bool) -> Result:
     """Actually RUN the querymaster security-canon detector so SECURITY.querymaster-rules
     is genuinely lived, not presence-with-extra-steps.
@@ -1708,6 +1803,7 @@ CHECKS = [
     ("waiver-age", check_waiver_age),
     ("incident-fixture-coverage", check_incident_fixture_coverage),
     ("reflex-triage", check_reflex_triage),
+    ("kernel-process-live", check_kernel_process_live),
     ("querymaster-security-detector", check_querymaster_security_detector),
     ("rule-1-naming", check_naming),
     ("rule-1-orphans", check_orphan_hooks),

--- a/scripts/capability_manifest.py
+++ b/scripts/capability_manifest.py
@@ -235,9 +235,13 @@ def scan_hooks() -> dict[str, list[str]]:
     with hooks_file.open(encoding="utf-8") as f:
         data = json.load(f)
 
-    events = ["PostToolUse", "PreToolUse", "SessionStart", "Stop", "UserPromptSubmit"]
+    # Derived from hooks.json itself, never a hardcoded list: a wired event the
+    # list did not name (SubagentStart, SubagentStop, PermissionDenied) rendered
+    # as if the brain had no hook on it, and the manifest is what the doctor and
+    # the docs read.
+    events = [k for k, v in data.items() if not k.startswith("$") and isinstance(v, list)]
     result: dict[str, list[str]] = {}
-    for event in events:
+    for event in sorted(events):
         entries = data.get(event, [])
         basenames: list[str] = []
         for entry in entries:
@@ -407,12 +411,11 @@ def render(
         lines.append("")
 
     # Hooks
-    events = ["PostToolUse", "PreToolUse", "SessionStart", "Stop", "UserPromptSubmit"]
     lines.append("## Hooks")
     lines.append("")
     lines.append("| Event | Wired Scripts |")
     lines.append("|---|---|")
-    for event in events:
+    for event in sorted(hooks):
         scripts_list = hooks.get(event, [])
         cell = ", ".join(scripts_list) if scripts_list else "(none)"
         lines.append(f"| {event} | {cell} |")

--- a/scripts/kernel_proc.py
+++ b/scripts/kernel_proc.py
@@ -483,6 +483,38 @@ def is_live(pid, table: dict = None, now: float = None, ttl: int = TTL,
     return False
 
 
+def update_row(pid, fields: dict) -> bool:
+    """Merge `fields` into one ptable row, under the same lock `register` takes.
+
+    The row is the process's mutable half (the journal is the immutable one), so
+    every later phase writes it through here: Phase 1a-2 marks a process exited,
+    Phase 1b records a release, Phase 2 claims lanes. Returns False when the pid
+    has no row, which is not an error: a child whose register hook lost its race
+    still has a journal, and the journal is what the gates read.
+    """
+    pid = safe_pid(pid)
+    os.makedirs(kernel_dir(), exist_ok=True)
+    fh = None
+    try:
+        fh = open(ptable_lock_path(), "a")
+        _flock(fh)
+        table = read_ptable()
+        procs = table.setdefault("processes", {})
+        row = procs.get(pid)
+        if row is None:
+            return False
+        row.update({k: v for k, v in fields.items() if v is not None})
+        _write_ptable(table)
+        return True
+    finally:
+        if fh is not None:
+            _funlock(fh)
+            try:
+                fh.close()
+            except OSError:
+                pass
+
+
 def prune(table: dict, now: float = None) -> int:
     """Drop process rows that are gone for good, and only those.
 
@@ -736,6 +768,38 @@ def _scripts_dir() -> str:
     return os.path.dirname(os.path.abspath(__file__))
 
 
+def _fixture_dir(fixture_dir: str = None) -> str:
+    root = os.path.dirname(_scripts_dir())
+    fdir = fixture_dir or os.path.join("registry", "fixtures",
+                                       "ARCHITECTURE.kernel-process")
+    return fdir if os.path.isabs(fdir) else os.path.join(root, fdir)
+
+
+def _sandbox_env(sandbox: str) -> dict:
+    """A hook's env for a sandbox run: HOME rebound, open mode off, and every
+    GIT_* variable a git hook exports stripped, so a selftest launched from
+    pre-push never operates on the live repo (brain_doctor.py:47-56)."""
+    env = dict(os.environ)
+    for k in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX",
+              "GIT_COMMON_DIR", "GIT_OBJECT_DIRECTORY", "GIT_NAMESPACE",
+              "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_QUARANTINE_PATH",
+              "OCTO_KERNEL_OPEN"):
+        env.pop(k, None)
+    env["HOME"] = sandbox
+    env["USERPROFILE"] = sandbox
+    env["CLAUDE_SESSION_ID"] = "__selftest__"
+    return env
+
+
+def _feed(script: str, payload: dict, sandbox: str, env: dict) -> tuple:
+    """Run one hook script exactly as the harness does: payload on stdin."""
+    import subprocess
+    cp = subprocess.run([sys.executable, os.path.join(_scripts_dir(), script)],
+                        input=json.dumps(payload), capture_output=True,
+                        text=True, cwd=sandbox, env=env, timeout=30)
+    return cp.returncode, cp.stdout
+
+
 def selftest_flow(fixture_dir: str = None) -> int:
     """Prove the PROCESS primitive end to end in a sandbox HOME.
 
@@ -747,14 +811,9 @@ def selftest_flow(fixture_dir: str = None) -> int:
     --selftest so there is one implementation, not three.
     """
     import shutil
-    import subprocess
     import tempfile
 
-    scripts = _scripts_dir()
-    root = os.path.dirname(scripts)
-    fdir = fixture_dir or os.path.join("registry", "fixtures", "ARCHITECTURE.kernel-process")
-    if not os.path.isabs(fdir):
-        fdir = os.path.join(root, fdir)
+    fdir = _fixture_dir(fixture_dir)
     if not os.path.isdir(fdir):
         print(f"selftest FAIL: fixture dir missing: {fdir}", file=sys.stderr)
         return 1
@@ -767,21 +826,10 @@ def selftest_flow(fixture_dir: str = None) -> int:
         if os.path.isdir(seed):
             shutil.copytree(seed, sandbox, dirs_exist_ok=True)
 
-        env = dict(os.environ)
-        for k in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX",
-                  "GIT_COMMON_DIR", "GIT_OBJECT_DIRECTORY", "GIT_NAMESPACE",
-                  "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_QUARANTINE_PATH",
-                  "OCTO_KERNEL_OPEN"):
-            env.pop(k, None)
-        env["HOME"] = sandbox
-        env["USERPROFILE"] = sandbox
-        env["CLAUDE_SESSION_ID"] = "__selftest__"
+        env = _sandbox_env(sandbox)
 
         def feed(script: str, payload: dict) -> tuple:
-            cp = subprocess.run([sys.executable, os.path.join(scripts, script)],
-                                input=json.dumps(payload), capture_output=True,
-                                text=True, cwd=sandbox, env=env, timeout=30)
-            return cp.returncode, cp.stdout
+            return _feed(script, payload, sandbox, env)
 
         with open(os.path.join(fdir, "start.json"), encoding="utf-8") as fh:
             start = json.load(fh)
@@ -848,6 +896,122 @@ def selftest_flow(fixture_dir: str = None) -> int:
         return 1
     print(f"selftest PASS: process registered, journal chained "
           f"(kernel_proc vs {os.path.basename(fdir)})")
+    return 0
+
+
+def selftest_exit_flow(fixture_dir: str = None) -> int:
+    """Prove the exit line end to end in a sandbox HOME (v8 Phase 1a-2).
+
+    Runs the whole life of one child through the REAL hooks: register the
+    session, register the subagent, two tool calls, then SubagentStop. Asserts
+    the `exit` line closes the chain with status ok, the tool count and a
+    duration; that the meta.json fields are picked up from the session dir; that
+    a second SubagentStop writes no second ending; and that a child whose last
+    message opens with an error is recorded as `error`, not `ok`.
+    """
+    import shutil
+    import tempfile
+
+    fdir = _fixture_dir(fixture_dir)
+    stop_seed = os.path.join(fdir, "subagent_stop.json")
+    if not os.path.isfile(stop_seed):
+        print(f"selftest FAIL: fixture missing: {stop_seed}", file=sys.stderr)
+        return 1
+
+    sandbox = tempfile.mkdtemp(prefix="kernel-exit-selftest-")
+    saved = (os.environ.get("HOME"), os.environ.get("USERPROFILE"))
+    failures = []
+    try:
+        seed = os.path.join(fdir, "home")
+        if os.path.isdir(seed):
+            shutil.copytree(seed, sandbox, dirs_exist_ok=True)
+        env = _sandbox_env(sandbox)
+        with open(os.path.join(fdir, "start.json"), encoding="utf-8") as fh:
+            start = json.load(fh)
+        with open(os.path.join(fdir, "subagent_start.json"), encoding="utf-8") as fh:
+            sub = json.load(fh)
+        with open(stop_seed, encoding="utf-8") as fh:
+            stop = json.load(fh)
+        parent = str(start.get("session_id") or "")
+        child = str(sub.get("agent_id") or "")
+
+        # the harness's own layout: <projects>/<slug>/<session>.jsonl next to
+        # <projects>/<slug>/<session>/subagents/agent-<id>.{jsonl,meta.json}
+        sess_dir = os.path.join(sandbox, "projects", "sandbox", parent)
+        subs = os.path.join(sess_dir, "subagents")
+        os.makedirs(subs, exist_ok=True)
+        atp = os.path.join(subs, f"agent-{child}.jsonl")
+        with open(atp, "w", encoding="utf-8") as fh:
+            fh.write("")
+        with open(atp[:-6] + ".meta.json", "w", encoding="utf-8") as fh:
+            json.dump({"agentType": sub.get("agent_type"), "toolUseId": "toolu_seed",
+                       "spawnDepth": 1, "model": "sonnet"}, fh)
+        stop["transcript_path"] = sess_dir + ".jsonl"
+        stop["agent_transcript_path"] = atp
+
+        _feed("r__session__proc-register.py", start, sandbox, env)
+        _feed("r__subagent-start__proc-register.py", sub, sandbox, env)
+        for i in range(2):
+            _feed("g__pretool__kernel.py", {
+                "session_id": parent, "agent_id": child, "tool_name": "Bash",
+                "tool_use_id": f"toolu_exit_{i}", "tool_input": {"command": "true"},
+                "cwd": sandbox}, sandbox, env)
+        rc, out = _feed("r__subagent-stop__proc-exit.py", stop, sandbox, env)
+        if rc != 0 or out.strip():
+            failures.append(f"exit hook was not silent (rc={rc})")
+        _feed("r__subagent-stop__proc-exit.py", stop, sandbox, env)  # idempotent
+
+        os.environ["HOME"] = sandbox
+        os.environ["USERPROFILE"] = sandbox
+        lines = [l for l in read_journal(child) if isinstance(l, dict)]
+        exits = [l for l in lines if l.get("kind") == "exit"]
+        if len(exits) != 1:
+            failures.append(f"{len(exits)} exit line(s), a repeated SubagentStop must add none")
+        if exits:
+            e = exits[0]
+            if e.get("status") != "ok" or e.get("ok") is not True:
+                failures.append(f"exit status {e.get('status')} != ok")
+            if e.get("tool_count") != 2:
+                failures.append(f"tool_count {e.get('tool_count')} != 2")
+            if not isinstance(e.get("duration"), (int, float)):
+                failures.append("exit line carries no duration")
+            if e.get("agent_transcript_path") != atp:
+                failures.append("exit line does not carry the agent transcript path")
+            if e.get("spawn_depth") != 1 or e.get("model") != "sonnet" \
+                    or e.get("spawn_tool_use_id") != "toolu_seed":
+                failures.append("meta.json fields (spawnDepth, model, toolUseId) not recorded")
+        code, why = verify_detail(child)
+        if code != 0:
+            failures.append(f"chain broken after exit: {why}")
+        row = (read_ptable().get("processes", {}).get(safe_pid(child)) or {})
+        if not row.get("exited") or row.get("status") != "ok":
+            failures.append(f"ptable row not marked exited: {row}")
+        if is_live(child):
+            failures.append("an exited child still reads live")
+
+        # a failing child, in its own process so the exit line is the first one
+        bad = dict(stop)
+        bad["agent_id"] = child + "-bad"
+        bad["agent_transcript_path"] = ""
+        bad["last_assistant_message"] = "Error: the build did not compile."
+        _feed("r__subagent-stop__proc-exit.py", bad, sandbox, env)
+        bad_exits = [l for l in read_journal(bad["agent_id"])
+                     if isinstance(l, dict) and l.get("kind") == "exit"]
+        if not bad_exits or bad_exits[0].get("status") != "error":
+            failures.append("a child reporting an error was not recorded as error")
+    finally:
+        os.environ["HOME"] = saved[0] or ""
+        if saved[1] is None:
+            os.environ.pop("USERPROFILE", None)
+        else:
+            os.environ["USERPROFILE"] = saved[1]
+        shutil.rmtree(sandbox, ignore_errors=True)
+
+    if failures:
+        print("selftest FAIL: " + "; ".join(failures), file=sys.stderr)
+        return 1
+    print(f"selftest PASS: exit line written once, chained, ptable marked "
+          f"(proc-exit vs {os.path.basename(fdir)})")
     return 0
 
 

--- a/scripts/kernel_proc.py
+++ b/scripts/kernel_proc.py
@@ -490,9 +490,12 @@ def update_row(pid, fields: dict) -> bool:
     every later phase writes it through here: Phase 1a-2 marks a process exited,
     Phase 1b records a release, Phase 2 claims lanes. Returns False when the pid
     has no row, which is not an error: a child whose register hook lost its race
-    still has a journal, and the journal is what the gates read.
+    still has a journal, and the journal is what the gates read. A HOME with
+    no table at all returns False without creating the kernel dir or its lock.
     """
     pid = safe_pid(pid)
+    if not os.path.exists(ptable_path()):
+        return False
     os.makedirs(kernel_dir(), exist_ok=True)
     fh = None
     try:

--- a/scripts/r__subagent-stop__proc-exit.py
+++ b/scripts/r__subagent-stop__proc-exit.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""r__subagent-stop__proc-exit.py: SubagentStop reflex, the child's exit line.
+
+v8 Phase 1a-2 (docs/architecture/v8-kernel.md section 3). Phase 1a gave a
+subagent a pid, a parent and a journal; it had no ending. This reflex closes
+the record: one `exit` line carrying the status, the harness-written
+`agent_transcript_path`, how many tool calls the process made and how long it
+ran, plus the ptable row marked exited so `octo ps` (Phase 1b) and the lane
+gate (Phase 2) stop treating a finished child as a live holder.
+
+Three fields only the harness knows come from
+`<session-dir>/subagents/agent-<id>.meta.json` (spawnDepth, model, toolUseId):
+the depth of the spawn tree, the engine the child actually ran on (the ladder
+row that was really used, not the one intended) and the tool_use id of the
+Agent call that created it, which is the link back to the parent's own journal
+line. The file is read when present and its absence is never an error.
+
+Liveness (v8-kernel.md section 2) reads an `exit` line as terminal, so writing
+it twice would be writing a second ending: a repeated SubagentStop for the same
+pid is a no-op, not a second line.
+
+Never blocks. Fail-open on every error.
+
+Stdin:  {"session_id", "agent_id", "agent_type", "agent_transcript_path",
+         "transcript_path", "last_assistant_message", ...}
+Stdout: nothing. Exit always 0.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# A child that opens its final message with one of these is reporting its own
+# failure. Matched on the first line only: an error named mid-report is a
+# finding, not a crash.
+_ERROR_HEAD = ("error", "fatal", "traceback (most recent call last)", "exception")
+
+
+def status_of(text) -> str:
+    """ok | error, read from the child's last assistant message.
+
+    No final message at all is the crash case: the process ended without ever
+    saying anything. Everything that is not an opening error marker is ok.
+    """
+    # TODO(Phase 3, v8-kernel.md section 3): exit precedence is quota > error >
+    # ok. The hot-path gate writes the `quota` line; this hook will read the
+    # journal tail for it and stamp status "quota" ahead of both branches below.
+    s = str(text or "").strip()
+    if not s:
+        return "error"
+    first = s.splitlines()[0].strip().lstrip("*_# ").lower()
+    return "error" if first.startswith(_ERROR_HEAD) else "ok"
+
+
+def meta_path(payload: dict, pid: str) -> str:
+    """`<session-dir>/subagents/agent-<id>.meta.json`, or '' when unresolvable.
+
+    The agent transcript is that same path with a `.jsonl` suffix, so it is the
+    direct route. The main `transcript_path` is the fallback: the session dir is
+    the transcript file without its suffix (projects/<slug>/<session>.jsonl next
+    to projects/<slug>/<session>/subagents/).
+    """
+    atp = str(payload.get("agent_transcript_path") or "")
+    if atp.endswith(".jsonl"):
+        return atp[:-6] + ".meta.json"
+    tp = str(payload.get("transcript_path") or "")
+    if tp.endswith(".jsonl"):
+        name = pid if pid.startswith("agent-") else "agent-" + pid
+        return os.path.join(tp[:-6], "subagents", name + ".meta.json")
+    return ""
+
+
+def read_meta(path: str) -> dict:
+    """spawnDepth / model / toolUseId under the journal's snake_case names."""
+    if not path or not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    out = {}
+    for src, dst in (("spawnDepth", "spawn_depth"), ("model", "model"),
+                     ("toolUseId", "spawn_tool_use_id")):
+        if data.get(src) not in (None, ""):
+            out[dst] = data[src]
+    return out
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.read())
+    except Exception:
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+    try:
+        import time
+
+        import kernel_proc
+        pid = str(payload.get("agent_id") or "")
+        if not pid or kernel_proc.has_exit(pid):
+            return 0
+        lines = [l for l in kernel_proc.read_journal(pid) if isinstance(l, dict)]
+        tail = lines[-1] if lines else {}
+        now = time.time()
+        rec = {
+            "kind": "exit",
+            "status": status_of(payload.get("last_assistant_message")),
+            "tool_count": sum(1 for l in lines if l.get("kind") == "tool"),
+            "seq_before": int(tail.get("seq", -1)),
+            "duration": round(max(0.0, now - float(tail.get("start_ts") or now)), 3),
+        }
+        rec["ok"] = rec["status"] == "ok"
+        if payload.get("agent_transcript_path"):
+            rec["agent_transcript_path"] = str(payload["agent_transcript_path"])
+        if payload.get("agent_type"):
+            rec["type"] = str(payload["agent_type"])
+        rec.update(read_meta(meta_path(payload, pid)))
+        kernel_proc.append(pid, rec)
+        row = {k: rec[k] for k in ("status", "tool_count", "duration", "model",
+                                   "spawn_depth", "spawn_tool_use_id",
+                                   "agent_transcript_path") if k in rec}
+        row.update({"exited": True, "exit_ts": round(now, 6)})
+        kernel_proc.update_row(pid, row)
+    except Exception:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv:
+        import kernel_proc
+        _i = sys.argv.index("--selftest")
+        sys.exit(kernel_proc.selftest_exit_flow(
+            sys.argv[_i + 1] if len(sys.argv) > _i + 1 else None))
+    try:
+        sys.exit(main())
+    except Exception:
+        sys.exit(0)

--- a/scripts/r__subagent-stop__proc-exit.py
+++ b/scripts/r__subagent-stop__proc-exit.py
@@ -28,6 +28,7 @@ Stdout: nothing. Exit always 0.
 from __future__ import annotations
 
 import json
+import re
 import os
 import sys
 
@@ -36,7 +37,8 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # A child that opens its final message with one of these is reporting its own
 # failure. Matched on the first line only: an error named mid-report is a
 # finding, not a crash.
-_ERROR_HEAD = ("error", "fatal", "traceback (most recent call last)", "exception")
+# Word-bounded: "Errors were found and fixed" and "Exceptionally good" are ok.
+_ERROR_HEAD = re.compile(r"^(?:error|fatal|exception)\b|^traceback \(most recent call last\)")
 
 
 def status_of(text) -> str:
@@ -52,7 +54,7 @@ def status_of(text) -> str:
     if not s:
         return "error"
     first = s.splitlines()[0].strip().lstrip("*_# ").lower()
-    return "error" if first.startswith(_ERROR_HEAD) else "ok"
+    return "error" if _ERROR_HEAD.match(first) else "ok"
 
 
 def meta_path(payload: dict, pid: str) -> str:

--- a/scripts/tests/test_kernel_proc.py
+++ b/scripts/tests/test_kernel_proc.py
@@ -446,6 +446,119 @@ class HotPathGateTest(SandboxHome):
         self.assertEqual(cp.stdout.strip(), "")
 
 
+class ExitHookTest(SandboxHome):
+    """The SubagentStop reflex as the harness runs it. What is pinned: an ending
+    is written once, it carries what the process did, and a child that failed is
+    not recorded as ok."""
+
+    def run_stop(self, payload):
+        env = dict(os.environ)
+        env["HOME"] = self.home
+        env["USERPROFILE"] = self.home
+        env.pop("OCTO_KERNEL_OPEN", None)
+        return subprocess.run([sys.executable, str(SCRIPTS / "r__subagent-stop__proc-exit.py")],
+                              input=json.dumps(payload), capture_output=True,
+                              text=True, env=env, cwd=self.home, timeout=60)
+
+    def child(self, tools=1):
+        kernel_proc.register("s1", {"kind": "main", "worktree": self.home})
+        kernel_proc.register("c1", {"kind": "subagent", "ppid": "s1", "type": "QA",
+                                    "worktree": self.home})
+        for i in range(tools):
+            kernel_proc.append("c1", {"kind": "tool", "tool_name": "Bash",
+                                      "tool_use_id": f"toolu_{i}"})
+
+    def payload(self, **kw):
+        base = {"hook_event_name": "SubagentStop", "session_id": "s1",
+                "agent_id": "c1", "agent_type": "QA",
+                "last_assistant_message": "Reviewed and shipped."}
+        base.update(kw)
+        return base
+
+    def exits(self, pid="c1"):
+        return [l for l in kernel_proc.read_journal(pid)
+                if isinstance(l, dict) and l.get("kind") == "exit"]
+
+    def test_a_normal_exit_is_ok_and_carries_what_the_process_did(self):
+        self.child(tools=2)
+        cp = self.run_stop(self.payload(agent_transcript_path="/tmp/agent-c1.jsonl"))
+        self.assertEqual(cp.returncode, 0)
+        self.assertEqual(cp.stdout.strip(), "", "a reflex never speaks to the model")
+        (e,) = self.exits()
+        self.assertEqual(e["status"], "ok")
+        self.assertIs(e["ok"], True)
+        self.assertEqual(e["tool_count"], 2)
+        self.assertEqual(e["agent_transcript_path"], "/tmp/agent-c1.jsonl")
+        self.assertGreaterEqual(e["duration"], 0)
+        self.assertEqual(kernel_proc.verify("c1"), 0)
+        row = kernel_proc.read_ptable()["processes"]["c1"]
+        self.assertTrue(row["exited"])
+        self.assertEqual(row["status"], "ok")
+        self.assertFalse(kernel_proc.is_live("c1"), "an exited child releases what it held")
+
+    def test_a_child_reporting_an_error_is_not_recorded_as_ok(self):
+        self.child()
+        self.run_stop(self.payload(last_assistant_message="Error: the build failed."))
+        (e,) = self.exits()
+        self.assertEqual(e["status"], "error")
+        self.assertIs(e["ok"], False)
+
+    def test_a_child_that_said_nothing_is_an_error(self):
+        self.child()
+        self.run_stop(self.payload(last_assistant_message=""))
+        self.assertEqual(self.exits()[0]["status"], "error")
+
+    def test_an_error_named_mid_report_is_a_finding_not_a_crash(self):
+        self.child()
+        self.run_stop(self.payload(
+            last_assistant_message="Found the bug: an error in the retry path. Fixed."))
+        self.assertEqual(self.exits()[0]["status"], "ok")
+
+    def test_a_missing_meta_json_is_not_an_error(self):
+        self.child()
+        self.run_stop(self.payload(
+            transcript_path=os.path.join(self.home, "projects", "x", "s1.jsonl")))
+        (e,) = self.exits()
+        self.assertEqual(e["status"], "ok")
+        for absent in ("spawn_depth", "model", "spawn_tool_use_id"):
+            self.assertNotIn(absent, e)
+
+    def test_the_meta_json_fields_are_read_when_present(self):
+        self.child()
+        subs = os.path.join(self.home, "projects", "x", "s1", "subagents")
+        os.makedirs(subs)
+        atp = os.path.join(subs, "agent-c1.jsonl")
+        with open(atp[:-6] + ".meta.json", "w", encoding="utf-8") as fh:
+            json.dump({"spawnDepth": 2, "model": "opus", "toolUseId": "toolu_parent"}, fh)
+        self.run_stop(self.payload(
+            transcript_path=os.path.join(self.home, "projects", "x", "s1.jsonl")))
+        (e,) = self.exits()
+        self.assertEqual((e["spawn_depth"], e["model"], e["spawn_tool_use_id"]),
+                         (2, "opus", "toolu_parent"))
+
+    def test_a_repeated_subagent_stop_writes_no_second_ending(self):
+        self.child()
+        for _ in range(3):
+            self.run_stop(self.payload())
+        self.assertEqual(len(self.exits()), 1)
+        self.assertEqual(kernel_proc.verify("c1"), 0)
+
+    def test_a_payload_without_an_agent_id_is_ignored(self):
+        self.child()
+        cp = self.run_stop(self.payload(agent_id=""))
+        self.assertEqual(cp.returncode, 0)
+        self.assertEqual(self.exits(), [])
+
+    def test_garbage_on_stdin_never_blocks(self):
+        env = dict(os.environ)
+        env["HOME"] = self.home
+        cp = subprocess.run([sys.executable, str(SCRIPTS / "r__subagent-stop__proc-exit.py")],
+                            input="not json", capture_output=True, text=True,
+                            env=env, cwd=self.home, timeout=60)
+        self.assertEqual(cp.returncode, 0)
+        self.assertEqual(cp.stdout.strip(), "")
+
+
 class SchemaTest(SandboxHome):
     def test_every_emitted_line_validates_against_the_schema(self):
         try:
@@ -489,6 +602,10 @@ class SelftestTest(unittest.TestCase):
 
     def test_journal_gate_selftest_passes(self):
         cp = self._run("g__pretool__kernel.py", "FLOW.kernel-journal")
+        self.assertEqual(cp.returncode, 0, cp.stderr)
+
+    def test_exit_selftest_passes(self):
+        cp = self._run("r__subagent-stop__proc-exit.py", "ARCHITECTURE.kernel-process")
         self.assertEqual(cp.returncode, 0, cp.stderr)
 
 

--- a/scripts/tests/test_kernel_proc.py
+++ b/scripts/tests/test_kernel_proc.py
@@ -611,3 +611,18 @@ class SelftestTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class ExitStatusWordBoundaryTest(unittest.TestCase):
+    def test_error_word_boundary(self):
+        import importlib.util, os
+        spec = importlib.util.spec_from_file_location(
+            "proc_exit", os.path.join(os.path.dirname(__file__), "..", "r__subagent-stop__proc-exit.py"))
+        m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+        self.assertEqual(m.status_of("Errors were found and fixed"), "ok")
+        self.assertEqual(m.status_of("Exceptionally good result"), "ok")
+        self.assertEqual(m.status_of("Error: boom"), "error")
+        self.assertEqual(m.status_of("**Fatal** problem"), "error")
+        self.assertEqual(m.status_of(""), "error")
+        self.assertEqual(m.status_of("QA-VERDICT: FAIL"), "ok")
+


### PR DESCRIPTION
Phase 1a-2 of docs/architecture/v8-kernel.md, stacked on #280 (base is the 1a branch; retarget to master once #280 merges).

- `scripts/r__subagent-stop__proc-exit.py` (SubagentStop): writes the process's `exit` line (status ok|error from the last message, transcript path, tool count from the journal seq, duration from start_ts, spawn depth/model/spawn tool_use_id from the agent meta file when present) and marks the table row exited; idempotent on a duplicate stop; `--selftest registry/fixtures/ARCHITECTURE.kernel-process` in a sandbox HOME.
- `brain_doctor` check `kernel-process-live`: both kernel selftests pass; every live process in the real table has a journal (FAIL on a phantom); the newest five chains verify (FAIL naming the pid); `open` calls in the last seven days counted; fallback note when hooks.json has no SubagentStart entry. PASS on a fresh machine with no table; never writes.
- `kernel_proc.py` gains `update_row(pid, fields)` (the one door for row updates, reused by 1b release and Phase 2 lanes) and the shared sandbox helpers; `capability_manifest.py` derives its hook event list from hooks.json (SubagentStart/SubagentStop/PermissionDenied now render); schema gains the exit-line fields; registry row `ARCHITECTURE.kernel-process` carries its third mechanism and proof.

Verified after rebasing onto the 1a fixes: 49 unit tests OK, four selftests rc=0, `capability_manifest.py --check` PASS, `kernel-process-live` PASS on an empty table and FAIL on a seeded ghost or a broken chain (negative controls in the builder report).

Open for the QA: whether `SubagentStop` fires when a subagent is stopped with TaskStop; if not, the 900 s TTL is the only lane release and the plan says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPPcRmXDTe7ZSKbCX5dosS