### PR TITLE
docs(changelog): backfill v7.4.0 through v7.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,22 @@ machine-generated growth ledger lives at
 
 ## [Unreleased]
 
+## [2026-09-07]: v7.7.1
+- fix(kernel): an ending must not be able to create a process (#294)
+
+## [2026-09-07]: v7.7.0
+- feat(kernel): phase 3, per-process quotas in the hot-path gate (v8) (#291)
+
+## [2026-09-07]: v7.6.0
+- feat(kernel): phase 4, every refusal and every receipt in the journal, replay proven (v8) (#293)
+
+## [2026-09-07]: v7.5.0
+- feat(kernel): phase 2, one writer per tree and per lane, enforced (v8) (#292)
+
+## [2026-09-07]: v7.4.0
+- feat(kernel): phase 1b, the octo CLI (ps, top, replay, journal, bench) (v8) (#290)
+- docs(changelog): backfill v7.3.0 (#289)
+
 ## [2026-09-07]: v7.3.0
 - feat(kernel): phase 1a, process table and hash-chained journal (v8) (#280)
 - docs(changelog): backfill v7.2.5 (#279)


### PR DESCRIPTION
Five releases were cut without CHANGELOG entries, which `brain_doctor`'s
`release-drift` check has been reporting as a WARN: newest tag v7.7.1, CHANGELOG
top v7.3.0.

The release bot had already written the backfill on this branch and no PR was
ever opened for it, so the branch also showed up under `stale-merged-branches`
(a remote branch with no PR). One merge closes both.

Content verified independently: the entries were re-derived by hand from
`gh release view` for each of v7.4.0, v7.5.0, v7.6.0, v7.7.0 and v7.7.1, and the
result was byte-identical to what the bot had written. With this applied,
`release-drift` reads `CHANGELOG top v7.7.1 has a matching git tag — released`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7xKHpiarYa1ErSAs4uQ4b