### PR TITLE
fix(doctor): execute every registry proof, so a rotted one cannot pass

### DIFF
--- a/docs/architecture/wired-or-corrupt.md
+++ b/docs/architecture/wired-or-corrupt.md
@@ -402,10 +402,36 @@ to the hook. It never showed because the resolver was only ever called on one ru
 whose matcher happened to be pipe-free. `_split_hooks_locator` now splits on the
 first and last pipe and gives the middle back to the matcher.
 
-**Cost.** The doctor got FASTER. `gate-liveness` and `enforcement-floor` each ran the
-same selftests independently, so every run paid for them twice: 37 proofs × 2 = 74
-subprocess executions, with 3 `EXIT_CODE` proofs never executed at all. A per-locator
-memo shared by all consumers makes it 40 unique locators executed once, 0 skipped.
+**Two sweeps, two counts, never one number.** `gate-liveness` runs the fixture-driven
+liveness sweep FIRST, on the rules it loaded: every fail-closed gate's `--selftest`,
+violation must block and benign must allow. Only then does it run the general
+`EXIT_CODE` executor over that same rule set. The counts are reported separately, and
+that separation is load-bearing rather than cosmetic. Generalising the executor once
+ATE the sweep: the check kept loading the selftest proofs, used them only for a count,
+and never ran one, so it printed `all 41 EXIT_CODE proof(s) executed and hold, 1 of them
+fixture-driven selftests` over a gate whose benign leg was dead. A single number that
+conflates "N proofs executed" with "the liveness sweep passed" is exactly the confident
+green sentence over an unverified property that this whole document exists to kill.
+Two anchors hold it: `test_gate_liveness.py` fails the doctor on a broken gate AND
+requires the verdict to name that gate and the leg it failed (any FAIL is not enough,
+the check has unrelated FAIL branches), and `--selftest` asserts `check_gate_liveness`
+still calls `_selftest_proofs` and `_run_selftest_locator`.
+
+**A judge judges the rows it was handed.** `evaluate_proofs` takes `rules=` and
+`registry_path=`. Hardcoding `root/registry/rules.yaml` is what let the sweep vanish
+unnoticed: the check loaded `REGISTRY_PATH`, the executor silently read a different
+file, and the verdict described 41 healthy proofs out of a registry the caller had
+never seen.
+
+**Cost.** The doctor got FASTER, and restoring the sweep did not give any of it back.
+`gate-liveness` and `enforcement-floor` each ran the same selftests independently, so
+every run paid for them twice: measured on master, 37 + 37 = 74 subprocess executions,
+with 3 `EXIT_CODE` proofs never executed at all. A per-locator memo shared by all
+consumers makes it 40 unique locators executed once, 0 skipped. The restored sweep
+spawns nothing new because it runs the same locators through the same memo: measured
+on this branch's registry, 42 proof-locator spawns before the fix and 42 after,
+identical (40 registry locators + 2 comment-rot mutant re-runs), with
+`enforcement-floor` down from 38 spawns to 0.
 
 **The prover is proven.** `brain_doctor.py --selftest registry/fixtures/META.rule-1-proof-execution`
 drives the executor over a matrix of miniature brains: one `violation-*` case per proof

--- a/docs/architecture/wired-or-corrupt.md
+++ b/docs/architecture/wired-or-corrupt.md
@@ -343,6 +343,79 @@ FORCED = fail-closed AND, when it carries a `--selftest` proof, that selftest pa
 
 **Deferred to a follow-up (telemetry week first).** D1 injection-scan (fetched content that DISCUSSES injection would false-positive) and D2 the machine-register greeting/closing detector carry real false-positive risk and stay deferred behind warn-mode telemetry. D5 the no-pause proposal detector SHIPPED as a detector, not a gate: `scripts/no-pause-suggestion.py` runs at Stop in `hooks.json` under rule `COMMS.no-pause`, recorded as detector by design (`v7_decision`) because a hard block measured false positives on legitimate clarifying questions.
 
+## 10. v8: EVERY PROOF IS EXECUTED (the unrun-proof class)
+
+**The defect.** RULE #1 says a rule is wired only when its registered mechanism is
+VERIFIABLY live, and names `brain_doctor` as the mechanism of that rule. The doctor
+filtered proofs down to one class before running anything:
+
+```python
+if p.get("method") == "EXIT_CODE" and "--selftest" in loc:
+```
+
+Measured on the registry at that point: **165 proofs, 38 evaluated, 127 never run.**
+62 `IN_HOOKS_JSON` (exactly one was resolved, for the corpus-coverage ledger), 45
+`ANCHOR_PRESENT` (covered incidentally by `registry-anchors`, never as proofs), 18
+`FILE_EXISTS` (the string did not appear in a single `.py` file in the repo), and 3
+`EXIT_CODE` locators without `--selftest`. A proof nobody runs is a declaration.
+
+**The consequence, reproduced.** Two of those three unrun `EXIT_CODE` locators were
+sentinel greps: `grep -q OCTORATO-WIRE-GATE .githooks/pre-push` and
+`grep -q OCTORATO-COMMIT-MSG-LANG-GATE .githooks/commit-msg`. In both hooks the
+sentinel appears exactly once, inside a banner **comment**. Deleting every
+`brain_doctor` invocation from a copy of `pre-push` while leaving the comments intact
+left both proofs exiting 0. `META.pre-push-gate`, the row that makes the
+constitutional rule enforceable, declared itself wired over a hook that no longer
+ran the doctor. The doctor's own D0 bootstrap test (`"OCTORATO-WIRE-GATE" in
+_rt(pp)`) had the identical shape, so it agreed.
+
+**The fix, in two halves.**
+
+1. **Execute everything.** `evaluate_proofs(root, methods, comment_rot)` runs all four
+   implemented methods against a given brain root and returns one failure line per
+   proof that does not hold. The cheap, deterministic three (`FILE_EXISTS`,
+   `ANCHOR_PRESENT`, `IN_HOOKS_JSON`) run in `check_proof_execution`, which is on the
+   `--registry` path the pre-push hook already takes; `EXIT_CODE` runs in
+   `gate-liveness`, which is the check that already pays for subprocesses. Each proof
+   is therefore executed exactly once per push, and none is skipped.
+
+2. **Executing a comment-satisfiable proof faithfully still proves nothing**, so the
+   executor carries a mutant test rather than a pattern heuristic. For an `EXIT_CODE`
+   proof that is a pure text search over a file, re-run the same search against a copy
+   of that file with every comment line removed. A proof that flips from hold to fail
+   had no live-line evidence: it proves the intent was written down, not that the
+   mechanism runs. That is the check that catches the NEXT rotted proof, not just the
+   two known ones.
+
+**Blast radius, measured before arming.** With the locator bug below fixed, **all 165
+proofs hold on master: 0 failures.** There was no red inventory to buy a transition
+period for, so both checks are FAIL, not WARN. The comment-rot mutant found exactly
+2 of 40 `EXIT_CODE` proofs and no false positives; both locators were rewritten to
+assert the invocation on a non-comment line (`grep -qE '^[^#]*brain_doctor\.py'`),
+and the doctor's D0 bootstrap now requires the same.
+
+**A latent bug the lift surfaced.** The one live `IN_HOOKS_JSON` resolver split the
+locator on every `|` and required exactly 3 fields. A Claude Code matcher is a regex
+ALTERNATION, so it carries its own pipes (`Write|Edit`, or a 7-way `mcp__` list):
+**9 of the 62** locators have 4+ fields and resolved to False for a reason unrelated
+to the hook. It never showed because the resolver was only ever called on one rule
+whose matcher happened to be pipe-free. `_split_hooks_locator` now splits on the
+first and last pipe and gives the middle back to the matcher.
+
+**Cost.** The doctor got FASTER. `gate-liveness` and `enforcement-floor` each ran the
+same selftests independently, so every run paid for them twice: 37 proofs × 2 = 74
+subprocess executions, with 3 `EXIT_CODE` proofs never executed at all. A per-locator
+memo shared by all consumers makes it 40 unique locators executed once, 0 skipped.
+
+**The prover is proven.** `brain_doctor.py --selftest registry/fixtures/META.rule-1-proof-execution`
+drives the executor over a matrix of miniature brains: one `violation-*` case per proof
+method with that proof rotted (each must go red), the comment-rot case, plus `benign`
+and a `control-noop` that must both stay green in the same batch. The assertion is set
+equality, so a checker that reddens on everything fails it exactly like one that reddens
+on nothing. `META.rule-1-wired-or-corrupt`, which until now carried only `FILE_EXISTS`
+and `ANCHOR_PRESENT`, two proofs nobody ran, now carries that selftest as an
+`EXIT_CODE` proof.
+
 ---
 
 **Decision record:** approved and shipped. Phase 0 landed in v4.0.0 (registry, doctor D0-D3, pre-push gate, phantom-script kill); the create-to-register loop landed in v4.2.0; the fail-closed meta-gate + gateable classification landed in v5.3.0 (#180); the waivers that armed it landed in v5.4.0; the v5.5.0 wave hardened the teeth: waiver `expires` is enforced (expired = unwaived = FAIL), release-drift is checked in both directions, anchor ambiguity is detected instead of first-match-wins, the corpus-coverage denominator counts skills canon plus memory directives, and the pre-push gate's own inputs are fail-closed (missing registry, doctor, or Python blocks the push, never a silent skip). The final wave closed corpus-coverage to an honest 100% and armed its teeth: skills canon is carried by 6 registry PRESENCE/DETECTOR rows, memory directives by a class row wired to the brain-memory-recall hook plus the MEMORY.md index, the denominator was pruned of echoes (83 raw entries down to 43 real rules), and the ledger flips from WARN to FAIL on any uncovered rule so a new un-wired rule blocks the push; enforcement strength prints per row (REFLEX/PRESENCE) so coverage is never misread as force.

--- a/registry/fixtures/META.rule-1-proof-execution/benign/.githooks/pre-push
+++ b/registry/fixtures/META.rule-1-proof-execution/benign/.githooks/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+# OCTORATO-DEMO-GATE - banner comment naming the gate
+# demo_gate.py is described here, in a comment
+if ! python3 "$REPO_ROOT/scripts/demo_gate.py"; then exit 1; fi

--- a/registry/fixtures/META.rule-1-proof-execution/benign/CLAUDE.md
+++ b/registry/fixtures/META.rule-1-proof-execution/benign/CLAUDE.md
@@ -1,0 +1,5 @@
+# Fixture brain
+
+## The Demo Rule
+
+Prose for the demo rule.

--- a/registry/fixtures/META.rule-1-proof-execution/benign/hooks.json
+++ b/registry/fixtures/META.rule-1-proof-execution/benign/hooks.json
@@ -1,0 +1,13 @@
+{
+  "PostToolUse": [
+    {
+      "matcher": "Write|Edit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 ~/.claude/scripts/demo-reflex.py"
+        }
+      ]
+    }
+  ]
+}

--- a/registry/fixtures/META.rule-1-proof-execution/benign/registry/rules.yaml
+++ b/registry/fixtures/META.rule-1-proof-execution/benign/registry/rules.yaml
@@ -1,0 +1,16 @@
+version: 1
+rules:
+  - id: DEMO.proof-execution
+    title: "Fixture rule exercising all four proof methods"
+    category: FLOW
+    source: { file: CLAUDE.md, anchor: "## The Demo Rule" }
+    strength: REFLEX
+    firing_mode: [hook]
+    mechanism:
+      - { kind: Reflex, canonical_name: demo-reflex.py, firing_event: PostToolUse, firing_matcher: "Write|Edit" }
+    proof:
+      - { method: FILE_EXISTS, locator: scripts/demo_gate.py, expect: present }
+      - { method: ANCHOR_PRESENT, locator: "## The Demo Rule", expect: present }
+      - { method: IN_HOOKS_JSON, locator: "PostToolUse|Write|Edit|demo-reflex.py", expect: present }
+      - { method: EXIT_CODE, locator: "grep -qE '^[^#]*demo_gate\\.py' .githooks/pre-push", expect: 0 }
+    liveness_required: FIRES

--- a/registry/fixtures/META.rule-1-proof-execution/benign/scripts/demo_gate.py
+++ b/registry/fixtures/META.rule-1-proof-execution/benign/scripts/demo_gate.py
@@ -1,0 +1,1 @@
+# fixture stand-in for the gate script

--- a/registry/fixtures/META.rule-1-proof-execution/control-noop/.githooks/pre-push
+++ b/registry/fixtures/META.rule-1-proof-execution/control-noop/.githooks/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+# OCTORATO-DEMO-GATE - banner comment naming the gate
+# demo_gate.py is described here, in a comment
+if ! python3 "$REPO_ROOT/scripts/demo_gate.py"; then exit 1; fi

--- a/registry/fixtures/META.rule-1-proof-execution/control-noop/CLAUDE.md
+++ b/registry/fixtures/META.rule-1-proof-execution/control-noop/CLAUDE.md
@@ -1,0 +1,7 @@
+# Fixture brain
+
+## The Demo Rule
+
+Prose for the demo rule.
+
+An unrelated paragraph added by the control.

--- a/registry/fixtures/META.rule-1-proof-execution/control-noop/hooks.json
+++ b/registry/fixtures/META.rule-1-proof-execution/control-noop/hooks.json
@@ -1,0 +1,13 @@
+{
+  "PostToolUse": [
+    {
+      "matcher": "Write|Edit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 ~/.claude/scripts/demo-reflex.py"
+        }
+      ]
+    }
+  ]
+}

--- a/registry/fixtures/META.rule-1-proof-execution/control-noop/registry/rules.yaml
+++ b/registry/fixtures/META.rule-1-proof-execution/control-noop/registry/rules.yaml
@@ -1,0 +1,16 @@
+version: 1
+rules:
+  - id: DEMO.proof-execution
+    title: "Fixture rule exercising all four proof methods"
+    category: FLOW
+    source: { file: CLAUDE.md, anchor: "## The Demo Rule" }
+    strength: REFLEX
+    firing_mode: [hook]
+    mechanism:
+      - { kind: Reflex, canonical_name: demo-reflex.py, firing_event: PostToolUse, firing_matcher: "Write|Edit" }
+    proof:
+      - { method: FILE_EXISTS, locator: scripts/demo_gate.py, expect: present }
+      - { method: ANCHOR_PRESENT, locator: "## The Demo Rule", expect: present }
+      - { method: IN_HOOKS_JSON, locator: "PostToolUse|Write|Edit|demo-reflex.py", expect: present }
+      - { method: EXIT_CODE, locator: "grep -qE '^[^#]*demo_gate\\.py' .githooks/pre-push", expect: 0 }
+    liveness_required: FIRES

--- a/registry/fixtures/META.rule-1-proof-execution/control-noop/scripts/demo_gate.py
+++ b/registry/fixtures/META.rule-1-proof-execution/control-noop/scripts/demo_gate.py
@@ -1,0 +1,1 @@
+# fixture stand-in for the gate script

--- a/registry/fixtures/META.rule-1-proof-execution/violation-anchor-absent/.githooks/pre-push
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-anchor-absent/.githooks/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+# OCTORATO-DEMO-GATE - banner comment naming the gate
+# demo_gate.py is described here, in a comment
+if ! python3 "$REPO_ROOT/scripts/demo_gate.py"; then exit 1; fi

--- a/registry/fixtures/META.rule-1-proof-execution/violation-anchor-absent/CLAUDE.md
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-anchor-absent/CLAUDE.md
@@ -1,0 +1,3 @@
+# Fixture brain
+
+The heading was renamed away.

--- a/registry/fixtures/META.rule-1-proof-execution/violation-anchor-absent/hooks.json
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-anchor-absent/hooks.json
@@ -1,0 +1,13 @@
+{
+  "PostToolUse": [
+    {
+      "matcher": "Write|Edit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 ~/.claude/scripts/demo-reflex.py"
+        }
+      ]
+    }
+  ]
+}

--- a/registry/fixtures/META.rule-1-proof-execution/violation-anchor-absent/registry/rules.yaml
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-anchor-absent/registry/rules.yaml
@@ -1,0 +1,16 @@
+version: 1
+rules:
+  - id: DEMO.proof-execution
+    title: "Fixture rule exercising all four proof methods"
+    category: FLOW
+    source: { file: CLAUDE.md, anchor: "## The Demo Rule" }
+    strength: REFLEX
+    firing_mode: [hook]
+    mechanism:
+      - { kind: Reflex, canonical_name: demo-reflex.py, firing_event: PostToolUse, firing_matcher: "Write|Edit" }
+    proof:
+      - { method: FILE_EXISTS, locator: scripts/demo_gate.py, expect: present }
+      - { method: ANCHOR_PRESENT, locator: "## The Demo Rule", expect: present }
+      - { method: IN_HOOKS_JSON, locator: "PostToolUse|Write|Edit|demo-reflex.py", expect: present }
+      - { method: EXIT_CODE, locator: "grep -qE '^[^#]*demo_gate\\.py' .githooks/pre-push", expect: 0 }
+    liveness_required: FIRES

--- a/registry/fixtures/META.rule-1-proof-execution/violation-anchor-absent/scripts/demo_gate.py
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-anchor-absent/scripts/demo_gate.py
@@ -1,0 +1,1 @@
+# fixture stand-in for the gate script

--- a/registry/fixtures/META.rule-1-proof-execution/violation-comment-rot/.githooks/pre-push
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-comment-rot/.githooks/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+# OCTORATO-DEMO-GATE - banner comment naming the gate
+# demo_gate.py is described here, in a comment
+echo 'the invocation was deleted; only the comments remain'

--- a/registry/fixtures/META.rule-1-proof-execution/violation-comment-rot/CLAUDE.md
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-comment-rot/CLAUDE.md
@@ -1,0 +1,5 @@
+# Fixture brain
+
+## The Demo Rule
+
+Prose for the demo rule.

--- a/registry/fixtures/META.rule-1-proof-execution/violation-comment-rot/hooks.json
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-comment-rot/hooks.json
@@ -1,0 +1,13 @@
+{
+  "PostToolUse": [
+    {
+      "matcher": "Write|Edit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 ~/.claude/scripts/demo-reflex.py"
+        }
+      ]
+    }
+  ]
+}

--- a/registry/fixtures/META.rule-1-proof-execution/violation-comment-rot/registry/rules.yaml
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-comment-rot/registry/rules.yaml
@@ -1,0 +1,16 @@
+version: 1
+rules:
+  - id: DEMO.proof-execution
+    title: "Fixture rule exercising all four proof methods"
+    category: FLOW
+    source: { file: CLAUDE.md, anchor: "## The Demo Rule" }
+    strength: REFLEX
+    firing_mode: [hook]
+    mechanism:
+      - { kind: Reflex, canonical_name: demo-reflex.py, firing_event: PostToolUse, firing_matcher: "Write|Edit" }
+    proof:
+      - { method: FILE_EXISTS, locator: scripts/demo_gate.py, expect: present }
+      - { method: ANCHOR_PRESENT, locator: "## The Demo Rule", expect: present }
+      - { method: IN_HOOKS_JSON, locator: "PostToolUse|Write|Edit|demo-reflex.py", expect: present }
+      - { method: EXIT_CODE, locator: "grep -q OCTORATO-DEMO-GATE .githooks/pre-push", expect: 0 }
+    liveness_required: FIRES

--- a/registry/fixtures/META.rule-1-proof-execution/violation-comment-rot/scripts/demo_gate.py
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-comment-rot/scripts/demo_gate.py
@@ -1,0 +1,1 @@
+# fixture stand-in for the gate script

--- a/registry/fixtures/META.rule-1-proof-execution/violation-exit-nonzero/.githooks/pre-push
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-exit-nonzero/.githooks/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+# OCTORATO-DEMO-GATE - banner comment naming the gate
+# demo_gate.py is described here, in a comment
+if ! python3 "$REPO_ROOT/scripts/demo_gate.py"; then exit 1; fi

--- a/registry/fixtures/META.rule-1-proof-execution/violation-exit-nonzero/CLAUDE.md
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-exit-nonzero/CLAUDE.md
@@ -1,0 +1,5 @@
+# Fixture brain
+
+## The Demo Rule
+
+Prose for the demo rule.

--- a/registry/fixtures/META.rule-1-proof-execution/violation-exit-nonzero/hooks.json
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-exit-nonzero/hooks.json
@@ -1,0 +1,13 @@
+{
+  "PostToolUse": [
+    {
+      "matcher": "Write|Edit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 ~/.claude/scripts/demo-reflex.py"
+        }
+      ]
+    }
+  ]
+}

--- a/registry/fixtures/META.rule-1-proof-execution/violation-exit-nonzero/registry/rules.yaml
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-exit-nonzero/registry/rules.yaml
@@ -1,0 +1,16 @@
+version: 1
+rules:
+  - id: DEMO.proof-execution
+    title: "Fixture rule exercising all four proof methods"
+    category: FLOW
+    source: { file: CLAUDE.md, anchor: "## The Demo Rule" }
+    strength: REFLEX
+    firing_mode: [hook]
+    mechanism:
+      - { kind: Reflex, canonical_name: demo-reflex.py, firing_event: PostToolUse, firing_matcher: "Write|Edit" }
+    proof:
+      - { method: FILE_EXISTS, locator: scripts/demo_gate.py, expect: present }
+      - { method: ANCHOR_PRESENT, locator: "## The Demo Rule", expect: present }
+      - { method: IN_HOOKS_JSON, locator: "PostToolUse|Write|Edit|demo-reflex.py", expect: present }
+      - { method: EXIT_CODE, locator: "grep -qE '^[^#]*no_such_token_anywhere' .githooks/pre-push", expect: 0 }
+    liveness_required: FIRES

--- a/registry/fixtures/META.rule-1-proof-execution/violation-exit-nonzero/scripts/demo_gate.py
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-exit-nonzero/scripts/demo_gate.py
@@ -1,0 +1,1 @@
+# fixture stand-in for the gate script

--- a/registry/fixtures/META.rule-1-proof-execution/violation-file-missing/.githooks/pre-push
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-file-missing/.githooks/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+# OCTORATO-DEMO-GATE - banner comment naming the gate
+# demo_gate.py is described here, in a comment
+if ! python3 "$REPO_ROOT/scripts/demo_gate.py"; then exit 1; fi

--- a/registry/fixtures/META.rule-1-proof-execution/violation-file-missing/CLAUDE.md
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-file-missing/CLAUDE.md
@@ -1,0 +1,5 @@
+# Fixture brain
+
+## The Demo Rule
+
+Prose for the demo rule.

--- a/registry/fixtures/META.rule-1-proof-execution/violation-file-missing/hooks.json
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-file-missing/hooks.json
@@ -1,0 +1,13 @@
+{
+  "PostToolUse": [
+    {
+      "matcher": "Write|Edit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 ~/.claude/scripts/demo-reflex.py"
+        }
+      ]
+    }
+  ]
+}

--- a/registry/fixtures/META.rule-1-proof-execution/violation-file-missing/registry/rules.yaml
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-file-missing/registry/rules.yaml
@@ -1,0 +1,16 @@
+version: 1
+rules:
+  - id: DEMO.proof-execution
+    title: "Fixture rule exercising all four proof methods"
+    category: FLOW
+    source: { file: CLAUDE.md, anchor: "## The Demo Rule" }
+    strength: REFLEX
+    firing_mode: [hook]
+    mechanism:
+      - { kind: Reflex, canonical_name: demo-reflex.py, firing_event: PostToolUse, firing_matcher: "Write|Edit" }
+    proof:
+      - { method: FILE_EXISTS, locator: scripts/demo_gate.py, expect: present }
+      - { method: ANCHOR_PRESENT, locator: "## The Demo Rule", expect: present }
+      - { method: IN_HOOKS_JSON, locator: "PostToolUse|Write|Edit|demo-reflex.py", expect: present }
+      - { method: EXIT_CODE, locator: "grep -qE '^[^#]*demo_gate\\.py' .githooks/pre-push", expect: 0 }
+    liveness_required: FIRES

--- a/registry/fixtures/META.rule-1-proof-execution/violation-hook-unwired/.githooks/pre-push
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-hook-unwired/.githooks/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+# OCTORATO-DEMO-GATE - banner comment naming the gate
+# demo_gate.py is described here, in a comment
+if ! python3 "$REPO_ROOT/scripts/demo_gate.py"; then exit 1; fi

--- a/registry/fixtures/META.rule-1-proof-execution/violation-hook-unwired/CLAUDE.md
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-hook-unwired/CLAUDE.md
@@ -1,0 +1,5 @@
+# Fixture brain
+
+## The Demo Rule
+
+Prose for the demo rule.

--- a/registry/fixtures/META.rule-1-proof-execution/violation-hook-unwired/hooks.json
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-hook-unwired/hooks.json
@@ -1,0 +1,13 @@
+{
+  "PostToolUse": [
+    {
+      "matcher": "Write|Edit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 ~/.claude/scripts/demo-reflex.py"
+        }
+      ]
+    }
+  ]
+}

--- a/registry/fixtures/META.rule-1-proof-execution/violation-hook-unwired/registry/rules.yaml
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-hook-unwired/registry/rules.yaml
@@ -1,0 +1,16 @@
+version: 1
+rules:
+  - id: DEMO.proof-execution
+    title: "Fixture rule exercising all four proof methods"
+    category: FLOW
+    source: { file: CLAUDE.md, anchor: "## The Demo Rule" }
+    strength: REFLEX
+    firing_mode: [hook]
+    mechanism:
+      - { kind: Reflex, canonical_name: demo-reflex.py, firing_event: PostToolUse, firing_matcher: "Write|Edit" }
+    proof:
+      - { method: FILE_EXISTS, locator: scripts/demo_gate.py, expect: present }
+      - { method: ANCHOR_PRESENT, locator: "## The Demo Rule", expect: present }
+      - { method: IN_HOOKS_JSON, locator: "PostToolUse|Write|Edit|not-registered.py", expect: present }
+      - { method: EXIT_CODE, locator: "grep -qE '^[^#]*demo_gate\\.py' .githooks/pre-push", expect: 0 }
+    liveness_required: FIRES

--- a/registry/fixtures/META.rule-1-proof-execution/violation-hook-unwired/scripts/demo_gate.py
+++ b/registry/fixtures/META.rule-1-proof-execution/violation-hook-unwired/scripts/demo_gate.py
@@ -1,0 +1,1 @@
+# fixture stand-in for the gate script

--- a/registry/rules.yaml
+++ b/registry/rules.yaml
@@ -24,6 +24,14 @@ rules:
   - method: ANCHOR_PRESENT
     locator: 'RULE #1'
     expect: present
+  # Until this row carried an EXECUTED proof, the constitutional keystone was backed
+  # by two declarations nobody ran. The selftest drives brain_doctor over a matrix of
+  # miniature brains: one case per proof method with that proof rotted (each must go
+  # red), plus a benign case and a no-op control (both must stay green). Set equality
+  # is the assertion, so a checker that reddens on everything fails it too.
+  - method: EXIT_CODE
+    locator: scripts/brain_doctor.py --selftest registry/fixtures/META.rule-1-proof-execution
+    expect: 0
   liveness_required: PRESENT
 - id: META.pre-push-gate
   title: brain_doctor is invoked from the tracked pre-push hook
@@ -46,7 +54,11 @@ rules:
     locator: .githooks/pre-push
     expect: present
   - method: EXIT_CODE
-    locator: grep -q OCTORATO-WIRE-GATE .githooks/pre-push
+    # The sentinel-only form of this proof lived at .githooks/pre-push:230, inside a
+    # COMMENT: deleting every brain_doctor invocation from the hook left the proof
+    # exiting 0, so RULE #1 declared itself wired over a hook that no longer ran the
+    # doctor. Assert the INVOCATION on a line that is not commented out instead.
+    locator: "grep -qE '^[^#]*brain_doctor\\.py' .githooks/pre-push"
     expect: 0
   liveness_required: PRESENT
 - id: COMMS.human-cadence
@@ -1690,7 +1702,9 @@ rules:
     locator: .githooks/commit-msg
     expect: present
   - method: EXIT_CODE
-    locator: grep -q OCTORATO-COMMIT-MSG-LANG-GATE .githooks/commit-msg
+    # Same comment-satisfiable shape as META.pre-push-gate: the sentinel only ever
+    # appeared in the header comment. Assert the gate is actually invoked.
+    locator: "grep -qE '^[^#]*commit_msg_language_gate\\.py' .githooks/commit-msg"
     expect: 0
   - method: EXIT_CODE
     locator: scripts/commit_msg_language_gate.py --selftest registry/fixtures/GENERIC.commit-msg-english-only

--- a/scripts/brain_doctor.py
+++ b/scripts/brain_doctor.py
@@ -11,12 +11,15 @@ Cross-platform: pure pathlib + subprocess with explicit args, no bash-isms.
 from __future__ import annotations
 
 import argparse
+import inspect
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 CLAUDE_DIR = Path(__file__).resolve().parent.parent
@@ -686,11 +689,12 @@ def _rt(p: Path) -> str:
         return ""
 
 
-def _hooks_index() -> set:
-    """(event, matcher, script_basename) tuples from tracked hooks.json."""
+def _hooks_index_at(root: Path) -> set:
+    """(event, matcher, script_basename) tuples from the hooks.json under `root`.
+    Root-parameterized so the proof executor can be pointed at a fixture brain."""
     idx = set()
     try:
-        data = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
+        data = json.loads((root / "hooks.json").read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return idx
     for ev, arr in data.items():
@@ -703,6 +707,37 @@ def _hooks_index() -> set:
                     if tok.endswith(".py"):
                         idx.add((ev, matcher, os.path.basename(tok)))
     return idx
+
+
+def _hooks_index() -> set:
+    """(event, matcher, script_basename) tuples from this brain's tracked hooks.json."""
+    return _hooks_index_at(CLAUDE_DIR)
+
+
+def _split_hooks_locator(locator: str):
+    """`event|matcher|script.py` -> (event, matcher, basename), or None if malformed.
+
+    The matcher is a Claude Code matcher, which is a regex ALTERNATION and therefore
+    contains its own pipes ("Write|Edit", or a 7-way mcp__ list). Splitting on every
+    pipe and demanding exactly 3 parts silently mis-reads 9 of the 62 IN_HOOKS_JSON
+    locators in the registry as malformed, so their proofs resolve to False for a
+    reason that has nothing to do with the hook. Event names never contain a pipe and
+    the script is always the last field, so split on the FIRST and LAST pipe and give
+    the whole middle back to the matcher."""
+    parts = locator.split("|")
+    if len(parts) < 3:
+        return None
+    return parts[0], "|".join(parts[1:-1]), parts[-1]
+
+
+def _proof_in_hooks(locator: str, hooks: set) -> bool:
+    """Does `event|matcher|script.py` name a hook that is actually registered?"""
+    split = _split_hooks_locator(locator)
+    if not split:
+        return False
+    ev, mt, base = split
+    return any(e == ev and b == base and (mm == mt or mt == "*" or mm == "*")
+               for (e, mm, b) in hooks)
 
 
 def _resolve_script(name: str) -> Path:
@@ -829,8 +864,14 @@ def check_registry(fix: bool) -> list:
     out = []
 
     # D0 bootstrap: pre-push gate present (WARN in Phase 0 until commit lands)
+    # Third instance of the comment-satisfiable class, in the doctor's own code: the
+    # sentinel OCTORATO-WIRE-GATE lives only in the hook's banner comment, so this
+    # test passed on a pre-push with every brain_doctor invocation deleted. Require a
+    # live (non-commented) invocation line, which is what "the gate is wired" means.
     pp = CLAUDE_DIR / ".githooks" / "pre-push"
-    sentinel = pp.exists() and "OCTORATO-WIRE-GATE" in _rt(pp)
+    sentinel = pp.exists() and any(
+        "brain_doctor.py" in ln and not ln.lstrip().startswith("#")
+        for ln in _rt(pp).splitlines())
     out.append(Result("registry-bootstrap", PASS if sentinel else WARN,
                       f"rules.yaml loads ({len(rules)} rules); pre-push gate "
                       f"{'present' if sentinel else 'NOT wired yet'}",
@@ -1047,18 +1088,10 @@ def check_corpus_coverage(fix: bool) -> Result:
     class_row = next((r for r in rules if r.get("id") == "MEMORY.feedback-directive-corpus"), None)
     hooks = _hooks_index()
 
-    def _in_hooks(locator: str) -> bool:
-        parts = locator.split("|")
-        if len(parts) != 3:
-            return False
-        ev, mt, base = parts
-        return any(e == ev and b == base and (mm == mt or mt == "*" or mm == "*")
-                   for (e, mm, b) in hooks)
-
     class_proofs = [p for p in (class_row or {}).get("proof", [])
                     if p.get("method") == "IN_HOOKS_JSON"]
     class_live = bool(class_row) and bool(class_proofs) and all(
-        _in_hooks(p.get("locator", "")) for p in class_proofs)
+        _proof_in_hooks(p.get("locator", ""), hooks) for p in class_proofs)
 
     mem_files = sorted(CLAUDE_DIR.glob("projects/*/memory/feedback_*.md"))
     if not mem_files:
@@ -1270,16 +1303,293 @@ def _selftest_proofs(rules: list) -> list:
     return out
 
 
-def _run_selftest_locator(locator: str) -> subprocess.CompletedProcess:
-    """Run a `<script> --selftest [dir]` locator. Strips a leading python/python3
-    token (some locators carry it), resolves a repo-relative script, and runs it
-    under our interpreter with cwd=CLAUDE_DIR so fixture paths resolve."""
-    toks = locator.split()
+def _exit_code_proofs(rules: list) -> list:
+    """(rule, locator, expect) for EVERY EXIT_CODE proof, selftest or not.
+
+    The selftest-only filter this function replaces meant a non-selftest EXIT_CODE
+    locator was registered as proof and then never run: three of them shipped that
+    way, two of which a comment alone could satisfy."""
+    out = []
+    for r in rules:
+        for p in (r.get("proof") or []):
+            if p.get("method") == "EXIT_CODE":
+                out.append((r, str(p.get("locator") or ""), p.get("expect")))
+    return out
+
+
+# One locator, one execution per process. gate-liveness and enforcement-floor each
+# used to run the SAME 37 selftests, so every doctor run paid for them twice; adding
+# a third consumer without this memo would have paid a third time.
+_EXIT_CODE_MEMO: dict = {}
+
+
+def _run_exit_code_locator(locator: str, root: Path | None = None) -> subprocess.CompletedProcess:
+    """Run an EXIT_CODE proof locator. Strips a leading python/python3 token (some
+    locators carry it), resolves a repo-relative .py under `root` and runs it with
+    our interpreter; anything else (grep, a shell tool) runs as given. cwd=root so
+    relative fixture and file paths resolve."""
+    root = root or CLAUDE_DIR
+    key = (str(root), locator)
+    if key in _EXIT_CODE_MEMO:
+        return _EXIT_CODE_MEMO[key]
+    toks = shlex.split(locator)
     if toks and os.path.basename(toks[0]) in ("python", "python3", "py"):
         toks = toks[1:]
-    if toks and toks[0].endswith((".py",)) and not os.path.isabs(toks[0]):
-        toks[0] = str(CLAUDE_DIR / toks[0])
-    return run([PYTHON or "python3", *toks], cwd=CLAUDE_DIR)
+    if toks and toks[0].endswith(".py") and not os.path.isabs(toks[0]):
+        toks = [PYTHON or "python3", str(root / toks[0]), *toks[1:]]
+    cp = run(toks, cwd=root)
+    _EXIT_CODE_MEMO[key] = cp
+    return cp
+
+
+def _run_selftest_locator(locator: str) -> subprocess.CompletedProcess:
+    """Back-compat alias: a --selftest locator is just an EXIT_CODE locator."""
+    return _run_exit_code_locator(locator)
+
+
+# --- comment-rot detector -------------------------------------------------------
+# A proof of the form `grep -q SENTINEL <file>` is satisfied by the sentinel wherever
+# it appears, INCLUDING inside a comment. That makes it a proof that the intent was
+# written down, never that the mechanism runs: delete every real invocation from the
+# hook, leave the comment banner, and the proof still exits 0. The rule then declares
+# itself wired over a hook that does nothing. Detect the class by mutating instead of
+# by pattern-matching the locator: re-run the same search against a copy of the target
+# with every comment line removed. A proof that flips from hold to fail had no
+# live-line evidence at all.
+_SEARCH_CMDS = {"grep", "egrep", "fgrep", "rg", "ggrep"}
+# Deliberately narrow: '#' (sh, python, yaml) and '//' (js, jsonc). SQL '--' and shell
+# '--' collide, and a markdown '*' is a bullet, i.e. real content, so stripping either
+# would invent failures. A proof over a file whose comments use another syntax is
+# reported as NOT ANALYZED rather than silently passed.
+_COMMENT_PREFIXES = ("#", "//")
+
+
+def _strip_comment_lines(text: str) -> str:
+    return "".join(ln for ln in text.splitlines(keepends=True)
+                   if not ln.lstrip().startswith(_COMMENT_PREFIXES))
+
+
+def _text_search_target(locator: str, root: Path):
+    """(token_index, path) of the file a text-search locator reads, or None when the
+    locator is not a text search or its target cannot be resolved."""
+    try:
+        toks = shlex.split(locator)
+    except ValueError:
+        return None
+    if not toks or os.path.basename(toks[0]) not in _SEARCH_CMDS:
+        return None
+    for i in range(len(toks) - 1, 0, -1):
+        cand = root / toks[i]
+        if cand.is_file():
+            return i, cand
+    return None
+
+
+def _comment_only_failure(rule_id: str, locator: str, expect, root: Path):
+    """Failure line when this proof holds ONLY because of comment lines, else None."""
+    target = _text_search_target(locator, root)
+    if not target:
+        return None
+    idx, path = target
+    body = _rt(path)
+    stripped = _strip_comment_lines(body)
+    if stripped == body:
+        return None  # no comments to lose; the proof already reads live lines
+    with tempfile.TemporaryDirectory() as td:
+        mutant = Path(td) / path.name
+        mutant.write_text(stripped, encoding="utf-8")
+        toks = shlex.split(locator)
+        toks[idx] = str(mutant)
+        cp = run(toks, cwd=root)
+    try:
+        want = int(expect)
+    except (TypeError, ValueError):
+        want = 0
+    if cp.returncode == want:
+        return None  # still holds without comments: there is live-line evidence
+    return (f"{rule_id}: proof `{locator}` is satisfied ONLY by comment lines in "
+            f"{path.relative_to(root).as_posix() if path.is_relative_to(root) else path.name} "
+            f"(it proves the intent is written down, not that the mechanism runs)")
+
+
+# --- the proof executor ----------------------------------------------------------
+CHEAP_PROOF_METHODS = ("FILE_EXISTS", "ANCHOR_PRESENT", "IN_HOOKS_JSON")
+
+
+def evaluate_proofs(root: Path, methods=CHEAP_PROOF_METHODS, comment_rot: bool = False) -> tuple:
+    """Execute every registry proof whose method is in `methods`, against `root`.
+
+    Returns (failures, evaluated, not_analyzed). RULE #1 says a rule is wired only
+    when its registered mechanism is VERIFIABLY live; a proof nobody runs verifies
+    nothing, so this evaluates all four implemented methods rather than the one
+    (EXIT_CODE --selftest) the doctor used to filter for."""
+    failures, not_analyzed = [], []
+    evaluated = 0
+    try:
+        import yaml
+        reg = yaml.safe_load((root / "registry" / "rules.yaml").read_text(encoding="utf-8")) or {}
+    except Exception as e:
+        return ([f"registry: cannot load rules.yaml: {e}"], 0, [])
+    rules = reg.get("rules", []) if isinstance(reg, dict) else []
+    hooks = _hooks_index_at(root)
+    texts: dict = {}
+
+    def body_of(rel: str) -> str:
+        if rel not in texts:
+            texts[rel] = _rt(root / rel)
+        return texts[rel]
+
+    for r in rules:
+        rid = r.get("id", "?")
+        sfile = (r.get("source") or {}).get("file", "CLAUDE.md")
+        for pr in (r.get("proof") or []):
+            method = pr.get("method")
+            if method not in methods:
+                continue
+            loc, exp = str(pr.get("locator") or ""), pr.get("expect")
+            evaluated += 1
+            if method == "FILE_EXISTS":
+                present = (root / loc).exists()
+                if present is not (exp != "absent"):
+                    failures.append(f"{rid}: FILE_EXISTS {loc} "
+                                    f"{'exists' if present else 'MISSING on disk'}, expect={exp}")
+            elif method == "ANCHOR_PRESENT":
+                body = body_of(sfile)
+                if not body:
+                    failures.append(f"{rid}: ANCHOR_PRESENT source file '{sfile}' missing or unreadable")
+                    continue
+                present = loc in body
+                if present is not (exp != "absent"):
+                    failures.append(f"{rid}: ANCHOR_PRESENT anchor {loc!r} "
+                                    f"{'present' if present else 'ABSENT'} in {sfile}, expect={exp}")
+            elif method == "IN_HOOKS_JSON":
+                if _split_hooks_locator(loc) is None:
+                    failures.append(f"{rid}: IN_HOOKS_JSON malformed locator {loc!r} "
+                                    f"(want event|matcher|script.py)")
+                    continue
+                present = _proof_in_hooks(loc, hooks)
+                if present is not (exp != "absent"):
+                    ev, mt, base = _split_hooks_locator(loc)
+                    failures.append(f"{rid}: IN_HOOKS_JSON {base} "
+                                    f"{'is' if present else 'NOT'} in hooks.json at {ev}|{mt}, expect={exp}")
+            elif method == "EXIT_CODE":
+                try:
+                    want = int(exp)
+                except (TypeError, ValueError):
+                    failures.append(f"{rid}: EXIT_CODE expect={exp!r} is not an exit status")
+                    continue
+                cp = _run_exit_code_locator(loc, root)
+                if cp.returncode != want:
+                    tail = (cp.stderr or cp.stdout or "").strip().splitlines()
+                    failures.append(f"{rid}: EXIT_CODE `{loc}` exited {cp.returncode}, expect {want}"
+                                    + (f" :: {tail[-1][:120]}" if tail else ""))
+                elif comment_rot:
+                    rot = _comment_only_failure(rid, loc, exp, root)
+                    if rot:
+                        failures.append(rot)
+            else:
+                not_analyzed.append(f"{rid}: method {method} has no executor")
+    return failures, evaluated, not_analyzed
+
+
+ALL_PROOF_METHODS = CHEAP_PROOF_METHODS + ("EXIT_CODE",)
+
+
+def proof_execution_selftest(fixture_dir: str) -> int:
+    """Fixture-driven liveness proof for the proof executor itself.
+
+    A fixture case is a miniature brain (CLAUDE.md + hooks.json + registry/rules.yaml
+    + .githooks/pre-push) carrying one rule whose four proofs exercise all four
+    methods. `benign` and `control-noop` must come back with ZERO failures; every
+    `violation-*` case must come back RED, and only those. Set equality is the
+    assertion: a check that reddens on everything is as dead as one that reddens on
+    nothing, and a no-op edit in the same batch must not move any verdict."""
+    root = Path(fixture_dir)
+    if not root.is_absolute():
+        root = CLAUDE_DIR / root
+    if not root.is_dir():
+        print(f"selftest: fixture dir not found: {root}")
+        return 1
+    cases = sorted(d for d in root.iterdir() if d.is_dir())
+    if not cases:
+        print(f"selftest: no fixture cases under {root}")
+        return 1
+    expected_red = {d.name for d in cases if d.name.startswith("violation-")}
+    actual_red, detail = set(), {}
+    for d in cases:
+        failures, evaluated, _na = evaluate_proofs(d, methods=ALL_PROOF_METHODS, comment_rot=True)
+        if evaluated == 0:
+            print(f"selftest: case {d.name} evaluated 0 proofs (fixture is inert, not green)")
+            return 1
+        if failures:
+            actual_red.add(d.name)
+            detail[d.name] = failures[0]
+    ok = actual_red == expected_red
+    for d in cases:
+        n = d.name
+        want = "RED" if n in expected_red else "green"
+        got = "RED" if n in actual_red else "green"
+        mark = "ok " if want == got else "MISS"
+        print(f"  [{mark}] {n:26s} want {want:5s} got {got:5s}"
+              + (f"  :: {detail[n][:100]}" if n in detail else ""))
+    if not ok:
+        print(f"selftest FAIL: expected red {sorted(expected_red)}, got red {sorted(actual_red)}")
+        return 1
+    # The fixture matrix proves the evaluator reddens correctly. It does NOT prove the
+    # evaluator is REACHABLE from the hook that blocks a push, and an unreachable
+    # checker is the same defect one level up, so assert both push paths as well.
+    #
+    # --registry is spawned for real: it is cheap and runs no EXIT_CODE proof, so it
+    # cannot re-enter here. --gate-receipt is asserted IN-PROCESS instead. It must not
+    # be spawned: gate-liveness runs this selftest as one of its own EXIT_CODE proofs,
+    # so spawning it from inside would recurse without a base case (measured: it forks
+    # until the machine is out of processes).
+    cp = run([PYTHON or "python3", str(CLAUDE_DIR / "scripts" / "brain_doctor.py"),
+              "--registry", "--json"], cwd=CLAUDE_DIR)
+    try:
+        keys = {c.get("key") for c in json.loads(cp.stdout or "{}").get("checks", [])}
+    except json.JSONDecodeError:
+        keys = set()
+    if "proof-execution" not in keys:
+        print("  [MISS] --registry does not run 'proof-execution': "
+              "the executor is not on the pre-push path")
+        return 1
+    print(f"  [ok ] {'wiring --registry':26s} runs 'proof-execution' (spawned)")
+    if ("gate-liveness", check_gate_liveness) not in CHECKS:
+        print("  [MISS] check_gate_liveness is not registered in CHECKS")
+        return 1
+    gl_src = inspect.getsource(check_gate_liveness)
+    if "evaluate_proofs" not in gl_src or '"EXIT_CODE"' not in gl_src:
+        print("  [MISS] check_gate_liveness no longer routes EXIT_CODE proofs through the executor")
+        return 1
+    print(f"  [ok ] {'wiring --gate-receipt':26s} routes EXIT_CODE through the executor (in-process)")
+    print(f"selftest PASS: {len(expected_red)} violation case(s) red, "
+          f"{len(cases) - len(expected_red)} benign/control case(s) green, "
+          f"executor reachable from both pre-push invocations")
+    return 0
+
+
+def check_proof_execution(fix: bool) -> Result:
+    """RULE #1 teeth: EXECUTE every cheap registry proof, do not merely store it.
+
+    The doctor used to run exactly one class of proof (EXIT_CODE with --selftest);
+    the other 127 rows were declarations. These three methods are deterministic and
+    cost no subprocess, so they run here, on the --registry path the pre-push hook
+    takes. The EXIT_CODE class is executed in gate-liveness, which already pays for
+    subprocesses, so no proof is run twice per push."""
+    key = "proof-execution"
+    failures, evaluated, not_analyzed = evaluate_proofs(CLAUDE_DIR)
+    if failures:
+        return Result(key, FAIL,
+                      f"{len(failures)}/{evaluated} registry proof(s) do NOT hold: "
+                      + "; ".join(failures[:5]),
+                      "a registered proof that does not hold is an unwired rule (RULE #1); "
+                      "fix the mechanism, or fix the locator if it points at the wrong thing")
+    msg = f"all {evaluated} disk/anchor/hooks proof(s) executed and hold"
+    if not_analyzed:
+        msg += f"; {len(not_analyzed)} proof(s) carry a method with no executor: " + "; ".join(not_analyzed[:3])
+    return Result(key, PASS if not not_analyzed else WARN, msg,
+                  "" if not not_analyzed else "implement an executor for these methods or drop them from the schema")
 
 
 def check_gate_liveness(fix: bool) -> Result:
@@ -1302,17 +1612,16 @@ def check_gate_liveness(fix: bool) -> Result:
     if not proofs:
         return Result(key, WARN, "no --selftest proofs registered",
                       "add EXIT_CODE --selftest proofs to fail-closed gates")
-    failed = []
-    for r, loc in proofs:
-        cp = _run_selftest_locator(loc)
-        if cp.returncode != 0:
-            detail = (cp.stderr or cp.stdout or "").strip().splitlines()
-            failed.append(f"{r.get('id', '?')}: {detail[-1] if detail else 'selftest exit '+str(cp.returncode)}")
+    # Every EXIT_CODE proof, not only the --selftest ones: a locator registered as
+    # proof and never executed proves nothing, and the comment-rot mutant runs here
+    # because this is the check that already pays for subprocesses on the push path.
+    failed, evaluated, _na = evaluate_proofs(CLAUDE_DIR, methods=("EXIT_CODE",), comment_rot=True)
     if failed:
         return Result(key, FAIL,
-                      f"{len(failed)}/{len(proofs)} gate selftest(s) do NOT block+allow correctly: "
+                      f"{len(failed)}/{evaluated} EXIT_CODE proof(s) do NOT hold: "
                       + "; ".join(failed[:6]),
-                      "a labeled gate that fails its violation/benign fixtures is dead; fix the gate or the fixture")
+                      "a labeled gate that fails its violation/benign fixtures is dead, and a proof a "
+                      "comment alone satisfies was never a proof; fix the gate, the fixture or the locator")
     # v7 gate receipt: the outward-send gate refuses to ship while no doctor has
     # proven the gates on THIS tree. Written here, in the doctor's process, never
     # by the model; the consumer compares the recorded HEAD to the live one.
@@ -1340,8 +1649,9 @@ def check_gate_liveness(fix: bool) -> Result:
         return Result(key, FAIL, f"gate receipt could not be written: {e}",
                       "the send gate denies without it; fix and re-run --gate-receipt")
     return Result(key, PASS,
-                  f"all {len(proofs)} gate/detector selftest(s) proven live "
-                  f"(gate: violation blocks + benign allows; detector: fires on fixture)")
+                  f"all {evaluated} EXIT_CODE proof(s) executed and hold, {len(proofs)} of them "
+                  f"fixture-driven selftests (gate: violation blocks + benign allows; detector: fires "
+                  f"on fixture); none satisfied by comment lines alone")
 
 
 def check_enforcement_floor(fix: bool) -> Result:
@@ -2154,6 +2464,7 @@ def check_stale_merged_branches(fix: bool) -> Result:
 CHECKS = [
     ("repo-identity", check_repo_identity),
     ("rule-1-registry", check_registry),
+    ("proof-execution", check_proof_execution),
     ("corpus-coverage", check_corpus_coverage),
     ("fixture-seeds-tracked", check_fixture_seeds_tracked),
     ("gate-liveness", check_gate_liveness),
@@ -2236,7 +2547,13 @@ def main() -> int:
                     help="run ONLY the RULE #1 registry checks (for .githooks/pre-push)")
     ap.add_argument("--gate-receipt", action="store_true",
                     help="run ONLY gate-liveness and write the v7 gate receipt (pre-push, ai-pull)")
+    ap.add_argument("--selftest", metavar="FIXTURE_DIR", nargs="?",
+                    const="registry/fixtures/META.rule-1-proof-execution",
+                    help="prove the proof executor reddens on rotted proofs and stays green otherwise")
     args = ap.parse_args()
+
+    if args.selftest:
+        return proof_execution_selftest(args.selftest)
 
     if args.gate_receipt:
         try:
@@ -2245,7 +2562,8 @@ def main() -> int:
             results = [Result("gate-liveness", FAIL, f"gate-liveness crashed: {e}", "report this bug")]
     elif args.registry:
         try:
-            results = check_registry(args.fix) + check_naming(args.fix) + check_orphan_hooks(args.fix)
+            results = (check_registry(args.fix) + [check_proof_execution(args.fix)]
+                       + check_naming(args.fix) + check_orphan_hooks(args.fix))
         except Exception as e:
             results = [Result("rule-1-registry", FAIL, f"registry check crashed: {e}",
                               "fix registry/rules.yaml so it loads and validates")]

--- a/scripts/brain_doctor.py
+++ b/scripts/brain_doctor.py
@@ -1325,9 +1325,15 @@ _EXIT_CODE_MEMO: dict = {}
 
 def _run_exit_code_locator(locator: str, root: Path | None = None) -> subprocess.CompletedProcess:
     """Run an EXIT_CODE proof locator. Strips a leading python/python3 token (some
-    locators carry it), resolves a repo-relative .py under `root` and runs it with
-    our interpreter; anything else (grep, a shell tool) runs as given. cwd=root so
-    relative fixture and file paths resolve."""
+    locators carry it), resolves a repo-relative .py under `root` and runs EVERY .py
+    under our interpreter; anything else (grep, a shell tool) runs as given. cwd=root
+    so relative fixture and file paths resolve.
+
+    The interpreter is prepended for an ABSOLUTE .py too. Gating that on a relative
+    path made an absolute locator exec the file directly, which raises PermissionError
+    on any .py that is not chmod +x, so a proof whose locator is absolute crashed the
+    doctor instead of running. Only the restored liveness sweep exposed it: every
+    locator in the tracked registry happens to be repo-relative."""
     root = root or CLAUDE_DIR
     key = (str(root), locator)
     if key in _EXIT_CODE_MEMO:
@@ -1335,8 +1341,9 @@ def _run_exit_code_locator(locator: str, root: Path | None = None) -> subprocess
     toks = shlex.split(locator)
     if toks and os.path.basename(toks[0]) in ("python", "python3", "py"):
         toks = toks[1:]
-    if toks and toks[0].endswith(".py") and not os.path.isabs(toks[0]):
-        toks = [PYTHON or "python3", str(root / toks[0]), *toks[1:]]
+    if toks and toks[0].endswith(".py"):
+        first = toks[0] if os.path.isabs(toks[0]) else str(root / toks[0])
+        toks = [PYTHON or "python3", first, *toks[1:]]
     cp = run(toks, cwd=root)
     _EXIT_CODE_MEMO[key] = cp
     return cp
@@ -1416,21 +1423,31 @@ def _comment_only_failure(rule_id: str, locator: str, expect, root: Path):
 CHEAP_PROOF_METHODS = ("FILE_EXISTS", "ANCHOR_PRESENT", "IN_HOOKS_JSON")
 
 
-def evaluate_proofs(root: Path, methods=CHEAP_PROOF_METHODS, comment_rot: bool = False) -> tuple:
+def evaluate_proofs(root: Path, methods=CHEAP_PROOF_METHODS, comment_rot: bool = False,
+                    rules: list = None, registry_path: Path = None) -> tuple:
     """Execute every registry proof whose method is in `methods`, against `root`.
 
     Returns (failures, evaluated, not_analyzed). RULE #1 says a rule is wired only
     when its registered mechanism is VERIFIABLY live; a proof nobody runs verifies
     nothing, so this evaluates all four implemented methods rather than the one
-    (EXIT_CODE --selftest) the doctor used to filter for."""
+    (EXIT_CODE --selftest) the doctor used to filter for.
+
+    `rules` lets a caller that ALREADY loaded a registry hand its rule list in, and
+    `registry_path` lets one point at a registry that is not `root/registry/rules.yaml`.
+    Re-reading that path unconditionally is what broke gate-liveness once: the check
+    loaded REGISTRY_PATH, the executor silently read a different file, and the verdict
+    came from a rule set the caller had never seen. A judge must judge the rows it was
+    handed."""
     failures, not_analyzed = [], []
     evaluated = 0
-    try:
-        import yaml
-        reg = yaml.safe_load((root / "registry" / "rules.yaml").read_text(encoding="utf-8")) or {}
-    except Exception as e:
-        return ([f"registry: cannot load rules.yaml: {e}"], 0, [])
-    rules = reg.get("rules", []) if isinstance(reg, dict) else []
+    if rules is None:
+        reg_path = registry_path or (root / "registry" / "rules.yaml")
+        try:
+            import yaml
+            reg = yaml.safe_load(reg_path.read_text(encoding="utf-8")) or {}
+        except Exception as e:
+            return ([f"registry: cannot load rules.yaml: {e}"], 0, [])
+        rules = reg.get("rules", []) if isinstance(reg, dict) else []
     hooks = _hooks_index_at(root)
     texts: dict = {}
 
@@ -1563,6 +1580,14 @@ def proof_execution_selftest(fixture_dir: str) -> int:
         print("  [MISS] check_gate_liveness no longer routes EXIT_CODE proofs through the executor")
         return 1
     print(f"  [ok ] {'wiring --gate-receipt':26s} routes EXIT_CODE through the executor (in-process)")
+    # Generalising the executor once ATE the sweep: check_gate_liveness kept loading
+    # the selftest proofs, used them only for a count, and never ran one. Assert both
+    # halves are still present, so the same deletion cannot pass this selftest again.
+    if "_selftest_proofs" not in gl_src or "_run_selftest_locator" not in gl_src:
+        print("  [MISS] check_gate_liveness no longer RUNS the fixture-driven selftest sweep "
+              "(a general proof count is not a liveness sweep)")
+        return 1
+    print(f"  [ok ] {'wiring liveness sweep':26s} check_gate_liveness still runs each --selftest proof")
     print(f"selftest PASS: {len(expected_red)} violation case(s) red, "
           f"{len(cases) - len(expected_red)} benign/control case(s) green, "
           f"executor reachable from both pre-push invocations")
@@ -1578,7 +1603,7 @@ def check_proof_execution(fix: bool) -> Result:
     takes. The EXIT_CODE class is executed in gate-liveness, which already pays for
     subprocesses, so no proof is run twice per push."""
     key = "proof-execution"
-    failures, evaluated, not_analyzed = evaluate_proofs(CLAUDE_DIR)
+    failures, evaluated, not_analyzed = evaluate_proofs(CLAUDE_DIR, registry_path=REGISTRY_PATH)
     if failures:
         return Result(key, FAIL,
                       f"{len(failures)}/{evaluated} registry proof(s) do NOT hold: "
@@ -1612,10 +1637,35 @@ def check_gate_liveness(fix: bool) -> Result:
     if not proofs:
         return Result(key, WARN, "no --selftest proofs registered",
                       "add EXIT_CODE --selftest proofs to fail-closed gates")
-    # Every EXIT_CODE proof, not only the --selftest ones: a locator registered as
+
+    # (1) The fixture-driven liveness sweep, asserted on its own over the rules THIS
+    # check loaded. This is the property gate-liveness is named for: every fail-closed
+    # gate's violation fixture must BLOCK and its benign fixture must ALLOW. Folding it
+    # into a general "execute every EXIT_CODE proof" pass once deleted it outright, and
+    # the check went on printing a confident green sentence while a gate that had
+    # stopped blocking was invisible: the exact failure class this feature exists to
+    # kill, inside the feature. Keep the two sweeps and their two counts separate.
+    live_failed = []
+    for r, loc in proofs:
+        cp = _run_selftest_locator(loc)
+        if cp.returncode != 0:
+            detail = (cp.stderr or cp.stdout or "").strip().splitlines()
+            live_failed.append(f"{r.get('id', '?')}: "
+                               f"{detail[-1] if detail else 'selftest exit ' + str(cp.returncode)}")
+    if live_failed:
+        return Result(key, FAIL,
+                      f"{len(live_failed)}/{len(proofs)} gate selftest(s) do NOT block+allow "
+                      "correctly: " + "; ".join(live_failed[:6]),
+                      "a labeled gate that fails its violation/benign fixtures is dead; "
+                      "fix the gate or the fixture")
+
+    # (2) Every EXIT_CODE proof, not only the --selftest ones: a locator registered as
     # proof and never executed proves nothing, and the comment-rot mutant runs here
     # because this is the check that already pays for subprocesses on the push path.
-    failed, evaluated, _na = evaluate_proofs(CLAUDE_DIR, methods=("EXIT_CODE",), comment_rot=True)
+    # Same rule set as the sweep above, and the shared memo means the selftests already
+    # run are not spawned a second time for this pass.
+    failed, evaluated, _na = evaluate_proofs(CLAUDE_DIR, methods=("EXIT_CODE",),
+                                             comment_rot=True, rules=rules)
     if failed:
         return Result(key, FAIL,
                       f"{len(failed)}/{evaluated} EXIT_CODE proof(s) do NOT hold: "
@@ -1648,10 +1698,12 @@ def check_gate_liveness(fix: bool) -> Result:
     except Exception as e:
         return Result(key, FAIL, f"gate receipt could not be written: {e}",
                       "the send gate denies without it; fix and re-run --gate-receipt")
+    # Two properties, two numbers, never one. A single count that conflated N executed
+    # proofs with the liveness sweep is what let the sweep disappear behind a green line.
     return Result(key, PASS,
-                  f"all {evaluated} EXIT_CODE proof(s) executed and hold, {len(proofs)} of them "
-                  f"fixture-driven selftests (gate: violation blocks + benign allows; detector: fires "
-                  f"on fixture); none satisfied by comment lines alone")
+                  f"{len(proofs)} fixture-driven selftest(s) proven live (gate: violation blocks "
+                  f"+ benign allows; detector: fires on fixture); separately, all {evaluated} "
+                  f"EXIT_CODE proof(s) executed and hold, none satisfied by comment lines alone")
 
 
 def check_enforcement_floor(fix: bool) -> Result:

--- a/scripts/tests/test_gate_liveness.py
+++ b/scripts/tests/test_gate_liveness.py
@@ -25,6 +25,15 @@ from pathlib import Path
 SCRIPTS = Path(__file__).resolve().parent.parent
 CLAUDE_DIR = SCRIPTS.parent
 
+# brain_doctor imports its siblings (receipt_ledger) by bare name. Run alone, this
+# module left scripts/ off sys.path, so check_gate_liveness raised ImportError and
+# returned FAIL from its receipt branch: the broken-gate assertion below was green
+# for a reason that had nothing to do with a broken gate. Under `unittest discover`
+# a sibling module happened to insert this path first, so the same test measured a
+# different thing depending on what ran before it. Pin it here.
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
 
 def _load_module(name: str, path: Path):
     spec = importlib.util.spec_from_file_location(name, path)
@@ -33,16 +42,32 @@ def _load_module(name: str, path: Path):
     return mod
 
 
+def _write_working_gate(d: Path) -> Path:
+    """The benign twin of the broken gate, derived from it by ONE edit: the deny is
+    conditional on the violation payload instead of unconditional. It blocks the
+    violation fixture and allows the benign one, so its selftest exits 0."""
+    return _write_gate(d, deny_when="'rm -rf' in cmd")
+
+
 def _write_block_everything_gate(d: Path) -> Path:
-    """A gate that denies EVERY payload, with a --selftest wired to the real harness."""
+    """A gate that denies EVERY payload: it blocks the violation fixture but ALSO
+    blocks the benign one, so its selftest must fail the benign leg."""
+    return _write_gate(d, deny_when="True")
+
+
+def _write_gate(d: Path, deny_when: str) -> Path:
+    """Write a gate whose --selftest is wired to the real harness. `deny_when` is the
+    python expression over `cmd` that decides whether to emit a PreToolUse deny."""
     script = d / "broken_gate.py"
     script.write_text(
         "import sys, json\n"
         f"sys.path.insert(0, {str(SCRIPTS)!r})\n"
         "def main():\n"
-        "    json.loads(sys.stdin.read() or '{}')\n"
-        "    print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse',\n"
-        "        'permissionDecision': 'deny', 'permissionDecisionReason': 'blocks everything'}}))\n"
+        "    payload = json.loads(sys.stdin.read() or '{}')\n"
+        "    cmd = (payload.get('tool_input') or {}).get('command', '')\n"
+        f"    if {deny_when}:\n"
+        "        print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse',\n"
+        "            'permissionDecision': 'deny', 'permissionDecisionReason': 'denied'}}))\n"
         "    return 0\n"
         "if __name__ == '__main__':\n"
         "    if '--selftest' in sys.argv:\n"
@@ -74,43 +99,86 @@ class GateLivenessHarnessTest(unittest.TestCase):
             self.assertNotEqual(cp.returncode, 0,
                                 "block-everything gate must FAIL the benign leg")
 
-    def test_doctor_gate_liveness_fails_on_broken_gate(self):
+    def test_evaluate_proofs_judges_the_rule_set_it_is_handed(self):
+        """The general proof executor must judge the caller's rules, never re-read the
+        brain's own registry behind its back. Re-reading is precisely what hid a dead
+        gate: check_gate_liveness loaded a registry holding one broken gate and the
+        executor answered about 41 healthy proofs out of a different file."""
+        doctor = _load_module("brain_doctor_rules_arg", SCRIPTS / "brain_doctor.py")
+        rules = [{"id": "TEST.handed-in",
+                  "proof": [{"method": "FILE_EXISTS",
+                             "locator": "no_such_file_in_this_brain.xyz",
+                             "expect": "present"}]}]
+        failures, evaluated, _na = doctor.evaluate_proofs(
+            CLAUDE_DIR, methods=("FILE_EXISTS",), rules=rules)
+        self.assertEqual(evaluated, 1,
+                         f"executor must evaluate the 1 handed-in proof, evaluated {evaluated}")
+        self.assertTrue(any("TEST.handed-in" in f for f in failures),
+                        f"handed-in failing proof must be reported, got {failures}")
+
+    def _run_doctor_over(self, d: Path, script: Path):
+        """Point brain_doctor's registry at a one-rule registry naming `script`'s
+        selftest, and return check_gate_liveness's verdict."""
         doctor = _load_module("brain_doctor_under_test", SCRIPTS / "brain_doctor.py")
+        registry = d / "rules.yaml"
+        registry.write_text(
+            "version: 1\n"
+            "rules:\n"
+            "  - id: TEST.broken-gate\n"
+            "    title: gate under test for the liveness harness self-test\n"
+            "    category: FLOW\n"
+            "    source: { file: CLAUDE.md, anchor: \"RULE #1\" }\n"
+            "    strength: GATE\n"
+            "    gateable: true\n"
+            "    enforcement: fail-closed\n"
+            "    firing_mode: [hook]\n"
+            "    mechanism:\n"
+            "      - { kind: Gate, canonical_name: broken_gate.py, firing_event: PreToolUse, firing_matcher: \"Bash\" }\n"
+            "    proof:\n"
+            # Single-quoted YAML scalar: inside DOUBLE quotes a backslash
+            # opens an escape sequence, so a Windows locator makes the whole
+            # registry unparseable and the doctor reports "cannot load
+            # registry" (WARN) instead of failing the broken gate this test
+            # is about. Single quotes take the path literally.
+            f"      - {{ method: EXIT_CODE, locator: '{script} --selftest {d/'fixtures'}', expect: 0 }}\n"
+            "    liveness_required: FIRES\n",
+            encoding="utf-8",
+        )
+        orig = doctor.REGISTRY_PATH
+        try:
+            doctor.REGISTRY_PATH = registry
+            return doctor, doctor.check_gate_liveness(False)
+        finally:
+            doctor.REGISTRY_PATH = orig
+
+    def test_doctor_gate_liveness_fails_on_broken_gate(self):
         with tempfile.TemporaryDirectory() as tmp:
             d = Path(tmp)
-            script = _write_block_everything_gate(d)
-            registry = d / "rules.yaml"
-            registry.write_text(
-                "version: 1\n"
-                "rules:\n"
-                "  - id: TEST.broken-gate\n"
-                "    title: deliberately broken gate for the harness self-test\n"
-                "    category: FLOW\n"
-                "    source: { file: CLAUDE.md, anchor: \"RULE #1\" }\n"
-                "    strength: GATE\n"
-                "    gateable: true\n"
-                "    enforcement: fail-closed\n"
-                "    firing_mode: [hook]\n"
-                "    mechanism:\n"
-                "      - { kind: Gate, canonical_name: broken_gate.py, firing_event: PreToolUse, firing_matcher: \"Bash\" }\n"
-                "    proof:\n"
-                # Single-quoted YAML scalar: inside DOUBLE quotes a backslash
-                # opens an escape sequence, so a Windows locator makes the whole
-                # registry unparseable and the doctor reports "cannot load
-                # registry" (WARN) instead of failing the broken gate this test
-                # is about. Single quotes take the path literally.
-                f"      - {{ method: EXIT_CODE, locator: '{script} --selftest {d/'fixtures'}', expect: 0 }}\n"
-                "    liveness_required: FIRES\n",
-                encoding="utf-8",
-            )
-            orig = doctor.REGISTRY_PATH
-            try:
-                doctor.REGISTRY_PATH = registry
-                result = doctor.check_gate_liveness(False)
-            finally:
-                doctor.REGISTRY_PATH = orig
-            self.assertEqual(result.status, doctor.FAIL,
-                             f"doctor must FAIL a broken gate, got {result.status}: {result.message}")
+            doctor, result = self._run_doctor_over(d, _write_block_everything_gate(d))
+        self.assertEqual(result.status, doctor.FAIL,
+                         f"doctor must FAIL a broken gate, got {result.status}: {result.message}")
+        # Any FAIL is not enough. The check has other FAIL branches (an unresolvable
+        # HEAD, a receipt that cannot be written), and this test was once green from
+        # one of them while the liveness sweep was gone. Demand the verdict name the
+        # broken gate and the leg it failed.
+        self.assertIn("block+allow", result.message,
+                      f"FAIL must come from the liveness sweep, got: {result.message}")
+        self.assertIn("TEST.broken-gate", result.message,
+                      f"FAIL must name the dead gate, got: {result.message}")
+
+    def test_doctor_gate_liveness_does_not_fail_on_a_working_gate(self):
+        """The other direction, one edit away: the same registry, the same fixtures,
+        a gate that denies the violation and allows the benign payload. A check that
+        reddens on everything proves as little as one that reddens on nothing."""
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            doctor, result = self._run_doctor_over(d, _write_working_gate(d))
+        self.assertNotIn("block+allow", result.message,
+                         f"a working gate must not fail the liveness sweep: {result.message}")
+        # PASS on a clean tree; WARN when gate surfaces differ from HEAD (the receipt
+        # branch deliberately refuses to vouch for uncommitted gates). Never FAIL.
+        self.assertIn(result.status, (doctor.PASS, doctor.WARN),
+                      f"working gate must not FAIL, got {result.status}: {result.message}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
RULE #1 says a rule is wired only when its registered mechanism is VERIFIABLY live, and that `brain_doctor` is the mechanism of that rule. The doctor executed **38 of 165 proofs**. The other 127 were read by humans and by QA, never by the machine.

## It had already happened, to the constitutional rule itself

`META.pre-push-gate` proved that pre-push invokes the doctor with `grep -q OCTORATO-WIRE-GATE .githooks/pre-push`. That sentinel exists exactly once, at line 230, **inside a comment**. Measured on a copy of the hook with every non-comment `brain_doctor` line deleted:

```
old locator  PASSES over a disarmed hook
new locator  FAILS
```

`GENERIC.commit-msg-english-only` had the same shape, and so did the doctor's own D0 bootstrap, which tested the same sentinel with `in` and therefore agreed with the rotted proof.

## The latent bug the lift surfaced, which is the more interesting half

Nine `IN_HOOKS_JSON` proofs never resolved. The locator is `event|matcher|script` and the resolver split on EVERY `|`, but a Claude Code matcher is a regex alternation carrying its own pipes. The nine it silently failed are the brain's own gates: `kernel-isolation`, `outward-send-gate`, `receipt-ledger`, `version-control`, `human-cadence`, `impact-radius`, `canon-heal`, `3d-diligent-gate`. It never showed because the resolver was only ever called for one rule, whose matcher happens to be pipe-free.

## FAIL, not WARN, argued from the number

With the locators fixed, all 165 proofs hold on master. There is no red inventory to buy a transition period for, and the 125 cheap proofs cost 0.00s. Weakening a proof to make it pass was not on the table.

## The doctor got cheaper

74 subprocess executions before (the 37 selftests ran twice, once by `gate-liveness` and again by `enforcement-floor`), 40 unique locators executed once through a shared memo after.

## A regression this branch caught on itself

The first commit generalised proof execution and deleted the fixture-driven liveness sweep. `.githooks/pre-push` refused the push on the one test that exists for it: break a gate, the doctor must FAIL. It answered PASS with a confident green sentence over a property that had stopped being verified, which is this branch's own subject turned on itself. Root cause: `evaluate_proofs` re-read `rules.yaml` and discarded the rules the caller had just loaded, so the two numbers in that message came from two different files. Fixed in `261b583`; the sweep and the general executor now run over the same rule set with the counts reported separately.

And the test itself had been measuring the environment rather than the doctor: run alone it passed in 36s against master's 0.283s, because without the suite `scripts/` is not on `sys.path`, the import raises, and the check returns FAIL from its receipt branch. `sys.path` is now pinned.

## Verified

- `brain_doctor.py --selftest registry/fixtures/META.rule-1-proof-execution`: 5 violation cases red, 2 benign/control green, wiring reachable from both pre-push invocations.
- Full suite: 210 tests OK.
- My own mutant of the restored sweep reddens exactly 1 of 4 and restoring returns green.

## Stated, not claimed

Comment-rot detection sees only text-search proofs, 2 of 41; the other 39 invoke scripts. It knows `#` and `//` only, because SQL and markdown comment syntax would invent failures. Executing a proof proves the PROOF holds, not that the mechanism is correct: `IN_HOOKS_JSON` proves a hook is registered, not that it fires. The `--gate-receipt` wiring is asserted in-process rather than spawned, because spawning recurses without a base case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbdTsWi5jScYVe7icdKPBL